### PR TITLE
feat(llm, anthropic, config): Serve `flex` as a batch request

### DIFF
--- a/crates/jp_cli/src/cmd/conversation/summarize.rs
+++ b/crates/jp_cli/src/cmd/conversation/summarize.rs
@@ -266,7 +266,7 @@ fn summarize_events(events: Vec<Event>) -> StreamOutcome {
             // else consumes them on this path, so keep them for the rebuild.
             Event::Patch(mut p) => patches.append(&mut p),
             // `KeepAlive` is a liveness signal.
-            Event::KeepAlive => {}
+            Event::KeepAlive { .. } => {}
         }
     }
 

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -357,7 +357,7 @@ impl TurnCoordinator {
 
             // Patch is handled by the caller before reaching here; KeepAlive is
             // a liveness signal with nothing to record or render.
-            Event::Patch(_) | Event::KeepAlive => HandleEventOutcome::new(Action::Continue),
+            Event::Patch(_) | Event::KeepAlive { .. } => HandleEventOutcome::new(Action::Continue),
         }
     }
 

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -130,25 +130,37 @@ fn claim_waiting_region(printer: &Printer, config: &StreamingConfig) -> StatusRe
     ))
 }
 
-/// Whether a streaming-loop event leaves the waiting indicator running.
+/// The detail to show while a streaming-loop event leaves the waiting indicator
+/// running, or `None` when the indicator has to be released.
 ///
 /// Keep-alive pings, history patches, and part-less flushes produce no terminal
 /// output, so the indicator stays up through them.
 /// Everything else (content parts, finish, stream errors, signals, preparing
 /// ticks) is about to write to the terminal and releases the indicator first.
 ///
+/// A keep-alive that names what it is waiting on replaces the default wording,
+/// so a provider that knows more than "still connected" can say so.
+///
 /// A `Flush` that commits content is always preceded by a `Part` for the same
 /// index, which already released the indicator; only a part-less flush — which
 /// commits nothing — can reach a live indicator.
-fn event_keeps_waiting_indicator(event: &StreamingLoopEvent) -> bool {
-    match event {
-        StreamingLoopEvent::Llm(result) => matches!(
-            result.as_ref(),
-            Ok(Event::KeepAlive | Event::Patch(_) | Event::Flush { .. })
-        ),
-        StreamingLoopEvent::Interrupt(_) => false,
+fn waiting_indicator_detail(event: &StreamingLoopEvent) -> Option<&str> {
+    let StreamingLoopEvent::Llm(result) = event else {
+        return None;
+    };
+
+    match result.as_ref() {
+        Ok(Event::KeepAlive { detail }) => {
+            Some(detail.as_deref().unwrap_or(DEFAULT_WAITING_DETAIL))
+        }
+        Ok(Event::Patch(_) | Event::Flush { .. }) => Some(DEFAULT_WAITING_DETAIL),
+        _ => None,
     }
 }
+
+/// What the waiting indicator says while the provider is producing a response
+/// but has not yet written anything to the terminal.
+const DEFAULT_WAITING_DETAIL: &str = "receiving response data";
 
 /// Runs the turn loop: streaming from LLM, handling signals, executing tools.
 ///
@@ -380,10 +392,9 @@ pub(super) async fn run_turn_loop(
                     // released on the first event that can write to the
                     // terminal. The printer erases the row before that write
                     // lands, so no ordering is owed here.
-                    if event_keeps_waiting_indicator(&event) {
-                        waiting.set_detail("receiving response data");
-                    } else {
-                        waiting.release();
+                    match waiting_indicator_detail(&event) {
+                        Some(detail) => waiting.set_detail(detail),
+                        None => waiting.release(),
                     }
 
                     match event {
@@ -535,7 +546,9 @@ pub(super) async fn run_turn_loop(
                             let advances_cycle = match &event {
                                 Event::Part { .. } => true,
                                 Event::Finished(reason) => *reason != FinishReason::Retry,
-                                Event::Flush { .. } | Event::Patch(_) | Event::KeepAlive => false,
+                                Event::Flush { .. } | Event::Patch(_) | Event::KeepAlive { .. } => {
+                                    false
+                                }
                             };
                             if !received_provider_event && advances_cycle {
                                 received_provider_event = true;

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -3391,7 +3391,7 @@ async fn test_waiting_indicator_survives_keep_alive_and_shows_status() {
         let provider: Arc<dyn Provider> =
             Arc::new(PacedMockProvider::new(Duration::from_millis(250), vec![
                 vec![
-                    (Duration::from_millis(250), Ok(Event::KeepAlive)),
+                    (Duration::from_millis(250), Ok(Event::keep_alive())),
                     (
                         Duration::from_millis(250),
                         Ok(Event::message(0, "Response after keep-alive")),
@@ -3468,6 +3468,94 @@ async fn test_waiting_indicator_survives_keep_alive_and_shows_status() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_waiting_indicator_shows_the_keep_alives_own_detail() {
+    // A request that is not producing tokens at all — an Anthropic batch being
+    // polled, say — would otherwise be described as "receiving response data",
+    // which is a plain lie for a wait measured in minutes. A keep-alive that
+    // names its own wait replaces that wording.
+
+    let test_result = Box::pin(timeout(Duration::from_secs(10), async {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let storage = root.join(".jp");
+
+        let mut config = AppConfig::new_test();
+        config.style.streaming.progress.show = true;
+        config.style.streaming.progress.delay_secs = 0;
+        config.style.streaming.progress.interval_ms = 50;
+
+        let fs = Arc::new(FsStorageBackend::new(&storage).expect("failed to create backend"));
+        let mut workspace = Workspace::in_memory(root).with_backend(fs.clone());
+
+        let lock = workspace
+            .create_and_lock_conversation(Conversation::default(), Arc::new(config.clone()), None)
+            .unwrap();
+
+        let provider: Arc<dyn Provider> =
+            Arc::new(PacedMockProvider::new(Duration::from_millis(250), vec![
+                vec![
+                    (
+                        Duration::from_millis(250),
+                        Ok(Event::keep_alive_with_detail("waiting on the batch")),
+                    ),
+                    (
+                        Duration::from_millis(250),
+                        Ok(Event::message(0, "Batched answer")),
+                    ),
+                    (Duration::ZERO, Ok(Event::flush(0))),
+                    (Duration::ZERO, Ok(Event::Finished(FinishReason::Completed))),
+                ],
+            ]));
+        let model = provider
+            .model_details(&"test-model".parse().unwrap())
+            .await
+            .unwrap();
+
+        let (printer, _out, err) = Printer::memory(OutputFormat::TextPretty);
+        let printer = Arc::new(printer.with_terminal(TerminalCapability::interactive(Some(80))));
+        let mcp_client = jp_mcp::Client::default();
+        let router = detached_router();
+
+        run_turn_loop(
+            Arc::clone(&provider),
+            &model,
+            &config,
+            &router,
+            &mcp_client,
+            root,
+            true, // interactive
+            &[],
+            &lock,
+            ToolChoice::Auto,
+            &[],
+            printer.clone(),
+            Arc::new(MockPromptBackend::new()),
+            ToolCoordinator::new(config.conversation.tools.clone(), empty_executor_source()),
+            ChatRequest::from("Hello"),
+            InvocationContext::default(),
+            PendingStreamTrim::default(),
+        )
+        .await
+        .unwrap();
+
+        printer.flush();
+
+        let chrome = err.lock();
+        assert!(
+            chrome.contains("(waiting on the batch)"),
+            "Indicator should show the keep-alive's own detail.\nChrome:\n{chrome}"
+        );
+        assert!(
+            !chrome.contains("(receiving response data)"),
+            "A labelled keep-alive replaces the default wording.\nChrome:\n{chrome}"
+        );
+    }))
+    .await;
+
+    assert!(test_result.is_ok(), "Test timed out");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_waiting_indicator_cleared_before_retry_notice() {
     // A stream error is about to write retry chrome, so the indicator must be
     // finished (line cleared) first. The keep-alive before the error also
@@ -3499,7 +3587,7 @@ async fn test_waiting_indicator_cleared_before_retry_notice() {
         let provider: Arc<dyn Provider> =
             Arc::new(PacedMockProvider::new(Duration::from_millis(100), vec![
                 vec![
-                    (Duration::from_millis(100), Ok(Event::KeepAlive)),
+                    (Duration::from_millis(100), Ok(Event::keep_alive())),
                     (
                         Duration::from_millis(100),
                         Err(StreamError::transient("simulated hiccup")),

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -427,11 +427,24 @@ impl AppConfig {
         // before the `#[setting(default)]` layer below, so an unset inquiry
         // field takes the user's configured assistant value rather than the
         // type's default.
+        //
+        // The capacity tier is withheld from what the inquiry inherits. An
+        // inquiry blocks the tool call that raised it, so it cannot pay for a
+        // discount in latency the way a long assistant turn can; Anthropic's
+        // `flex` is the sharp case, served by the Message Batches API, which
+        // answers in minutes. Withholding it here rather than pinning `off` on
+        // the inquiry leaves the field genuinely unset, so nothing is recorded
+        // into a conversation's stored config. Setting
+        // `conversation.inquiry.assistant.model.parameters.service_tier`
+        // explicitly still wins, since that value is already in place.
+        let mut inherited = partial.assistant.clone();
+        inherited.model.parameters.service_tier = None;
+
         partial.conversation.inquiry.assistant = partial
             .conversation
             .inquiry
             .assistant
-            .inherit_from(partial.assistant.clone());
+            .inherit_from(inherited);
 
         let partial = match PartialAppConfig::default_values(&())? {
             Some(defaults) => partial.fill_from(defaults),

--- a/crates/jp_config/src/lib_tests.rs
+++ b/crates/jp_config/src/lib_tests.rs
@@ -3,7 +3,10 @@ use schematic::PartialConfig as _;
 use test_log::test;
 
 use super::*;
-use crate::assignment::{KvAssignmentError, KvAssignmentErrorKind};
+use crate::{
+    assignment::{KvAssignmentError, KvAssignmentErrorKind},
+    model::parameters::ServiceTier,
+};
 
 #[test]
 fn test_partial_app_config_empty_serialize() {
@@ -105,6 +108,65 @@ fn inquiry_inherits_assistant_collections() {
         inquiry.system_prompt_sections.len(),
         1,
         "the inquiry inherits the assistant's prompt sections"
+    );
+}
+
+/// An inquiry blocks the tool call that raised it, so it cannot pay for a
+/// discount in latency the way a long assistant turn can.
+///
+/// Anthropic's `flex` is the sharp case: it is served by the Message Batches
+/// API, so an inherited tier would stall the tool for however long the batch
+/// takes.
+#[test]
+fn an_inquiry_does_not_inherit_the_assistants_service_tier() {
+    let mut partial = PartialAppConfig::new_test();
+    partial.assistant.model.parameters.service_tier = Some(ServiceTier::Flex);
+
+    let config = AppConfig::from_partial_with_defaults(partial).expect("valid config");
+
+    assert_eq!(
+        config.assistant.model.parameters.service_tier,
+        Some(ServiceTier::Flex),
+        "the assistant keeps the tier it was given"
+    );
+    assert_eq!(
+        config
+            .conversation
+            .inquiry
+            .assistant
+            .model
+            .parameters
+            .service_tier,
+        None,
+        "the inquiry asks for no tier at all, and records no value for it"
+    );
+}
+
+/// The rule is about inheritance, not about forbidding the tier: an inquiry
+/// pointed at a tier explicitly still gets it.
+#[test]
+fn an_explicit_inquiry_service_tier_survives() {
+    let mut partial = PartialAppConfig::new_test();
+    partial.assistant.model.parameters.service_tier = Some(ServiceTier::Priority);
+    partial
+        .conversation
+        .inquiry
+        .assistant
+        .model
+        .parameters
+        .service_tier = Some(ServiceTier::Flex);
+
+    let config = AppConfig::from_partial_with_defaults(partial).expect("valid config");
+
+    assert_eq!(
+        config
+            .conversation
+            .inquiry
+            .assistant
+            .model
+            .parameters
+            .service_tier,
+        Some(ServiceTier::Flex)
     );
 }
 

--- a/crates/jp_config/src/model/parameters.rs
+++ b/crates/jp_config/src/model/parameters.rs
@@ -59,6 +59,10 @@ pub struct ParametersConfig {
     /// - `off`: Send no tier, taking whatever the account is set up for.
     /// - `flex`: Slower and best-effort, priced at a discount where the
     ///   provider offers one.
+    ///   On `anthropic` this runs the request through the Message Batches API:
+    ///   half price, no streaming, and an answer that usually takes minutes.
+    ///   Tune the wait with `providers.llm.anthropic.batch_max_wait_secs` and
+    ///   `providers.llm.anthropic.batch_poll_interval_secs`.
     /// - `standard`: Regular priority and regular pricing.
     /// - `priority`: Faster and served from prioritized capacity, priced above
     ///   the regular rate where the provider charges for it.
@@ -73,7 +77,7 @@ pub struct ParametersConfig {
     /// account.
     /// A provider that sells no equivalent of the requested tier refuses the
     /// query and says so, rather than quietly falling back to a rung that costs
-    /// something else: `anthropic` has no `flex`, for instance.
+    /// something else.
     ///
     /// That refusal is per provider, not per model.
     /// A provider that sells the tier but cannot serve the chosen model with it

--- a/crates/jp_config/src/providers/llm/anthropic.rs
+++ b/crates/jp_config/src/providers/llm/anthropic.rs
@@ -40,6 +40,28 @@ pub struct AnthropicConfig {
     /// <https://docs.anthropic.com/en/release-notes/api>
     #[setting(default = vec![], merge = append_vec_dedup)]
     pub beta_headers: Vec<String>,
+
+    /// How often to check whether a batched request has finished, in seconds.
+    ///
+    /// Defaults to `15`.
+    ///
+    /// Only used when `assistant.model.parameters.service_tier` is `flex`,
+    /// which Anthropic serves through its Message Batches API.
+    #[setting(default = 15)]
+    pub batch_poll_interval_secs: u32,
+
+    /// How long to wait for a batched request to finish, in seconds.
+    ///
+    /// Defaults to `3600` (one hour).
+    /// Set to `0` to wait as long as Anthropic keeps the batch alive, which is
+    /// 24 hours.
+    ///
+    /// Only used when `assistant.model.parameters.service_tier` is `flex`.
+    /// Most batches finish within an hour.
+    /// Giving up leaves the batch running and reports its id, so the answer can
+    /// still be fetched from the Anthropic API by hand.
+    #[setting(default = 3600)]
+    pub batch_max_wait_secs: u32,
 }
 
 impl AssignKeyValue for PartialAnthropicConfig {
@@ -50,6 +72,10 @@ impl AssignKeyValue for PartialAnthropicConfig {
             "base_url" => self.base_url = kv.try_some_string()?,
             "chain_on_max_tokens" => self.chain_on_max_tokens = kv.try_some_bool()?,
             "beta_headers" => kv.try_some_vec_of_strings(&mut self.beta_headers)?,
+            "batch_poll_interval_secs" => {
+                self.batch_poll_interval_secs = kv.try_some_u32()?;
+            }
+            "batch_max_wait_secs" => self.batch_max_wait_secs = kv.try_some_u32()?,
             _ => return missing_key(&kv),
         }
 
@@ -67,6 +93,14 @@ impl PartialConfigDelta for PartialAnthropicConfig {
                 next.chain_on_max_tokens,
             ),
             beta_headers: delta_opt_vec(self.beta_headers.as_ref(), next.beta_headers),
+            batch_poll_interval_secs: delta_opt(
+                self.batch_poll_interval_secs.as_ref(),
+                next.batch_poll_interval_secs,
+            ),
+            batch_max_wait_secs: delta_opt(
+                self.batch_max_wait_secs.as_ref(),
+                next.batch_max_wait_secs,
+            ),
         }
     }
 
@@ -84,6 +118,14 @@ impl PartialConfigDelta for PartialAnthropicConfig {
                 next.beta_headers,
                 unsets,
             ),
+            batch_poll_interval_secs: delta_opt(
+                self.batch_poll_interval_secs.as_ref(),
+                next.batch_poll_interval_secs,
+            ),
+            batch_max_wait_secs: delta_opt(
+                self.batch_max_wait_secs.as_ref(),
+                next.batch_max_wait_secs,
+            ),
         }
     }
 }
@@ -95,6 +137,10 @@ impl FillDefaults for PartialAnthropicConfig {
             base_url: self.base_url.or(defaults.base_url),
             chain_on_max_tokens: self.chain_on_max_tokens.or(defaults.chain_on_max_tokens),
             beta_headers: self.beta_headers.or(defaults.beta_headers),
+            batch_poll_interval_secs: self
+                .batch_poll_interval_secs
+                .or(defaults.batch_poll_interval_secs),
+            batch_max_wait_secs: self.batch_max_wait_secs.or(defaults.batch_max_wait_secs),
         }
     }
 }
@@ -111,6 +157,14 @@ impl ToPartial for AnthropicConfig {
                 defaults.chain_on_max_tokens,
             ),
             beta_headers: partial_opt(&self.beta_headers, defaults.beta_headers),
+            batch_poll_interval_secs: partial_opt(
+                &self.batch_poll_interval_secs,
+                defaults.batch_poll_interval_secs,
+            ),
+            batch_max_wait_secs: partial_opt(
+                &self.batch_max_wait_secs,
+                defaults.batch_max_wait_secs,
+            ),
         }
     }
 }

--- a/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__app_config_fields.snap
@@ -71,6 +71,8 @@ expression: "AppConfig::fields()"
     "providers.llm.cerebras.base_url",
     "providers.llm.anthropic.api_key_env",
     "providers.llm.anthropic.base_url",
+    "providers.llm.anthropic.batch_max_wait_secs",
+    "providers.llm.anthropic.batch_poll_interval_secs",
     "providers.llm.anthropic.beta_headers",
     "providers.llm.anthropic.chain_on_max_tokens",
     "plugins.auto_install",

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default.snap
@@ -220,6 +220,8 @@ PartialAppConfig {
                 base_url: None,
                 chain_on_max_tokens: None,
                 beta_headers: None,
+                batch_poll_interval_secs: None,
+                batch_max_wait_secs: None,
             },
             cerebras: PartialCerebrasConfig {
                 api_key_env: None,

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_default_values.snap
@@ -454,6 +454,12 @@ Ok(
                         beta_headers: Some(
                             [],
                         ),
+                        batch_poll_interval_secs: Some(
+                            15,
+                        ),
+                        batch_max_wait_secs: Some(
+                            3600,
+                        ),
                     },
                     cerebras: PartialCerebrasConfig {
                         api_key_env: Some(

--- a/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__partial_app_config_empty_serialize.snap
@@ -220,6 +220,8 @@ PartialAppConfig {
                 base_url: None,
                 chain_on_max_tokens: None,
                 beta_headers: None,
+                batch_poll_interval_secs: None,
+                batch_max_wait_secs: None,
             },
             cerebras: PartialCerebrasConfig {
                 api_key_env: None,

--- a/crates/jp_llm/src/event.rs
+++ b/crates/jp_llm/src/event.rs
@@ -69,9 +69,14 @@ pub enum Event {
 
     /// A liveness signal from the provider, such as an SSE keep-alive ping.
     ///
-    /// Carries no content and is never persisted or rendered.
-    /// It signals only that the connection is still alive.
-    KeepAlive,
+    /// Carries no content and is never persisted.
+    /// It signals only that the request is still alive.
+    ///
+    /// `detail` is a short phrase describing what the request is waiting on,
+    /// shown in the terminal's waiting indicator while the provider is silent.
+    /// `None` leaves the indicator's wording to the caller, which is right for
+    /// a heartbeat that says nothing beyond "still connected".
+    KeepAlive { detail: Option<String> },
 }
 
 /// A chunk of streaming data from an LLM provider.
@@ -243,6 +248,21 @@ impl From<&EventPatch> for OverlayPatch {
 }
 
 impl Event {
+    /// Create a new [`Event::KeepAlive`] carrying no description of the wait.
+    #[must_use]
+    pub fn keep_alive() -> Self {
+        Self::KeepAlive { detail: None }
+    }
+
+    /// Create a new [`Event::KeepAlive`] describing what the request is waiting
+    /// on.
+    #[must_use]
+    pub fn keep_alive_with_detail(detail: impl Into<String>) -> Self {
+        Self::KeepAlive {
+            detail: Some(detail.into()),
+        }
+    }
+
     /// Create a new [`Event::Part`] with a message chunk.
     #[must_use]
     pub fn message(index: usize, content: impl Into<String>) -> Self {

--- a/crates/jp_llm/src/event_builder.rs
+++ b/crates/jp_llm/src/event_builder.rs
@@ -65,7 +65,7 @@ pub fn structured_data(events: Vec<Event>) -> Option<Value> {
                 flushed.extend(builder.handle_flush(index, metadata));
             }
             Event::Finished(_) => flushed.extend(builder.drain()),
-            Event::Patch(_) | Event::KeepAlive => {}
+            Event::Patch(_) | Event::KeepAlive { .. } => {}
         }
     }
 

--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -44,6 +44,8 @@ use crate::{
     tool::ToolDefinition,
 };
 
+mod batch;
+
 static PROVIDER: ProviderId = ProviderId::Anthropic;
 
 /// Anthropic limits the number of explicit cache breakpoints to 4 per request,
@@ -132,6 +134,49 @@ pub struct Anthropic {
 
     /// Which beta features are enabled.
     beta: BetaFeatures,
+
+    /// How long to wait on a batched request, and how often to check it.
+    ///
+    /// Only consulted for the `flex` service tier, which Anthropic serves
+    /// through the Message Batches API.
+    batch_poll: batch::PollConfig,
+}
+
+/// How a request reaches the model.
+///
+/// Both routes end in the same [`EventStream`], so everything layered on top of
+/// a request — chaining on the token ceiling, the forced-tool fallback, the
+/// thinking-rejection repair — behaves identically either way.
+#[derive(Debug, Clone)]
+struct Transport {
+    client: Client,
+
+    /// Set when the request is served through the Message Batches API rather
+    /// than the streaming Messages endpoint.
+    batch: Option<batch::PollConfig>,
+}
+
+impl Transport {
+    /// Send `request` and return the events it produces.
+    async fn send(
+        &self,
+        request: types::CreateMessagesRequest,
+        is_structured: bool,
+    ) -> EventStream {
+        if let Some(poll) = self.batch {
+            return batch::events(self.client.clone(), request, is_structured, poll);
+        }
+
+        Box::pin(
+            self.client
+                .messages()
+                .create_stream(request)
+                .await
+                .map_err(StreamError::from)
+                .map_ok(move |event| stream::iter(map_event(event, is_structured)))
+                .try_flatten(),
+        )
+    }
 }
 
 #[async_trait]
@@ -173,17 +218,20 @@ impl Provider for Anthropic {
         model: &ModelDetails,
         query: ChatQuery,
     ) -> Result<EventStream> {
-        let client = self.client.clone();
-        let max_tokens_config = query
-            .thread
-            .events
-            .config()?
-            .assistant
-            .model
-            .parameters
-            .max_tokens;
+        let parameters = query.thread.events.config()?.assistant.model.parameters;
+        let max_tokens_config = parameters.max_tokens;
 
-        let (request, is_structured, forced_tool) = create_request(model, query, true, &self.beta)?;
+        // `flex` is served by the Message Batches API, which refuses `stream`
+        // and hands back one complete message instead of a token stream.
+        let batched = parameters.service_tier == Some(ServiceTier::Flex);
+
+        let transport = Transport {
+            client: self.client.clone(),
+            batch: batched.then_some(self.batch_poll),
+        };
+
+        let (request, is_structured, forced_tool) =
+            create_request(model, query, !batched, &self.beta)?;
 
         // Chaining is disabled for structured output — the provider guarantees
         // schema compliance so the response won't hit max_tokens for a
@@ -199,7 +247,7 @@ impl Provider for Anthropic {
             0
         };
 
-        debug!(stream = true, "Anthropic chat completion stream request.");
+        debug!(batched, "Anthropic chat completion stream request.");
         trace!(
             request = %trace_to_tmpfile("jp-anthropic-request", &request),
             "Request payload."
@@ -207,7 +255,7 @@ impl Provider for Anthropic {
 
         Ok(with_tool_call_keepalive(
             call(
-                client,
+                transport,
                 request,
                 chains_remaining,
                 is_structured,
@@ -283,9 +331,8 @@ impl ForcedToolFallback {
 /// If the API rejects a thinking block in the request, emits [`Event::Patch`]
 /// instructions to fix the conversation stream and finishes with
 /// [`FinishReason::Retry`] so the caller can rebuild and retry.
-#[expect(clippy::too_many_lines)]
 fn call(
-    client: Client,
+    transport: Transport,
     request: types::CreateMessagesRequest,
     chains_remaining: u8,
     is_structured: bool,
@@ -314,13 +361,9 @@ fn call(
         // tool).
         let mut tool_names_called: Vec<String> = vec![];
 
-        let stream = client
-            .messages()
-            .create_stream(request.clone())
+        let stream = transport
+            .send(request.clone(), is_structured)
             .await
-            .map_err(StreamError::from)
-            .map_ok(|v| stream::iter(map_event(v, is_structured)))
-            .try_flatten()
             .peekable();
 
         pin_mut!(stream);
@@ -358,7 +401,7 @@ fn call(
 
                     chain_events.extend(chain_builder.drain());
                     for await event in chain(
-                        client.clone(),
+                        transport.clone(),
                         request.clone(),
                         chain_events,
                         is_structured,
@@ -380,7 +423,7 @@ fn call(
                 {
                     chain_events.extend(chain_builder.drain());
                     for await event in dispatch_force_retry(
-                        client.clone(),
+                        transport.clone(),
                         request.clone(),
                         chain_events,
                         fallback,
@@ -437,7 +480,7 @@ fn call(
                     yield flush;
                 }
                 patch @ Event::Patch(_) => yield patch,
-                keep_alive @ Event::KeepAlive => yield keep_alive,
+                keep_alive @ Event::KeepAlive { .. } => yield keep_alive,
             }
         }
     }))
@@ -453,7 +496,7 @@ fn should_chain(event: &Event, tool_calls_requested: bool, chains_remaining: u8)
 /// Create a new `EventStream` by asking the assistant to continue from where it
 /// left off.
 fn chain(
-    client: Client,
+    transport: Transport,
     mut request: types::CreateMessagesRequest,
     events: Vec<ConversationEvent>,
     is_structured: bool,
@@ -499,7 +542,7 @@ fn chain(
     });
 
     Box::pin(try_stream!({
-        for await event in call(client, request, chains_remaining, is_structured, None) {
+        for await event in call(transport, request, chains_remaining, is_structured, None) {
             let mut event = event?;
 
             // When chaining new events, the reasoning content is irrelevant, as
@@ -540,7 +583,7 @@ fn chain(
 
 /// Dispatch the forced-tool retry that matches `fallback`'s strategy.
 fn dispatch_force_retry(
-    client: Client,
+    transport: Transport,
     request: types::CreateMessagesRequest,
     events: Vec<ConversationEvent>,
     fallback: &ForcedToolFallback,
@@ -552,14 +595,21 @@ fn dispatch_force_retry(
                 "Model did not call the required tool. Retrying with thinking disabled and forced \
                  tool_choice."
             );
-            force_tool_retry(client, request, events, fallback, is_structured)
+            force_tool_retry(transport, request, events, fallback, is_structured)
         }
         ForceStrategy::EscalatingNudge { remaining } => {
             info!(
                 remaining,
                 "Model did not call the required tool. Retrying with a firmer nudge."
             );
-            soft_force_retry(client, request, events, fallback, is_structured, remaining)
+            soft_force_retry(
+                transport,
+                request,
+                events,
+                fallback,
+                is_structured,
+                remaining,
+            )
         }
     }
 }
@@ -572,7 +622,7 @@ fn dispatch_force_retry(
 /// message requesting the tool call, then issues a new request with thinking
 /// disabled and the original forced `tool_choice`.
 fn force_tool_retry(
-    client: Client,
+    transport: Transport,
     mut request: types::CreateMessagesRequest,
     events: Vec<ConversationEvent>,
     fallback: &ForcedToolFallback,
@@ -627,7 +677,7 @@ fn force_tool_retry(
 
     Box::pin(try_stream!({
         // Pass `None` for forced_tool_fallback to prevent infinite retries.
-        for await event in call(client, request, 0, is_structured, None) {
+        for await event in call(transport, request, 0, is_structured, None) {
             let event = event?;
 
             // Skip reasoning (shouldn't appear with thinking disabled, but
@@ -653,7 +703,7 @@ fn force_tool_retry(
 /// re-issue it with a progressively firmer instruction, up to `remaining` more
 /// times, before accepting the response.
 fn soft_force_retry(
-    client: Client,
+    transport: Transport,
     mut request: types::CreateMessagesRequest,
     events: Vec<ConversationEvent>,
     fallback: &ForcedToolFallback,
@@ -709,7 +759,7 @@ fn soft_force_retry(
     });
 
     Box::pin(try_stream!({
-        for await event in call(client, request, 0, is_structured, next_fallback) {
+        for await event in call(transport, request, 0, is_structured, next_fallback) {
             yield event?;
         }
 
@@ -1123,19 +1173,16 @@ const FAST_MODE_BETA: &str = "fast-mode-2026-02-01";
 /// Each tier sets at most one of them, never both, which is also what keeps the
 /// request out of the combination Anthropic rejects (fast mode is unavailable
 /// under a commitment).
-///
-/// # Errors
-///
-/// Returns [`Error::UnsupportedServiceTier`] for `flex`, which Anthropic sells
-/// no equivalent of.
-fn apply_service_tier(
-    builder: &mut types::CreateMessagesRequestBuilder,
-    tier: ServiceTier,
-) -> Result<()> {
+fn apply_service_tier(builder: &mut types::CreateMessagesRequestBuilder, tier: ServiceTier) {
     match tier {
         // Sending neither field is how the account's own default decides, which
         // for Anthropic means `service_tier: "auto"` and standard speed.
-        ServiceTier::Off => {}
+        //
+        // `Flex` also sends neither: Anthropic prices it through the Message
+        // Batches API, which is a different endpoint rather than a request
+        // field, so `Transport` realizes it instead of the request body. The
+        // batch API rejects `speed` outright.
+        ServiceTier::Off | ServiceTier::Flex => {}
 
         ServiceTier::Standard => {
             builder.service_tier(types::ServiceTier::StandardOnly);
@@ -1147,18 +1194,7 @@ fn apply_service_tier(
             builder.speed(types::Speed::Fast);
             builder.betas(vec![FAST_MODE_BETA.to_owned()]);
         }
-
-        // The Batch API is the nearest thing Anthropic offers and is not
-        // reachable through a request parameter, so there is nothing to map to.
-        ServiceTier::Flex => {
-            return Err(Error::UnsupportedServiceTier {
-                provider: PROVIDER,
-                tier,
-            });
-        }
     }
-
-    Ok(())
 }
 
 /// Map the configured cache policy to an Anthropic cache-control annotation.
@@ -1412,7 +1448,7 @@ fn create_request(
     let parameters = &config.assistant.model.parameters;
 
     if let Some(tier) = parameters.service_tier {
-        apply_service_tier(&mut builder, tier)?;
+        apply_service_tier(&mut builder, tier);
     }
 
     let max_tokens = parameters
@@ -1964,7 +2000,7 @@ fn map_event(
         MessageStart { .. } => vec![],
         // Keep-alive heartbeat: surface it so the idle-timeout layer treats the
         // connection as live, but it carries no content.
-        Ping => vec![Ok(Event::KeepAlive)],
+        Ping => vec![Ok(Event::keep_alive())],
     }
 }
 
@@ -1988,6 +2024,12 @@ impl TryFrom<&AnthropicConfig> for Anthropic {
         Ok(Anthropic {
             beta: BetaFeatures(config.beta_headers.clone()),
             chain_on_max_tokens: config.chain_on_max_tokens,
+            batch_poll: batch::PollConfig {
+                interval: Duration::from_secs(u64::from(config.batch_poll_interval_secs))
+                    .max(batch::MIN_POLL_INTERVAL),
+                max_wait: (config.batch_max_wait_secs > 0)
+                    .then(|| Duration::from_secs(u64::from(config.batch_max_wait_secs))),
+            },
             client: builder
                 .build()
                 .map_err(|e| Error::Anthropic(AnthropicError::Unknown(e.to_string())))?,

--- a/crates/jp_llm/src/provider/anthropic/batch.rs
+++ b/crates/jp_llm/src/provider/anthropic/batch.rs
@@ -1,0 +1,477 @@
+//! Anthropic's Message Batches API, driven one request at a time.
+//!
+//! A batch holds a single request, is polled until it ends, and its one result
+//! is replayed as the stream events the synchronous endpoint would have
+//! produced.
+//! This is what `assistant.model.parameters.service_tier = "flex"` resolves to
+//! on Anthropic: half price, no token streaming, and a wait measured in minutes
+//! rather than seconds.
+//!
+//! See:
+//! <https://platform.claude.com/docs/en/build-with-claude/batch-processing>
+
+use std::{
+    mem,
+    time::{Duration, Instant},
+};
+
+use async_anthropic::{
+    Client,
+    errors::{AnthropicError, ApiError},
+    types,
+};
+use async_stream::try_stream;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use tokio::time::sleep;
+use tracing::{debug, info, warn};
+
+use crate::{error::StreamError, event::Event, stream::EventStream};
+
+/// The `custom_id` carried by the single request in every batch JP submits.
+///
+/// Anthropic requires the id to match `^[a-zA-Z0-9_-]{1,64}$` and uses it to
+/// pair results with requests; with one request per batch there is nothing to
+/// disambiguate.
+const CUSTOM_ID: &str = "jp";
+
+/// Where the Message Batches API lives, relative to the configured base URL.
+const BATCHES_PATH: &str = "/v1/messages/batches";
+
+/// How often a keep-alive is emitted while the batch is being waited on.
+///
+/// The downstream idle timeout treats a silent stream as a dead connection and
+/// rebuilds it, which for a batch means submitting and paying for a second one.
+/// Five seconds stays below the enforced minimum `stream_idle_timeout_secs`
+/// (10s), so a heartbeat always lands before the idle window elapses,
+/// regardless of how far apart the polls are.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// The shortest gap allowed between two status checks.
+///
+/// A zero-second interval would poll in a tight loop and exhaust the Batches
+/// API's own request rate limit long before the batch finished.
+pub(super) const MIN_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// How many consecutive transport failures a wait tolerates before giving up.
+///
+/// A hiccup while polling must not end a wait measured in minutes: the batch
+/// keeps running either way, and surfacing the error hands the caller something
+/// its retry layer answers by submitting a second, separately billed batch.
+/// The counter resets on every successful poll, so only a sustained outage
+/// exhausts it.
+const MAX_TRANSPORT_FAILURES: u8 = 5;
+
+/// How long to wait between polls, and how long to keep waiting overall.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct PollConfig {
+    /// How long to wait between status checks.
+    pub interval: Duration,
+
+    /// How long to wait in total before giving up on the batch.
+    ///
+    /// `None` waits as long as Anthropic keeps the batch alive, which is 24
+    /// hours.
+    pub max_wait: Option<Duration>,
+}
+
+/// Submit `request` as a single-request batch and stream its result.
+///
+/// The batch is created before the first poll, so a rejected submission
+/// surfaces as the first item of the stream rather than silently later.
+/// While the batch runs, the stream carries nothing but keep-alives; the whole
+/// response arrives at once when it ends.
+///
+/// Abandoning the returned stream cancels the batch.
+pub(super) fn events(
+    client: Client,
+    request: types::CreateMessagesRequest,
+    is_structured: bool,
+    poll: PollConfig,
+) -> EventStream {
+    Box::pin(try_stream!({
+        let mut request = request;
+        let betas = mem::take(&mut request.betas);
+
+        let batch = create(&client, &request, &betas)
+            .await
+            .map_err(StreamError::from)?;
+
+        info!(
+            batch = %batch.id,
+            interval_secs = poll.interval.as_secs(),
+            "Submitted Anthropic message batch."
+        );
+
+        // Armed for as long as the batch is running: dropping the stream is how
+        // the caller abandons a turn, and a batch nobody is waiting for still
+        // bills for whatever the model has already produced.
+        let mut cancel_guard = CancelOnDrop {
+            client: client.clone(),
+            id: Some(batch.id.clone()),
+        };
+
+        let id = batch.id;
+        let started = Instant::now();
+        let mut status = batch.processing_status;
+        let mut failures = 0;
+
+        while status != ProcessingStatus::Ended {
+            if let Some(max_wait) = poll.max_wait
+                && started.elapsed() >= max_wait
+            {
+                // The batch outlives this process: report where to find it
+                // rather than cancelling work that is already paid for.
+                cancel_guard.disarm();
+                Err(StreamError::other(format!(
+                    "Anthropic batch {id} has not finished after {}s and is still running. \
+                     Retrieve it with `GET {BATCHES_PATH}/{id}`, or raise \
+                     `providers.llm.anthropic.batch_max_wait_secs`.",
+                    max_wait.as_secs()
+                )))?;
+            }
+
+            let detail = match status {
+                ProcessingStatus::Canceling => "cancelling the batch",
+                _ => "waiting on the batch",
+            };
+
+            let mut remaining = poll.interval.max(MIN_POLL_INTERVAL);
+            while !remaining.is_zero() {
+                let slice = HEARTBEAT_INTERVAL.min(remaining);
+                sleep(slice).await;
+                remaining = remaining.saturating_sub(slice);
+                yield Event::keep_alive_with_detail(detail);
+            }
+
+            match retrieve(&client, &id).await {
+                Ok(batch) => {
+                    failures = 0;
+                    status = batch.processing_status;
+                    debug!(
+                        batch = %id,
+                        ?status,
+                        elapsed_secs = started.elapsed().as_secs(),
+                        "Polled batch."
+                    );
+                }
+                Err(error) => {
+                    let error = StreamError::from(error);
+                    failures += 1;
+                    if !error.is_retryable() || failures > MAX_TRANSPORT_FAILURES {
+                        Err(error)?;
+                    } else {
+                        warn!(
+                            batch = %id,
+                            failures,
+                            %error,
+                            "Failed to poll the batch; still waiting."
+                        );
+                    }
+                }
+            }
+        }
+
+        // An ended batch has nothing left to cancel.
+        cancel_guard.disarm();
+
+        info!(
+            batch = %id,
+            elapsed_secs = started.elapsed().as_secs(),
+            "Anthropic message batch finished."
+        );
+
+        // The answer is stored for 29 days and is already paid for, so a
+        // transport failure here is worth waiting out rather than reporting:
+        // the caller's retry would submit a whole new batch to fetch it.
+        let outcome = loop {
+            match result(&client, &id).await {
+                Ok(outcome) => break outcome,
+                Err(error) => {
+                    let error = StreamError::from(error);
+                    failures += 1;
+                    if !error.is_retryable() || failures > MAX_TRANSPORT_FAILURES {
+                        Err(error)?;
+                    } else {
+                        warn!(batch = %id, failures, %error, "Failed to read the batch result.");
+                    }
+
+                    sleep(HEARTBEAT_INTERVAL).await;
+                    yield Event::keep_alive_with_detail("reading the batch result");
+                }
+            }
+        };
+
+        for event in synthesize(into_response(&id, outcome)?) {
+            for mapped in super::map_event(event, is_structured) {
+                yield mapped?;
+            }
+        }
+    }))
+}
+
+/// Unwrap the single result of a finished batch into the message it produced.
+///
+/// A request the batch rejected is reported in the same shape a synchronous
+/// request would have used, so the retry and thinking-repair layers classify it
+/// identically whichever route it took.
+fn into_response(id: &str, outcome: Outcome) -> Result<types::CreateMessagesResponse, StreamError> {
+    match outcome {
+        Outcome::Message(response) => Ok(*response),
+        Outcome::Failed(error) => Err(StreamError::from(AnthropicError::Api(error))),
+        Outcome::Canceled => Err(StreamError::other(format!(
+            "Anthropic batch {id} was cancelled before the request reached the model."
+        ))),
+        Outcome::Expired => Err(StreamError::other(format!(
+            "Anthropic batch {id} expired before the request reached the model."
+        ))),
+    }
+}
+
+/// Replay a finished message as the stream events its streaming counterpart
+/// would have produced.
+///
+/// Everything downstream — chaining on the token ceiling, the forced-tool
+/// fallback, the event builder — is written against the streaming shape.
+/// Rebuilding that shape here keeps [`super::map_event`] the single place that
+/// knows how Anthropic content maps onto JP events.
+fn synthesize(response: types::CreateMessagesResponse) -> Vec<types::MessagesStreamEvent> {
+    let mut events = vec![];
+
+    for (index, block) in response.content.into_iter().enumerate() {
+        // A tool call's arguments only reach `map_event` through a delta: the
+        // block that opens the call carries its id and name and nothing else.
+        let arguments = match &block {
+            types::MessageContent::ToolUse(tool_use) => Some(tool_use.input.to_string()),
+            _ => None,
+        };
+
+        events.push(types::MessagesStreamEvent::ContentBlockStart {
+            index,
+            content_block: block,
+        });
+
+        if let Some(partial_json) = arguments {
+            events.push(types::MessagesStreamEvent::ContentBlockDelta {
+                index,
+                delta: types::ContentBlockDelta::InputJsonDelta { partial_json },
+            });
+        }
+
+        events.push(types::MessagesStreamEvent::ContentBlockStop { index });
+    }
+
+    events.push(types::MessagesStreamEvent::MessageDelta {
+        delta: types::MessageDelta {
+            stop_reason: response.stop_reason,
+            stop_sequence: response.stop_sequence,
+            // A batch result reports the stop reason alone; the refusal
+            // category and explanation ride only on the streaming event.
+            stop_details: None,
+        },
+        usage: response.usage,
+    });
+    events.push(types::MessagesStreamEvent::MessageStop);
+
+    events
+}
+
+/// Cancels the batch it holds when dropped.
+///
+/// Dropping the stream is how a caller abandons a turn, and a batch nobody is
+/// waiting for keeps running and billing on Anthropic's side.
+/// `Drop` cannot await, so the cancel goes out on a detached task and its
+/// outcome is only logged.
+struct CancelOnDrop {
+    client: Client,
+    id: Option<String>,
+}
+
+impl CancelOnDrop {
+    /// Stop cancelling on drop, for a batch that has already ended.
+    fn disarm(&mut self) {
+        self.id = None;
+    }
+}
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        let Some(id) = self.id.take() else {
+            return;
+        };
+
+        // A drop during runtime shutdown has no runtime to spawn onto, and
+        // `tokio::spawn` panics there rather than returning an error.
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            warn!(batch = %id, "Abandoned Anthropic batch left running: no runtime to cancel it on.");
+            return;
+        };
+
+        let client = self.client.clone();
+        handle.spawn(async move {
+            match cancel(&client, &id).await {
+                Ok(()) => info!(batch = %id, "Cancelled abandoned Anthropic batch."),
+                Err(error) => {
+                    warn!(batch = %id, %error, "Failed to cancel abandoned Anthropic batch.");
+                }
+            }
+        });
+    }
+}
+
+/// A Message Batch, reduced to the fields the polling loop reads.
+#[derive(Debug, Deserialize)]
+struct Batch {
+    id: String,
+    processing_status: ProcessingStatus,
+}
+
+/// How far along a batch is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ProcessingStatus {
+    /// Requests are still being processed.
+    InProgress,
+
+    /// Cancellation was requested and is being finalized.
+    Canceling,
+
+    /// Every request has finished and the results are ready.
+    Ended,
+
+    /// A status this build does not know, treated as still running.
+    #[serde(other)]
+    Unknown,
+}
+
+/// The wire body for creating a batch.
+#[derive(Debug, Serialize)]
+struct CreateBatch {
+    requests: [BatchRequest; 1],
+}
+
+/// One request within a batch.
+///
+/// `params` is a serialized [`types::CreateMessagesRequest`] rather than the
+/// struct itself: the batch API rejects `stream`, which the struct always
+/// serializes.
+#[derive(Debug, Serialize)]
+struct BatchRequest {
+    custom_id: &'static str,
+    params: Value,
+}
+
+/// What the model produced for the single request in a batch.
+enum Outcome {
+    /// The request was answered.
+    Message(Box<types::CreateMessagesResponse>),
+
+    /// The request failed, in the shape a synchronous request would report.
+    Failed(ApiError),
+
+    /// The batch was cancelled before the request reached the model.
+    Canceled,
+
+    /// The batch expired before the request reached the model.
+    Expired,
+}
+
+/// One line of the batch results file.
+#[derive(Debug, Deserialize)]
+struct ResultLine {
+    result: BatchResult,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum BatchResult {
+    Succeeded {
+        message: types::CreateMessagesResponse,
+    },
+    Errored {
+        error: ErrorEnvelope,
+    },
+    Canceled,
+    Expired,
+}
+
+/// Anthropic's error envelope, whose outer `type` is always `"error"`.
+#[derive(Debug, Deserialize)]
+struct ErrorEnvelope {
+    error: ApiError,
+}
+
+/// Submit `request` as the only entry in a new batch.
+///
+/// Anthropic validates `params` asynchronously, so a malformed request is
+/// accepted here and reported as an errored result once the batch ends.
+async fn create(
+    client: &Client,
+    request: &types::CreateMessagesRequest,
+    betas: &[String],
+) -> Result<Batch, AnthropicError> {
+    let body = CreateBatch {
+        requests: [BatchRequest {
+            custom_id: CUSTOM_ID,
+            params: batch_params(request)?,
+        }],
+    };
+
+    client.post(BATCHES_PATH, body, betas).await
+}
+
+/// Serialize `request` into the `params` object of a batch entry.
+///
+/// `stream` is dropped: the batch API rejects the key, and the request struct
+/// always serializes it.
+fn batch_params(request: &types::CreateMessagesRequest) -> Result<Value, AnthropicError> {
+    let mut params = serde_json::to_value(request).map_err(AnthropicError::Deserialization)?;
+    if let Some(object) = params.as_object_mut() {
+        object.remove("stream");
+    }
+
+    Ok(params)
+}
+
+/// Read a batch's current processing status.
+async fn retrieve(client: &Client, id: &str) -> Result<Batch, AnthropicError> {
+    client.get(&format!("{BATCHES_PATH}/{id}")).await
+}
+
+/// Read the result of the single request in an ended batch.
+///
+/// The results endpoint serves JSONL.
+/// A batch of one produces a single line, which is itself a complete JSON
+/// document, so it deserializes directly.
+///
+/// The path is rebuilt from the batch id rather than taken from the batch's
+/// `results_url`, which is absolute and would bypass a configured `base_url`.
+async fn result(client: &Client, id: &str) -> Result<Outcome, AnthropicError> {
+    let line: ResultLine = client.get(&format!("{BATCHES_PATH}/{id}/results")).await?;
+
+    Ok(match line.result {
+        BatchResult::Succeeded { message } => Outcome::Message(Box::new(message)),
+        BatchResult::Errored { error } => Outcome::Failed(error.error),
+        BatchResult::Canceled => Outcome::Canceled,
+        BatchResult::Expired => Outcome::Expired,
+    })
+}
+
+/// Ask Anthropic to stop processing a batch.
+///
+/// Requests the model has already answered are still billed and still readable;
+/// the ones it has not reached are dropped.
+async fn cancel(client: &Client, id: &str) -> Result<(), AnthropicError> {
+    client
+        .post::<_, Value>(
+            &format!("{BATCHES_PATH}/{id}/cancel"),
+            Map::<String, Value>::new(),
+            &[],
+        )
+        .await
+        .map(drop)
+}
+
+#[cfg(test)]
+#[path = "batch_tests.rs"]
+mod tests;

--- a/crates/jp_llm/src/provider/anthropic/batch_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic/batch_tests.rs
@@ -1,0 +1,537 @@
+use std::time::{Duration, Instant};
+
+use async_anthropic::types::{
+    CreateMessagesRequest, CreateMessagesRequestBuilder, CreateMessagesResponse, MessageContent,
+    MessagesStreamEvent, Text, Thinking, ToolUse, Usage,
+};
+use futures::StreamExt as _;
+use jp_test::mock::{GET, MockServer, POST};
+use serde_json::json;
+use test_log::test;
+
+use super::*;
+use crate::{
+    error::StreamErrorKind,
+    event::{EventPart, FinishReason},
+    provider::anthropic::map_event,
+};
+
+/// A response carrying `content`, with the fields a finished message always
+/// has.
+fn response(content: Vec<MessageContent>) -> CreateMessagesResponse {
+    CreateMessagesResponse {
+        id: Some("msg_0000000000000000000000".to_owned()),
+        content,
+        model: Some("claude-opus-5".to_owned()),
+        stop_reason: Some("end_turn".to_owned()),
+        stop_sequence: None,
+        usage: Some(Usage {
+            input_tokens: Some(11),
+            output_tokens: Some(22),
+        }),
+    }
+}
+
+#[test]
+fn batch_params_drop_the_stream_key() {
+    let request = CreateMessagesRequestBuilder::default()
+        .model("claude-opus-5")
+        .messages(vec!["hello".into()])
+        .max_tokens(64)
+        .build()
+        .unwrap();
+
+    let params = batch_params(&request).unwrap();
+    let object = params.as_object().unwrap();
+
+    // The batch API rejects `stream` outright, and the request struct
+    // serializes it whether it is set or not.
+    assert!(
+        !object.contains_key("stream"),
+        "params must not carry `stream`, got {params}"
+    );
+    assert_eq!(object.get("model"), Some(&json!("claude-opus-5")));
+    assert_eq!(object.get("max_tokens"), Some(&json!(64)));
+}
+
+#[test]
+fn synthesize_replays_a_text_block_as_start_stop_and_message_end() {
+    let events = synthesize(response(vec![MessageContent::Text(Text {
+        text: "Hello.".to_owned(),
+        cache_control: None,
+    })]));
+
+    assert_eq!(events, vec![
+        MessagesStreamEvent::ContentBlockStart {
+            index: 0,
+            content_block: MessageContent::Text(Text {
+                text: "Hello.".to_owned(),
+                cache_control: None,
+            }),
+        },
+        MessagesStreamEvent::ContentBlockStop { index: 0 },
+        MessagesStreamEvent::MessageDelta {
+            delta: types::MessageDelta {
+                stop_reason: Some("end_turn".to_owned()),
+                stop_sequence: None,
+                stop_details: None,
+            },
+            usage: Some(Usage {
+                input_tokens: Some(11),
+                output_tokens: Some(22),
+            }),
+        },
+        MessagesStreamEvent::MessageStop,
+    ]);
+}
+
+/// A tool call's arguments reach `map_event` only through an input-json delta:
+/// the block that opens the call carries its id and name and nothing else.
+/// Without the synthetic delta the call would arrive with empty arguments.
+#[test]
+fn synthesize_replays_tool_call_arguments_as_a_delta() {
+    let events = synthesize(response(vec![MessageContent::ToolUse(ToolUse {
+        id: "toolu_0000000000000000000000".to_owned(),
+        name: "read_file".to_owned(),
+        input: json!({ "path": "src/lib.rs" }),
+        cache_control: None,
+    })]));
+
+    assert_eq!(
+        events.get(1),
+        Some(&MessagesStreamEvent::ContentBlockDelta {
+            index: 0,
+            delta: types::ContentBlockDelta::InputJsonDelta {
+                partial_json: r#"{"path":"src/lib.rs"}"#.to_owned(),
+            },
+        })
+    );
+}
+
+/// Each content block gets its own index, so the event builder keeps reasoning,
+/// prose, and tool calls apart the way the streaming endpoint does.
+#[test]
+fn synthesize_indexes_each_content_block() {
+    let events = synthesize(response(vec![
+        MessageContent::Thinking(Thinking {
+            thinking: "Considering.".to_owned(),
+            signature: Some("sig".to_owned()),
+        }),
+        MessageContent::Text(Text {
+            text: "Answer.".to_owned(),
+            cache_control: None,
+        }),
+    ]));
+
+    let indices: Vec<_> = events
+        .iter()
+        .filter_map(|event| match event {
+            MessagesStreamEvent::ContentBlockStart { index, .. } => Some(*index),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(indices, vec![0, 1]);
+}
+
+/// The point of replaying the streaming shape: a batched tool call produces the
+/// same JP events a streamed one does, so everything downstream is unaware of
+/// which route the request took.
+#[test]
+fn a_synthesized_tool_call_maps_to_the_same_jp_events_as_a_streamed_one() {
+    let events: Vec<_> = synthesize(response(vec![MessageContent::ToolUse(ToolUse {
+        id: "toolu_0000000000000000000000".to_owned(),
+        name: "read_file".to_owned(),
+        input: json!({ "path": "src/lib.rs" }),
+        cache_control: None,
+    })]))
+    .into_iter()
+    .flat_map(|event| map_event(event, false))
+    .map(|event| event.expect("mapping a synthesized event cannot fail"))
+    .collect();
+
+    assert_eq!(events, vec![
+        Event::tool_call_start(0, "toolu_0000000000000000000000", "read_file"),
+        Event::tool_call_args(0, r#"{"path":"src/lib.rs"}"#),
+        Event::flush(0),
+        Event::Finished(FinishReason::Completed),
+    ]);
+}
+
+/// A response stopped by the token ceiling has to surface as `MaxTokens`, since
+/// that is what drives the chaining path.
+#[test]
+fn a_max_tokens_stop_reason_survives_the_replay() {
+    let mut response = response(vec![MessageContent::Text(Text {
+        text: "Half an ans".to_owned(),
+        cache_control: None,
+    })]);
+    response.stop_reason = Some("max_tokens".to_owned());
+
+    let events: Vec<_> = synthesize(response)
+        .into_iter()
+        .flat_map(|event| map_event(event, false))
+        .map(|event| event.expect("mapping a synthesized event cannot fail"))
+        .collect();
+
+    assert!(
+        events.contains(&Event::Finished(FinishReason::MaxTokens)),
+        "expected a MaxTokens finish, got {events:?}"
+    );
+}
+
+/// Structured output arrives as a text block, and has to be replayed as a
+/// structured part rather than assistant prose.
+#[test]
+fn a_structured_response_replays_as_structured_content() {
+    let events: Vec<_> = synthesize(response(vec![MessageContent::Text(Text {
+        text: r#"{"answer":42}"#.to_owned(),
+        cache_control: None,
+    })]))
+    .into_iter()
+    .flat_map(|event| map_event(event, true))
+    .map(|event| event.expect("mapping a synthesized event cannot fail"))
+    .collect();
+
+    assert_eq!(
+        events.first(),
+        Some(&Event::Part {
+            index: 0,
+            part: EventPart::Structured(r#"{"answer":42}"#.to_owned()),
+            metadata: serde_json::Map::new(),
+        })
+    );
+}
+
+#[test]
+fn a_succeeded_result_line_carries_the_message() {
+    let line: ResultLine = serde_json::from_str(
+        r#"{"custom_id":"jp","result":{"type":"succeeded","message":{"id":"msg_01","type":"message","role":"assistant","model":"claude-opus-5","content":[{"type":"text","text":"Hi."}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":2}}}}"#,
+    )
+    .unwrap();
+
+    let BatchResult::Succeeded { message } = line.result else {
+        panic!("expected a succeeded result");
+    };
+
+    assert_eq!(message.stop_reason, Some("end_turn".to_owned()));
+    assert_eq!(
+        message.content.first().and_then(MessageContent::as_text),
+        Some(&Text {
+            text: "Hi.".to_owned(),
+            cache_control: None,
+        })
+    );
+}
+
+/// A batch validates `params` asynchronously, so a malformed request comes back
+/// as an errored result rather than a rejected submission.
+/// It has to unwrap to the same `ApiError` a synchronous call would report, or
+/// the retry and thinking-repair layers classify it differently depending on
+/// the route.
+#[test]
+fn an_errored_result_line_unwraps_to_the_api_error() {
+    let line: ResultLine = serde_json::from_str(
+        r#"{"custom_id":"jp","result":{"type":"errored","error":{"type":"error","error":{"type":"invalid_request_error","message":"thinking blocks were modified"}}}}"#,
+    )
+    .unwrap();
+
+    let BatchResult::Errored { error } = line.result else {
+        panic!("expected an errored result");
+    };
+
+    assert_eq!(error.error.error_type, "invalid_request_error");
+    assert_eq!(
+        error.error.message.as_deref(),
+        Some("thinking blocks were modified")
+    );
+}
+
+#[test]
+fn terminal_result_types_deserialize() {
+    let canceled: ResultLine =
+        serde_json::from_str(r#"{"custom_id":"jp","result":{"type":"canceled"}}"#).unwrap();
+    assert!(matches!(canceled.result, BatchResult::Canceled));
+
+    let expired: ResultLine =
+        serde_json::from_str(r#"{"custom_id":"jp","result":{"type":"expired"}}"#).unwrap();
+    assert!(matches!(expired.result, BatchResult::Expired));
+}
+
+/// A status Anthropic adds later must not read as "finished": treating an
+/// unknown status as ended would fetch results that do not exist yet.
+#[test]
+fn an_unknown_processing_status_is_not_ended() {
+    let batch: Batch = serde_json::from_str(
+        r#"{"id":"msgbatch_01","processing_status":"something_new","request_counts":{}}"#,
+    )
+    .unwrap();
+
+    assert_eq!(batch.id, "msgbatch_01");
+    assert_eq!(batch.processing_status, ProcessingStatus::Unknown);
+    assert_ne!(batch.processing_status, ProcessingStatus::Ended);
+}
+
+#[test]
+fn known_processing_statuses_deserialize() {
+    for (raw, expected) in [
+        ("in_progress", ProcessingStatus::InProgress),
+        ("canceling", ProcessingStatus::Canceling),
+        ("ended", ProcessingStatus::Ended),
+    ] {
+        let batch: Batch =
+            serde_json::from_str(&format!(r#"{{"id":"b","processing_status":"{raw}"}}"#)).unwrap();
+
+        assert_eq!(batch.processing_status, expected, "for {raw}");
+    }
+}
+
+/// A client pointed at `server`, standing in for the Anthropic API.
+fn mock_client(server: &MockServer) -> Client {
+    let mut builder = Client::builder();
+    builder
+        .api_key("test-key")
+        .base_url(server.base_url())
+        .version("2023-06-01");
+
+    builder.build().expect("a client for the mock server")
+}
+
+/// A minimal request to batch.
+fn request() -> CreateMessagesRequest {
+    CreateMessagesRequestBuilder::default()
+        .model("claude-test")
+        .messages(vec!["go on then".into()])
+        .max_tokens(16)
+        .stream(true)
+        .build()
+        .expect("a valid request")
+}
+
+/// Poll one status check per second, and never give up.
+///
+/// One second is [`MIN_POLL_INTERVAL`], so a test that waits through a single
+/// interval costs a second rather than the configured default of fifteen.
+const FAST_POLL: PollConfig = PollConfig {
+    interval: MIN_POLL_INTERVAL,
+    max_wait: None,
+};
+
+/// A batch that is already finished when first polled still produces the same
+/// JP events a streamed response would, and reports the wait while it lasts.
+#[test(tokio::test)]
+async fn a_finished_batch_replays_as_a_streamed_response() {
+    let server = MockServer::start_async().await;
+
+    // Matching on the body is what pins the submitted shape end to end: a mock
+    // that does not match answers 404 and fails the test. `stream` matters
+    // specifically — the batch API rejects the key outright.
+    let create = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/v1/messages/batches")
+                .body_includes(r#""custom_id":"jp""#)
+                .body_includes(r#""model":"claude-test""#)
+                .body_excludes(r#""stream""#);
+            then.status(200).json_body(json!({
+                "id": "msgbatch_test",
+                "processing_status": "in_progress",
+            }));
+        })
+        .await;
+
+    let retrieve = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/v1/messages/batches/msgbatch_test");
+            then.status(200).json_body(json!({
+                "id": "msgbatch_test",
+                "processing_status": "ended",
+            }));
+        })
+        .await;
+
+    let results = server
+        .mock_async(|when, then| {
+            when.method(GET)
+                .path("/v1/messages/batches/msgbatch_test/results");
+            then.status(200).body(
+                r#"{"custom_id":"jp","result":{"type":"succeeded","message":{"id":"msg_01","type":"message","role":"assistant","model":"claude-test","content":[{"type":"text","text":"Answered."}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}}}"#,
+            );
+        })
+        .await;
+
+    let events: Vec<_> = events(mock_client(&server), request(), false, FAST_POLL)
+        .map(|event| event.expect("the batch route must not error"))
+        .collect()
+        .await;
+
+    // The keep-alive is what stops the idle timeout from tearing the stream
+    // down and submitting a second, separately billed batch.
+    assert_eq!(events, vec![
+        Event::keep_alive_with_detail("waiting on the batch"),
+        Event::message(0, "Answered."),
+        Event::flush(0),
+        Event::Finished(FinishReason::Completed),
+    ]);
+
+    assert_eq!(create.calls_async().await, 1);
+    assert_eq!(retrieve.calls_async().await, 1);
+    assert_eq!(results.calls_async().await, 1);
+}
+
+/// A request the batch rejects has to reach the caller as the API error it is,
+/// so the retry and thinking-repair layers classify it the same way they would
+/// for a synchronous request.
+#[test(tokio::test)]
+async fn an_errored_result_surfaces_as_the_api_error() {
+    let server = MockServer::start_async().await;
+
+    server
+        .mock_async(|when, then| {
+            when.method(POST).path("/v1/messages/batches");
+            then.status(200).json_body(json!({
+                "id": "msgbatch_test",
+                "processing_status": "ended",
+            }));
+        })
+        .await;
+
+    server
+        .mock_async(|when, then| {
+            when.method(GET).path("/v1/messages/batches/msgbatch_test");
+            then.status(200).json_body(json!({
+                "id": "msgbatch_test",
+                "processing_status": "ended",
+            }));
+        })
+        .await;
+
+    server
+        .mock_async(|when, then| {
+            when.method(GET)
+                .path("/v1/messages/batches/msgbatch_test/results");
+            then.status(200).body(
+                r#"{"custom_id":"jp","result":{"type":"errored","error":{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}}}"#,
+            );
+        })
+        .await;
+
+    let cancel = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/v1/messages/batches/msgbatch_test/cancel");
+            then.status(200).json_body(json!({}));
+        })
+        .await;
+
+    let events: Vec<_> = events(mock_client(&server), request(), false, FAST_POLL)
+        .collect()
+        .await;
+
+    let [Err(error)] = events.as_slice() else {
+        panic!("expected a single error, got {events:?}");
+    };
+
+    // `overloaded_error` is one Anthropic recommends retrying, and the
+    // classification has to survive the trip through the batch result.
+    assert_eq!(error.kind, StreamErrorKind::Transient);
+    assert!(
+        error.to_string().contains("Overloaded"),
+        "the API message must reach the caller, got {error}"
+    );
+
+    // An ended batch has nothing left to cancel, and cancelling it would report
+    // a failure the user cannot act on.
+    assert_eq!(cancel.calls_async().await, 0);
+}
+
+/// Abandoning the stream is how the CLI ends a turn early.
+/// The batch keeps running and billing on Anthropic's side unless something
+/// stops it.
+#[test(tokio::test)]
+async fn dropping_the_stream_cancels_a_running_batch() {
+    let server = MockServer::start_async().await;
+
+    server
+        .mock_async(|when, then| {
+            when.method(POST).path("/v1/messages/batches");
+            then.status(200).json_body(json!({
+                "id": "msgbatch_test",
+                "processing_status": "in_progress",
+            }));
+        })
+        .await;
+
+    // Never finishes, so the only way out of the stream is to drop it.
+    server
+        .mock_async(|when, then| {
+            when.method(GET).path("/v1/messages/batches/msgbatch_test");
+            then.status(200).json_body(json!({
+                "id": "msgbatch_test",
+                "processing_status": "in_progress",
+            }));
+        })
+        .await;
+
+    let cancel = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/v1/messages/batches/msgbatch_test/cancel");
+            then.status(200).json_body(json!({}));
+        })
+        .await;
+
+    let mut stream = events(mock_client(&server), request(), false, FAST_POLL);
+
+    // Pull one item so the batch is submitted and the wait is under way. The
+    // first item can only be a keep-alive: the batch never ends.
+    assert_eq!(
+        stream.next().await.transpose().unwrap(),
+        Some(Event::keep_alive_with_detail("waiting on the batch"))
+    );
+
+    drop(stream);
+
+    // The cancel goes out on a detached task, so there is nothing to await.
+    // Two seconds is far longer than a request to a local mock server takes,
+    // and a cancel that never arrives fails rather than passing on a lucky
+    // poll.
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let calls = cancel.calls_async().await;
+        if calls >= 1 {
+            break;
+        }
+
+        assert!(
+            Instant::now() < deadline,
+            "the abandoned batch was never cancelled"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+/// The batch body has to name each request, and the id has to satisfy
+/// Anthropic's `^[a-zA-Z0-9_-]{1,64}$`.
+#[test]
+fn the_batch_body_wraps_one_named_request() {
+    let request = CreateMessagesRequestBuilder::default()
+        .model("claude-opus-5")
+        .messages(vec!["hello".into()])
+        .build()
+        .unwrap();
+
+    let body = CreateBatch {
+        requests: [BatchRequest {
+            custom_id: CUSTOM_ID,
+            params: batch_params(&request).unwrap(),
+        }],
+    };
+
+    let value = serde_json::to_value(&body).unwrap();
+    let requests = value["requests"].as_array().unwrap();
+
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0]["custom_id"], json!("jp"));
+    assert_eq!(requests[0]["params"]["model"], json!("claude-opus-5"));
+}

--- a/crates/jp_llm/src/provider/anthropic_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic_tests.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use assert_matches::assert_matches;
 use indexmap::IndexMap;
 use jp_config::model::{
     id::ModelIdConfig,
@@ -96,7 +95,12 @@ async fn chaining_is_bounded_by_the_continuation_budget() {
         .build()
         .expect("a valid request");
 
-    let events: Vec<_> = call(client, request, MAX_CHAIN_DEPTH, false, None)
+    let transport = Transport {
+        client,
+        batch: None,
+    };
+
+    let events: Vec<_> = call(transport, request, MAX_CHAIN_DEPTH, false, None)
         .collect()
         .await;
 
@@ -910,20 +914,26 @@ fn no_other_tier_asks_for_the_fast_mode_beta() {
     }
 }
 
-/// Anthropic sells no discounted latency-tolerant tier.
-/// Substituting the neighbouring rung would quietly bill standard rates for a
-/// request that asked to be cheap, so the turn is refused instead.
+/// Anthropic prices `flex` through the Message Batches API, which is reached by
+/// posting to a different endpoint rather than by setting a request field.
+///
+/// `speed` matters specifically: the batch API rejects it outright, so a `flex`
+/// request that carried fast mode would be refused on submission.
 #[test]
-fn request_refuses_flex() {
-    let error = tier_request(Some(ServiceTier::Flex)).expect_err("flex has no Anthropic mapping");
+fn request_omits_both_tier_fields_for_flex() {
+    assert_eq!(tier_fields(Some(ServiceTier::Flex)), (None, None));
+}
 
-    assert_matches!(error, Error::UnsupportedServiceTier {
-        provider: ProviderId::Anthropic,
-        tier: ServiceTier::Flex,
-    });
-    assert_eq!(
-        error.to_string(),
-        "The `anthropic` provider has no `flex` service tier"
+/// The beta that admits `speed` is refused along with `speed` itself inside a
+/// batch, so `flex` must not ask for it either.
+#[test]
+fn flex_does_not_ask_for_the_fast_mode_beta() {
+    let request = tier_request(Some(ServiceTier::Flex)).unwrap();
+
+    assert!(
+        request.betas.is_empty(),
+        "flex must not request a beta, got {:?}",
+        request.betas
     );
 }
 

--- a/crates/jp_llm/src/provider/openrouter.rs
+++ b/crates/jp_llm/src/provider/openrouter.rs
@@ -225,7 +225,7 @@ fn call(
                     yield flush;
                 }
                 patch @ Event::Patch(_) => yield patch,
-                keep_alive @ Event::KeepAlive => yield keep_alive,
+                keep_alive @ Event::KeepAlive { .. } => yield keep_alive,
             }
         }
     })

--- a/crates/jp_llm/src/stream.rs
+++ b/crates/jp_llm/src/stream.rs
@@ -230,7 +230,7 @@ pub fn with_tool_call_keepalive(stream: EventStream, interval: Duration) -> Even
                 Ok(None) => break,
                 // No event within `interval` while a tool call is open: emit a
                 // heartbeat so the gap reads as activity, then keep waiting.
-                Err(_elapsed) => yield Ok(Event::KeepAlive),
+                Err(_elapsed) => yield Ok(Event::keep_alive()),
             }
         }
     }

--- a/crates/jp_llm/src/stream/chain.rs
+++ b/crates/jp_llm/src/stream/chain.rs
@@ -118,7 +118,7 @@ impl EventChain {
             }
 
             // Pass through immediately — not part of the content stream.
-            Event::Patch(_) | Event::KeepAlive => vec![event],
+            Event::Patch(_) | Event::KeepAlive { .. } => vec![event],
         }
     }
 
@@ -165,7 +165,7 @@ impl EventChain {
             }
 
             // Pass through immediately — not part of the content stream.
-            Event::Patch(_) | Event::KeepAlive => vec![event],
+            Event::Patch(_) | Event::KeepAlive { .. } => vec![event],
         }
     }
 

--- a/crates/jp_llm/src/stream_tests.rs
+++ b/crates/jp_llm/src/stream_tests.rs
@@ -125,7 +125,7 @@ async fn non_content_events_do_not_count_toward_the_ceiling() {
     // so a stream of nothing but those must survive a 1-byte ceiling.
     let inner = stream::iter(vec![
         Ok(Event::flush(0)),
-        Ok(Event::KeepAlive),
+        Ok(Event::keep_alive()),
         Ok(Event::Patch(vec![])),
         Ok(Event::flush(1)),
     ])
@@ -254,7 +254,7 @@ async fn tool_call_keepalive_emitted_during_open_tool_call() {
 
     assert!(matches!(wrapped.next().await, Some(Ok(Event::Part { .. }))));
     assert!(
-        matches!(wrapped.next().await, Some(Ok(Event::KeepAlive))),
+        matches!(wrapped.next().await, Some(Ok(Event::KeepAlive { .. }))),
         "a keepalive is injected during the gap"
     );
     assert!(matches!(

--- a/crates/jp_llm/src/test.rs
+++ b/crates/jp_llm/src/test.rs
@@ -675,7 +675,7 @@ pub async fn run_chat_completion(
                                         stream.extend(std::iter::once(event));
                                     }
                                 }
-                                Event::Patch(_) | Event::KeepAlive => {}
+                                Event::Patch(_) | Event::KeepAlive { .. } => {}
                                 Event::Finished(reason) => {
                                     for mut event in builder.drain() {
                                         event.timestamp =

--- a/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_chat_completion_stream__raw_events.snap
@@ -11,7 +11,9 @@ expression: v
             ),
             metadata: {},
         },
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Reasoning(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_fable_5_forced_tool_soft_forces__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_fable_5_forced_tool_soft_forces__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/anthropic/test_fable_5_forced_tool_soft_forces__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_fable_5_forced_tool_soft_forces__raw_events.snap
@@ -14,7 +14,9 @@ expression: v
             ),
             metadata: {},
         },
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: ToolCall(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_image_attachment__raw_events.snap
@@ -4,7 +4,9 @@ expression: v
 ---
 [
     [
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Message(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_multi_turn_conversation__raw_events.snap
@@ -4,7 +4,9 @@ expression: v
 ---
 [
     [
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Message(
@@ -49,7 +51,9 @@ expression: v
             ),
             metadata: {},
         },
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Reasoning(
@@ -103,7 +107,9 @@ expression: v
             ),
             metadata: {},
         },
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: ToolCall(
@@ -140,7 +146,9 @@ expression: v
         ),
     ],
     [
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Message(
@@ -220,7 +228,9 @@ expression: v
             ),
             metadata: {},
         },
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Reasoning(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_adaptive_thinking__raw_events.snap
@@ -11,7 +11,9 @@ expression: v
             ),
             metadata: {},
         },
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Reasoning(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_opus_4_6_max_effort__raw_events.snap
@@ -11,7 +11,9 @@ expression: v
             ),
             metadata: {},
         },
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Reasoning(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_redacted_thinking__raw_events.snap
@@ -13,7 +13,9 @@ expression: v
                 "anthropic_redacted_thinking": String("EoECCpoBCBEYAipAugv+UDXDqtkNQB7QcXVqFdRNvm29uAES3efyU/39vgCbULFfOT4wnvHKIphhWI0YxHIe024emNB5vyOqu5qwGDIZY2xhdWRlLWhhaWt1LTQtNS0yMDI1MTAwMTgAQgh0aGlua2luZ1okYjE0ZDEzN2QtZjUxMi00MzA5LTk3NGQtM2ZmMTMyYWYxNTYyqAH02qHUBhIMn9Knul2JVFz4x9gyGgwaS0GieNlrvSPrMSciMAHQe/rttGFZRD9ZkcAa7TeH18dcpyCxea36Lq5v6OqaM0y0RY0EI+g1eigbZ9uHhyoUKwFWUb2aLuxLFJplmGIWlfo7mNAYAQ=="),
             },
         },
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Flush {
             index: 0,
             metadata: {},
@@ -185,7 +187,9 @@ expression: v
         ),
     ],
     [
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Message(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__conversation_stream.snap
@@ -183,7 +183,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_request_chaining__raw_events.snap
@@ -11,7 +11,9 @@ expression: v
             ),
             metadata: {},
         },
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Reasoning(
@@ -361,7 +363,9 @@ expression: v
             ),
             metadata: {},
         },
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Flush {
             index: 0,
             metadata: {},
@@ -555,7 +559,9 @@ expression: v
             ),
             metadata: {},
         },
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Flush {
             index: 0,
             metadata: {},

--- a/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_structured_output__raw_events.snap
@@ -11,7 +11,9 @@ expression: v
             ),
             metadata: {},
         },
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Structured(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_auto__raw_events.snap
@@ -14,7 +14,9 @@ expression: v
             ),
             metadata: {},
         },
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: ToolCall(
@@ -78,7 +80,9 @@ expression: v
         ),
     ],
     [
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Message(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_function__raw_events.snap
@@ -14,7 +14,9 @@ expression: v
             ),
             metadata: {},
         },
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: ToolCall(
@@ -69,7 +71,9 @@ expression: v
         ),
     ],
     [
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Message(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_reasoning__raw_events.snap
@@ -11,7 +11,9 @@ expression: v
             ),
             metadata: {},
         },
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Reasoning(
@@ -169,7 +171,9 @@ expression: v
         ),
     ],
     [
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Message(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_no_reasoning__raw_events.snap
@@ -14,7 +14,9 @@ expression: v
             ),
             metadata: {},
         },
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: ToolCall(
@@ -51,7 +53,9 @@ expression: v
         ),
     ],
     [
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Message(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_required_reasoning__raw_events.snap
@@ -11,7 +11,9 @@ expression: v
             ),
             metadata: {},
         },
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Reasoning(
@@ -129,7 +131,9 @@ expression: v
         ),
     ],
     [
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Message(

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__raw_events.snap
+++ b/crates/jp_llm/tests/fixtures/anthropic/test_tool_call_stream__raw_events.snap
@@ -14,7 +14,9 @@ expression: v
             ),
             metadata: {},
         },
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: ToolCall(
@@ -69,7 +71,9 @@ expression: v
         ),
     ],
     [
-        KeepAlive,
+        KeepAlive {
+            detail: None,
+        },
         Part {
             index: 0,
             part: Message(

--- a/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_chat_completion_stream__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_multi_turn_conversation__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_structured_output__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_auto__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_function__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_required_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_tool_call_stream__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/cerebras/test_unknown_model_auto_omits_effort__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_unknown_model_auto_omits_effort__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/cerebras/test_unknown_model_off_sends_none__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/cerebras/test_unknown_model_off_sends_none__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_chat_completion_stream__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_gemini_3_reasoning__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_image_attachment__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_multi_turn_conversation__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_structured_output__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_auto__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_function__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_required_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_tool_call_stream__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/google/test_unknown_model_inferred_thinking_level__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/google/test_unknown_model_inferred_thinking_level__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_chat_completion_stream__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_image_attachment__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_multi_turn_conversation__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_structured_output__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_auto__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_function__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_required_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/llamacpp/test_tool_call_stream__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_chat_completion_stream__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_image_attachment__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_multi_turn_conversation__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_structured_output__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_auto__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_function__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_required_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/ollama/test_tool_call_stream__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_chat_completion_stream__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openai/test_gpt_5_6_cache_off_sends_explicit_optout__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_gpt_5_6_cache_off_sends_explicit_optout__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openai/test_gpt_5_6_pro_reasoning_and_explicit_caching__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_gpt_5_6_pro_reasoning_and_explicit_caching__conversation_stream.snap
@@ -183,7 +183,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openai/test_gpt_5_6_prompt_cache_read_after_write__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_gpt_5_6_prompt_cache_read_after_write__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_image_attachment__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_multi_turn_conversation__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openai/test_reasoning_history_replayed_to_reasoning_unsupported_model__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_reasoning_history_replayed_to_reasoning_unsupported_model__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_structured_output__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_auto__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_function__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_required_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openai/test_tool_call_stream__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/anthropic_test_sub_provider_event_metadata__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/google_test_sub_provider_event_metadata__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/minimax_test_sub_provider_event_metadata__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openrouter/test_anthropic_opus_5_parallel_tool_round_trip__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_anthropic_opus_5_parallel_tool_round_trip__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_chat_completion_stream__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_image_attachment__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_multi_turn_conversation__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_structured_output__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_auto__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_function__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_no_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_required_reasoning__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/test_tool_call_stream__conversation_stream.snap
@@ -178,7 +178,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
+++ b/crates/jp_llm/tests/fixtures/openrouter/x-ai_test_sub_provider_event_metadata__conversation_stream.snap
@@ -181,7 +181,9 @@ expression: v
           "api_key_env": "ANTHROPIC_API_KEY",
           "base_url": "https://api.anthropic.com",
           "chain_on_max_tokens": true,
-          "beta_headers": []
+          "beta_headers": [],
+          "batch_poll_interval_secs": 15,
+          "batch_max_wait_secs": 3600
         },
         "cerebras": {
           "api_key_env": "CEREBRAS_API_KEY",

--- a/docs/architecture/ubiquitous-language.md
+++ b/docs/architecture/ubiquitous-language.md
@@ -282,7 +282,9 @@ The grade of capacity a request is served from, trading price against latency
 and availability.
 JP models four rungs (`off`, `flex`, `standard`, `priority`) as `ServiceTier` in
 `jp_config::model::parameters`, and each [Provider](#provider) maps them onto
-its own wire vocabulary.
+its own mechanism — usually a request field, but not always: Anthropic prices
+`flex` through its asynchronous Message Batches API, so the rung selects an
+endpoint rather than a parameter.
 `off` is the rung that asks for nothing, which every provider expresses by
 sending no tier at all.
 


### PR DESCRIPTION
`jp q --tier flex` against `anthropic` used to fail, because Anthropic sells no flex tier. It now runs the request through their Message Batches API, which carries the same 50% discount other providers' flex tiers offer. Nothing streams: the answer arrives complete, typically after tens of minutes, and the status row reads `⏱ Waiting… 240.0s (waiting on the batch)` until it does. A batched response is replayed as the events a streamed one produces, so tool calls, chaining past the token ceiling, and thinking-block repair behave the same either way.

Interrupting the turn cancels the batch, so an abandoned request stops billing. Waiting longer than
`providers.llm.anthropic.batch_max_wait_secs` (one hour by default) gives up and reports the batch id, leaving it running so the answer can still be fetched by hand; `0` waits the full 24 hours Anthropic keeps a batch alive. `batch_poll_interval_secs` sets how often the status is checked.

Inquiries no longer inherit the assistant's service tier. An inquiry blocks the tool call that raised it, so it cannot pay for a discount in latency; setting
`conversation.inquiry.assistant.model.parameters.service_tier` on the inquiry still applies.