### PR TITLE
refactor(storage): Generalize conversation locking into a resource locker

### DIFF
--- a/crates/jp_storage/src/backend/fs.rs
+++ b/crates/jp_storage/src/backend/fs.rs
@@ -20,12 +20,8 @@ use super::{
     PersistBackend, Projection, SanitizeReport, SessionBackend, TrashedConversation,
 };
 use crate::{
-    CONVERSATIONS_DIR, LoadError, Storage, dir_entries,
-    error::Result,
-    get_expiring_timestamp,
-    load::load_json,
-    load_conversation_id_from_entry,
-    lock::{ConversationFileLock, LockInfo},
+    CONVERSATIONS_DIR, LoadError, Storage, dir_entries, error::Result, get_expiring_timestamp,
+    load::load_json, load_conversation_id_from_entry, lock::LockInfo,
     validate::trash_invalid_conversation,
 };
 
@@ -336,7 +332,7 @@ impl LockBackend for FsStorageBackend {
             .storage
             .try_lock_conversation(conversation_id, session)?
         {
-            Some(lock) => Ok(Some(Box::new(lock))),
+            Some(guard) => Ok(Some(Box::new(guard))),
             None => Ok(None),
         }
     }
@@ -374,8 +370,6 @@ impl SessionBackend for FsStorageBackend {
             .collect()
     }
 }
-
-impl ConversationLockGuard for ConversationFileLock {}
 
 #[cfg(debug_assertions)]
 impl FsStorageBackend {

--- a/crates/jp_storage/src/backend/lock.rs
+++ b/crates/jp_storage/src/backend/lock.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use jp_conversation::ConversationId;
 
-use crate::lock::LockInfo;
+use crate::{lock::LockInfo, resource_lock::ResourceGuard};
 
 /// Conversation-level locking.
 ///
@@ -30,7 +30,10 @@ pub trait LockBackend: Send + Sync + Debug {
 
 /// A held conversation lock.
 /// Released on drop.
-///
-/// The filesystem implementation wraps `ConversationFileLock`.
-/// In-memory backends use a mutex-based guard.
 pub trait ConversationLockGuard: Send + Sync + Debug {}
+
+/// Any held resource lock can serve as a conversation lock guard; the backends
+/// produce their guards through [`ResourceLocker`] implementations.
+///
+/// [`ResourceLocker`]: crate::resource_lock::ResourceLocker
+impl ConversationLockGuard for Box<dyn ResourceGuard> {}

--- a/crates/jp_storage/src/backend/memory.rs
+++ b/crates/jp_storage/src/backend/memory.rs
@@ -5,8 +5,7 @@
 //! Intended for tests and future non-filesystem environments.
 
 use std::{
-    collections::{HashMap, HashSet},
-    fmt,
+    collections::HashMap,
     sync::{Arc, Mutex},
 };
 
@@ -19,7 +18,13 @@ use super::{
     ConversationFilter, ConversationIndexEntry, ConversationLockGuard, LoadBackend, LockBackend,
     PersistBackend, Projection, SanitizeReport, SessionBackend, StoragePresence,
 };
-use crate::{LoadError, error::Result, load::LoadErrorInner, lock::LockInfo};
+use crate::{
+    LoadError,
+    error::Result,
+    load::LoadErrorInner,
+    lock::LockInfo,
+    resource_lock::{InMemoryResourceLocker, ResourceLocker as _},
+};
 
 /// A stored conversation: metadata, event stream, and the projection of its
 /// most recent write.
@@ -34,7 +39,7 @@ type StoredConversation = (Conversation, ConversationStream, Projection);
 pub struct InMemoryStorageBackend {
     conversations: Arc<Mutex<HashMap<ConversationId, StoredConversation>>>,
     archived: Arc<Mutex<HashMap<ConversationId, StoredConversation>>>,
-    locks: Arc<Mutex<HashSet<String>>>,
+    locks: InMemoryResourceLocker,
     sessions: Arc<Mutex<HashMap<String, Value>>>,
 }
 
@@ -188,16 +193,14 @@ impl LockBackend for InMemoryStorageBackend {
         conversation_id: &str,
         _session: Option<&str>,
     ) -> Result<Option<Box<dyn ConversationLockGuard>>> {
-        let mut locks = self.locks.lock().expect("poisoned");
-        if locks.contains(conversation_id) {
-            return Ok(None);
+        match self
+            .locks
+            .try_lock(conversation_id, None)
+            .map_err(|error| error.source)?
+        {
+            Some(guard) => Ok(Some(Box::new(guard))),
+            None => Ok(None),
         }
-        locks.insert(conversation_id.to_owned());
-
-        Ok(Some(Box::new(InMemoryLockGuard {
-            conversation_id: conversation_id.to_owned(),
-            locks: Arc::clone(&self.locks),
-        })))
     }
 
     fn lock_info(&self, _conversation_id: &str) -> Option<LockInfo> {
@@ -234,32 +237,6 @@ impl SessionBackend for InMemoryStorageBackend {
             .collect()
     }
 }
-
-/// A held in-process lock.
-/// Removes itself from the lock set on drop.
-struct InMemoryLockGuard {
-    conversation_id: String,
-    locks: Arc<Mutex<HashSet<String>>>,
-}
-
-impl Drop for InMemoryLockGuard {
-    fn drop(&mut self) {
-        self.locks
-            .lock()
-            .expect("poisoned")
-            .remove(&self.conversation_id);
-    }
-}
-
-impl fmt::Debug for InMemoryLockGuard {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("InMemoryLockGuard")
-            .field("conversation_id", &self.conversation_id)
-            .finish_non_exhaustive()
-    }
-}
-
-impl ConversationLockGuard for InMemoryLockGuard {}
 
 #[cfg(test)]
 #[path = "memory_tests.rs"]

--- a/crates/jp_storage/src/lib.rs
+++ b/crates/jp_storage/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod backend;
 pub mod error;
 pub mod lock;
+pub mod resource_lock;
 pub mod value;
 
 pub mod load;

--- a/crates/jp_storage/src/lock.rs
+++ b/crates/jp_storage/src/lock.rs
@@ -1,19 +1,24 @@
 //! Advisory file-based conversation locks.
 //!
-//! Uses OS-level advisory locks (`flock` on Unix, `LockFileEx` on Windows) to
-//! prevent concurrent writes to the same conversation.
+//! The domain layer over [`resource_lock`]: conversation-id resource names,
+//! [`LockInfo`] holder diagnostics, and the user-vs-workspace lock-file
+//! placement policy.
+//! The locking mechanics themselves (OS advisory locks, guard lifetimes) live
+//! in [`resource_lock`].
+//!
+//! [`resource_lock`]: crate::resource_lock
 
-use std::{
-    fs::{self, File, OpenOptions},
-    io::{self, Read, Seek, Write},
-};
+use std::fs::File;
 
 use camino::{Utf8Path, Utf8PathBuf};
 use chrono::Utc;
 use relative_path::RelativePath;
 use serde::{Deserialize, Serialize};
 
-use crate::error::Result;
+use crate::{
+    error::Result,
+    resource_lock::{FsResourceLocker, ResourceGuard, ResourceLocker as _, try_exclusive_lock},
+};
 
 pub(crate) const LOCKS_DIR: &str = "locks";
 
@@ -36,92 +41,13 @@ pub struct LockInfo {
     pub acquired_at: String,
 }
 
-/// An acquired exclusive advisory lock on a conversation.
-///
-/// The OS lock is held as long as the `File` is open.
-/// On drop, the lock file is deleted and the file handle is closed (releasing
-/// the flock).
-#[derive(Debug)]
-pub struct ConversationFileLock {
-    file: Option<File>,
-    path: Utf8PathBuf,
-}
-
-impl ConversationFileLock {
-    /// Try to acquire an exclusive advisory lock on the given path.
-    ///
-    /// `session` is the current process's session identity, written to the lock
-    /// file for diagnostics.
-    ///
-    /// Returns `Ok(Some(lock))` if the lock was acquired, `Ok(None)` if another
-    /// process holds it, or `Err` on I/O failure.
-    fn try_acquire(path: Utf8PathBuf, session: Option<&str>) -> Result<Option<Self>> {
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-
-        let file = OpenOptions::new()
-            .create(true)
-            .truncate(false)
-            .write(true)
-            .read(true)
-            .open(&path)?;
-
-        if try_exclusive_lock(&file) {
-            let mut lock = Self {
-                file: Some(file),
-                path,
-            };
-
-            // Write diagnostic info to the lock file (best-effort).
-            let _err = lock.write_info(session);
-
-            Ok(Some(lock))
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// Write diagnostic info to the lock file (best-effort).
-    fn write_info(&mut self, session: Option<&str>) -> Result<()> {
-        let Some(file) = self.file.as_mut() else {
-            return Ok(());
-        };
-
-        let info = LockInfo {
-            pid: std::process::id(),
-            session: session.map(String::from),
-            acquired_at: Utc::now().to_rfc3339(),
-        };
-
-        // Truncate + rewrite. Ignore errors — the info is purely diagnostic.
-        file.set_len(0)?;
-        file.seek(io::SeekFrom::Start(0))?;
-        serde_json::to_writer(&*file, &info)?;
-        file.flush().map_err(Into::into)
-    }
-}
-
 /// Read diagnostic info from a lock file (best-effort).
 ///
 /// Returns `None` if the file can't be read or parsed.
 #[must_use]
 pub fn read_lock_info(path: &Utf8Path) -> Option<LockInfo> {
-    let mut file = File::open(path).ok()?;
-    let mut buf = String::new();
-
-    file.read_to_string(&mut buf).ok()?;
-    serde_json::from_str(&buf).ok()
-}
-
-impl Drop for ConversationFileLock {
-    fn drop(&mut self) {
-        // Drop the file handle first to release the OS lock.
-        self.file.take();
-
-        // Best-effort cleanup of the lock file.
-        let _err = fs::remove_file(&self.path);
-    }
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
 }
 
 impl super::Storage {
@@ -133,15 +59,37 @@ impl super::Storage {
     /// The lock file is placed in user storage if available, otherwise in
     /// workspace storage.
     ///
-    /// Returns `Ok(Some(lock))` if the lock was acquired, `Ok(None)` if another
-    /// process holds it, or `Err` on I/O errors.
+    /// Returns `Ok(Some(guard))` if the lock was acquired, `Ok(None)` if
+    /// another process holds it, or `Err` on I/O errors.
     pub fn try_lock_conversation(
         &self,
         conversation_id: &str,
         session: Option<&str>,
-    ) -> Result<Option<ConversationFileLock>> {
+    ) -> Result<Option<Box<dyn ResourceGuard>>> {
         let path = self.lock_file_path(conversation_id).unwrap_or_else(|p| p);
-        ConversationFileLock::try_acquire(path, session)
+        let dir = path.parent().unwrap_or(Utf8Path::new("."));
+
+        // Holder info is purely diagnostic; failing to serialize it must
+        // not fail the acquisition.
+        let info = serde_json::to_string(&LockInfo {
+            pid: std::process::id(),
+            session: session.map(String::from),
+            acquired_at: Utc::now().to_rfc3339(),
+        })
+        .ok();
+
+        // Conversation lock files double as presence markers (see
+        // `is_conversation_locked` and the orphan scan), so they are removed
+        // when the guard drops. Removal is not free: a contender that opens the
+        // path between the handle closing and the unlink locks an inode about
+        // to disappear, while the next acquisition locks a fresh file at the
+        // same path. `try_lock` keeps that to the close/unlink window instead
+        // of the certainty a blocking wait would give, but does not close it;
+        // RFD 106 tracks the fix as the release-then-unlink defect.
+        FsResourceLocker::new(dir)
+            .with_remove_on_drop()
+            .try_lock(conversation_id, info.as_deref())
+            .map_err(|error| error.source.into())
     }
 
     /// Read lock holder info for a conversation.
@@ -201,7 +149,7 @@ impl super::Storage {
 /// If it succeeds, the file is orphaned.
 /// The lock is immediately released.
 pub(crate) fn is_orphaned_lock(path: &camino::Utf8Path) -> bool {
-    let Ok(file) = std::fs::File::open(path) else {
+    let Ok(file) = File::open(path) else {
         return false;
     };
 
@@ -212,42 +160,4 @@ pub(crate) fn is_orphaned_lock(path: &camino::Utf8Path) -> bool {
     } else {
         false
     }
-}
-
-#[cfg(unix)]
-fn try_exclusive_lock(file: &File) -> bool {
-    use std::os::unix::io::AsRawFd;
-
-    // SAFETY: flock is a standard POSIX function. The file descriptor is valid
-    // because we hold a reference to the open File.
-    unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) == 0 }
-}
-
-#[cfg(windows)]
-fn try_exclusive_lock(file: &File) -> bool {
-    use std::os::windows::io::AsRawHandle;
-
-    use windows_sys::Win32::{
-        Storage::FileSystem::{LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, LockFileEx},
-        System::IO::OVERLAPPED,
-    };
-
-    let handle = file.as_raw_handle();
-    let mut overlapped: OVERLAPPED = unsafe { std::mem::zeroed() };
-    let flags = LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY;
-
-    // Lock a single byte at a high offset, far past the diagnostic JSON
-    // written at offset 0. Windows exclusive byte-range locks prevent ALL
-    // other handles from reading the locked region, so placing the lock
-    // away from the file content lets other handles read the lock info.
-    overlapped.Anonymous.Anonymous.Offset = u32::MAX;
-
-    // SAFETY: handle is valid (from an open File), overlapped is initialized.
-    unsafe { LockFileEx(handle, flags, 0, 1, 0, &mut overlapped) != 0 }
-}
-
-#[cfg(not(any(unix, windows)))]
-fn try_exclusive_lock(_file: &File) -> bool {
-    // No locking support; assume success (best-effort).
-    true
 }

--- a/crates/jp_storage/src/resource_lock.rs
+++ b/crates/jp_storage/src/resource_lock.rs
@@ -1,0 +1,470 @@
+//! Cross-process resource locking.
+//!
+//! [`ResourceLocker`] serializes access to named resources.
+//! It is the locking *primitive*: acquire, release on drop, probe, and opaque
+//! holder info.
+//! Domain policies — which resource names exist, what the holder info
+//! contains, where lock files live — belong to the consumer.
+//!
+//! Three implementations:
+//!
+//! - [`FsResourceLocker`] — one `<resource>.lock` file per resource, held via
+//!   OS advisory locks (`flock` on Unix, `LockFileEx` on Windows).
+//! - [`InMemoryResourceLocker`] — in-process locking for tests and
+//!   memory-backed setups.
+//! - [`NullResourceLocker`] — every acquisition succeeds; for flows that
+//!   deliberately run without cross-process exclusion.
+
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    fs::{File, OpenOptions},
+    io::{self, Read as _, Seek as _, Write as _},
+    sync::{Arc, Condvar, Mutex},
+};
+
+use camino::Utf8PathBuf;
+
+/// Failure to acquire or inspect a resource lock.
+#[derive(Debug, thiserror::Error)]
+#[error("failed to lock resource {resource:?}: {source}")]
+pub struct LockError {
+    /// The resource whose lock operation failed.
+    pub resource: String,
+
+    #[source]
+    pub source: io::Error,
+}
+
+impl LockError {
+    fn new(resource: &str, source: io::Error) -> Self {
+        Self {
+            resource: resource.to_owned(),
+            source,
+        }
+    }
+}
+
+/// Serializes access to named resources across processes.
+pub trait ResourceLocker: Send + Sync + Debug {
+    /// Attempt to acquire the resource's exclusive lock without blocking.
+    ///
+    /// Returns `Ok(None)` when another holder has it.
+    /// `info` is opaque holder metadata recorded best-effort at acquisition,
+    /// readable through [`Self::holder_info`] while the lock file (or in-memory
+    /// entry) exists.
+    /// `None` records nothing, and clears anything an earlier holder left.
+    fn try_lock(
+        &self,
+        resource: &str,
+        info: Option<&str>,
+    ) -> Result<Option<Box<dyn ResourceGuard>>, LockError>;
+
+    /// Block until the resource's exclusive lock is acquired.
+    fn lock(&self, resource: &str, info: Option<&str>)
+    -> Result<Box<dyn ResourceGuard>, LockError>;
+
+    /// Whether another holder currently has the resource.
+    ///
+    /// A non-destructive probe: no lock file is created or removed.
+    fn is_held(&self, resource: &str) -> bool;
+
+    /// Read the info recorded by the most recent acquisition (best-effort).
+    ///
+    /// Not proof that anyone holds the resource: a file-based locker that keeps
+    /// its lock files reports the last holder's info after that holder's guard
+    /// dropped.
+    /// Pair this with [`Self::is_held`] when the current holder is what
+    /// matters.
+    fn holder_info(&self, resource: &str) -> Option<String>;
+}
+
+/// A held resource lock.
+/// Released on drop.
+pub trait ResourceGuard: Send + Sync + Debug {}
+
+/// File-based locking: one `<resource>.lock` file per resource under a fixed
+/// directory, held via OS advisory locks.
+///
+/// Killing the holding process releases the OS lock automatically; the lock
+/// file may remain, but a leftover file does not block the next acquisition.
+#[derive(Debug, Clone)]
+pub struct FsResourceLocker {
+    dir: Utf8PathBuf,
+
+    /// Remove the lock file when the guard drops.
+    ///
+    /// Unlinking is never fully sound.
+    /// The OS lock releases when the handle closes, so a contender that opens
+    /// the path in the window before the unlink takes a lock on an inode about
+    /// to disappear, while the next acquisition creates and locks a fresh file
+    /// at the same path: two holders at once.
+    /// RFD 106 calls this the release-then-unlink defect.
+    ///
+    /// [`ResourceLocker::try_lock`] bounds that window to the few instructions
+    /// between the close and the unlink.
+    /// [`ResourceLocker::lock`] would make it a certainty, because a blocking
+    /// waiter is already parked on the doomed inode when the unlink lands, and
+    /// is refused for that reason.
+    remove_on_drop: bool,
+}
+
+impl FsResourceLocker {
+    /// A locker placing its lock files in `dir` (created on demand).
+    pub fn new(dir: impl Into<Utf8PathBuf>) -> Self {
+        Self {
+            dir: dir.into(),
+            remove_on_drop: false,
+        }
+    }
+
+    /// Remove lock files when their guard drops.
+    ///
+    /// Restricts the locker to [`ResourceLocker::try_lock`]:
+    /// [`ResourceLocker::lock`] returns an error, because a blocking waiter
+    /// parks on the inode a concurrent drop is about to unlink and would end up
+    /// holding it alongside whoever locks the recreated path.
+    #[must_use]
+    pub fn with_remove_on_drop(mut self) -> Self {
+        self.remove_on_drop = true;
+        self
+    }
+
+    fn lock_path(&self, resource: &str) -> Utf8PathBuf {
+        self.dir.join(format!("{resource}.lock"))
+    }
+
+    /// Open (or create) the lock file for `resource`.
+    fn open(&self, resource: &str) -> Result<(File, Utf8PathBuf), LockError> {
+        let path = self.lock_path(resource);
+        std::fs::create_dir_all(&self.dir).map_err(|e| LockError::new(resource, e))?;
+
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .read(true)
+            .open(&path)
+            .map_err(|e| LockError::new(resource, e))?;
+
+        Ok((file, path))
+    }
+
+    fn guard(&self, file: File, path: Utf8PathBuf, info: Option<&str>) -> Box<dyn ResourceGuard> {
+        let mut guard = FsResourceGuard {
+            file: Some(file),
+            path,
+            remove_on_drop: self.remove_on_drop,
+        };
+
+        // Holder info is purely diagnostic; failing to record it must not fail
+        // the acquisition. `None` truncates, so a file left behind by an
+        // earlier holder never reports that holder's info as this one's.
+        let _err = guard.write_info(info.unwrap_or(""));
+
+        Box::new(guard)
+    }
+}
+
+impl ResourceLocker for FsResourceLocker {
+    fn try_lock(
+        &self,
+        resource: &str,
+        info: Option<&str>,
+    ) -> Result<Option<Box<dyn ResourceGuard>>, LockError> {
+        let (file, path) = self.open(resource)?;
+
+        if !try_exclusive_lock(&file) {
+            return Ok(None);
+        }
+
+        Ok(Some(self.guard(file, path, info)))
+    }
+
+    fn lock(
+        &self,
+        resource: &str,
+        info: Option<&str>,
+    ) -> Result<Box<dyn ResourceGuard>, LockError> {
+        // Refused before the file is created: a blocking waiter parks on the
+        // inode a concurrent drop is about to unlink, and would hold it
+        // alongside whoever locks the recreated path.
+        if self.remove_on_drop {
+            return Err(LockError::new(
+                resource,
+                io::Error::other("blocking lock is unavailable with remove_on_drop"),
+            ));
+        }
+
+        let (file, path) = self.open(resource)?;
+
+        if !exclusive_lock(&file) {
+            return Err(LockError::new(resource, io::Error::last_os_error()));
+        }
+
+        Ok(self.guard(file, path, info))
+    }
+
+    fn is_held(&self, resource: &str) -> bool {
+        let Ok(file) = File::open(self.lock_path(resource)) else {
+            return false;
+        };
+
+        // Acquiring the probe lock proves nobody holds it; the probe's own
+        // lock releases when `file` drops, and the file is left in place.
+        !try_exclusive_lock(&file)
+    }
+
+    fn holder_info(&self, resource: &str) -> Option<String> {
+        let mut file = File::open(self.lock_path(resource)).ok()?;
+        let mut buf = String::new();
+        file.read_to_string(&mut buf).ok()?;
+
+        (!buf.is_empty()).then_some(buf)
+    }
+}
+
+/// A held file lock.
+///
+/// The OS lock is held as long as the `File` is open.
+#[derive(Debug)]
+struct FsResourceGuard {
+    file: Option<File>,
+    path: Utf8PathBuf,
+    remove_on_drop: bool,
+}
+
+impl FsResourceGuard {
+    /// Record holder info in the lock file (best-effort).
+    fn write_info(&mut self, info: &str) -> io::Result<()> {
+        let Some(file) = self.file.as_mut() else {
+            return Ok(());
+        };
+
+        file.set_len(0)?;
+        file.seek(io::SeekFrom::Start(0))?;
+        file.write_all(info.as_bytes())?;
+        file.flush()
+    }
+}
+
+impl Drop for FsResourceGuard {
+    fn drop(&mut self) {
+        // Drop the file handle first to release the OS lock.
+        self.file.take();
+
+        if self.remove_on_drop {
+            let _err = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+impl ResourceGuard for FsResourceGuard {}
+
+/// In-process locking backed by a mutex-guarded map.
+///
+/// Blocking acquisitions wait on a condition variable notified by guard drops.
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryResourceLocker {
+    state: Arc<LockState>,
+}
+
+#[derive(Debug, Default)]
+struct LockState {
+    held: Mutex<HashMap<String, Option<String>>>,
+    released: Condvar,
+}
+
+impl InMemoryResourceLocker {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn guard(&self, resource: &str) -> Box<dyn ResourceGuard> {
+        Box::new(InMemoryResourceGuard {
+            resource: resource.to_owned(),
+            state: Arc::clone(&self.state),
+        })
+    }
+}
+
+impl ResourceLocker for InMemoryResourceLocker {
+    fn try_lock(
+        &self,
+        resource: &str,
+        info: Option<&str>,
+    ) -> Result<Option<Box<dyn ResourceGuard>>, LockError> {
+        let mut held = self.state.held.lock().expect("poisoned");
+        if held.contains_key(resource) {
+            return Ok(None);
+        }
+
+        held.insert(resource.to_owned(), info.map(str::to_owned));
+        drop(held);
+
+        Ok(Some(self.guard(resource)))
+    }
+
+    fn lock(
+        &self,
+        resource: &str,
+        info: Option<&str>,
+    ) -> Result<Box<dyn ResourceGuard>, LockError> {
+        let mut held = self.state.held.lock().expect("poisoned");
+        while held.contains_key(resource) {
+            held = self.state.released.wait(held).expect("poisoned");
+        }
+
+        held.insert(resource.to_owned(), info.map(str::to_owned));
+        drop(held);
+
+        Ok(self.guard(resource))
+    }
+
+    fn is_held(&self, resource: &str) -> bool {
+        self.state
+            .held
+            .lock()
+            .expect("poisoned")
+            .contains_key(resource)
+    }
+
+    fn holder_info(&self, resource: &str) -> Option<String> {
+        self.state
+            .held
+            .lock()
+            .expect("poisoned")
+            .get(resource)
+            .cloned()
+            .flatten()
+    }
+}
+
+/// A held in-process lock.
+/// Removes its entry and wakes blocked waiters on drop.
+#[derive(Debug)]
+struct InMemoryResourceGuard {
+    resource: String,
+    state: Arc<LockState>,
+}
+
+impl Drop for InMemoryResourceGuard {
+    fn drop(&mut self) {
+        self.state
+            .held
+            .lock()
+            .expect("poisoned")
+            .remove(&self.resource);
+        self.state.released.notify_all();
+    }
+}
+
+impl ResourceGuard for InMemoryResourceGuard {}
+
+/// No-op locking: every acquisition succeeds, nothing is ever held.
+///
+/// For flows that deliberately run without cross-process exclusion (e.g.
+/// ephemeral no-persist runs).
+/// Never use it where unserialized mutation can corrupt durable state.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NullResourceLocker;
+
+#[derive(Debug)]
+struct NullResourceGuard;
+
+impl ResourceGuard for NullResourceGuard {}
+
+impl ResourceLocker for NullResourceLocker {
+    fn try_lock(
+        &self,
+        _resource: &str,
+        _info: Option<&str>,
+    ) -> Result<Option<Box<dyn ResourceGuard>>, LockError> {
+        Ok(Some(Box::new(NullResourceGuard)))
+    }
+
+    fn lock(
+        &self,
+        _resource: &str,
+        _info: Option<&str>,
+    ) -> Result<Box<dyn ResourceGuard>, LockError> {
+        Ok(Box::new(NullResourceGuard))
+    }
+
+    fn is_held(&self, _resource: &str) -> bool {
+        false
+    }
+
+    fn holder_info(&self, _resource: &str) -> Option<String> {
+        None
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn try_exclusive_lock(file: &File) -> bool {
+    use std::os::unix::io::AsRawFd;
+
+    // SAFETY: flock is a standard POSIX function. The file descriptor is valid
+    // because we hold a reference to the open File.
+    unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) == 0 }
+}
+
+#[cfg(unix)]
+fn exclusive_lock(file: &File) -> bool {
+    use std::os::unix::io::AsRawFd;
+
+    // SAFETY: see `try_exclusive_lock`.
+    unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) == 0 }
+}
+
+#[cfg(windows)]
+pub(crate) fn try_exclusive_lock(file: &File) -> bool {
+    windows_lock(file, true)
+}
+
+#[cfg(windows)]
+fn exclusive_lock(file: &File) -> bool {
+    windows_lock(file, false)
+}
+
+#[cfg(windows)]
+fn windows_lock(file: &File, fail_immediately: bool) -> bool {
+    use std::os::windows::io::AsRawHandle;
+
+    use windows_sys::Win32::{
+        Storage::FileSystem::{LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, LockFileEx},
+        System::IO::OVERLAPPED,
+    };
+
+    let handle = file.as_raw_handle();
+    let mut overlapped: OVERLAPPED = unsafe { std::mem::zeroed() };
+    let mut flags = LOCKFILE_EXCLUSIVE_LOCK;
+    if fail_immediately {
+        flags |= LOCKFILE_FAIL_IMMEDIATELY;
+    }
+
+    // Lock a single byte at a high offset, far past any holder info written
+    // at offset 0. Windows exclusive byte-range locks prevent ALL other
+    // handles from reading the locked region, so placing the lock away from
+    // the file content lets other handles read the holder info.
+    overlapped.Anonymous.Anonymous.Offset = u32::MAX;
+
+    // SAFETY: handle is valid (from an open File), overlapped is initialized.
+    unsafe { LockFileEx(handle, flags, 0, 1, 0, &mut overlapped) != 0 }
+}
+
+#[cfg(not(any(unix, windows)))]
+pub(crate) fn try_exclusive_lock(_file: &File) -> bool {
+    // No locking support; assume success (best-effort).
+    true
+}
+
+#[cfg(not(any(unix, windows)))]
+fn exclusive_lock(_file: &File) -> bool {
+    true
+}
+
+#[cfg(test)]
+#[path = "resource_lock_tests.rs"]
+mod tests;

--- a/crates/jp_storage/src/resource_lock_tests.rs
+++ b/crates/jp_storage/src/resource_lock_tests.rs
@@ -1,0 +1,164 @@
+use std::time::Duration;
+
+use camino_tempfile::Utf8TempDir;
+use test_log::test;
+
+use super::*;
+
+/// The lockers that must behave identically through the trait.
+fn lockers() -> Vec<(&'static str, Box<dyn ResourceLocker>, Option<Utf8TempDir>)> {
+    let dir = Utf8TempDir::new().unwrap();
+    vec![
+        (
+            "fs",
+            Box::new(FsResourceLocker::new(dir.path().to_owned())),
+            Some(dir),
+        ),
+        ("memory", Box::new(InMemoryResourceLocker::new()), None),
+    ]
+}
+
+#[test]
+fn test_try_lock_excludes_second_holder() {
+    for (name, locker, _dir) in lockers() {
+        let guard = locker.try_lock("res", None).unwrap();
+        assert!(guard.is_some(), "locker: {name}");
+
+        let second = locker.try_lock("res", None).unwrap();
+        assert!(second.is_none(), "locker: {name}");
+
+        // Independent resources are unaffected.
+        let other = locker.try_lock("other", None).unwrap();
+        assert!(other.is_some(), "locker: {name}");
+
+        // Dropping the guard releases the resource.
+        drop(guard);
+        let third = locker.try_lock("res", None).unwrap();
+        assert!(third.is_some(), "locker: {name}");
+    }
+}
+
+#[test]
+fn test_is_held_probe_is_non_destructive() {
+    for (name, locker, _dir) in lockers() {
+        assert!(!locker.is_held("res"), "locker: {name}");
+
+        let guard = locker.try_lock("res", None).unwrap().unwrap();
+        assert!(locker.is_held("res"), "locker: {name}");
+
+        // Probing does not steal or release the lock.
+        assert!(
+            locker.try_lock("res", None).unwrap().is_none(),
+            "locker: {name}"
+        );
+
+        drop(guard);
+        assert!(!locker.is_held("res"), "locker: {name}");
+    }
+}
+
+#[test]
+fn test_holder_info_roundtrip() {
+    for (name, locker, _dir) in lockers() {
+        assert_eq!(locker.holder_info("res"), None, "locker: {name}");
+
+        let guard = locker
+            .try_lock("res", Some(r#"{"pid":42}"#))
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            locker.holder_info("res").as_deref(),
+            Some(r#"{"pid":42}"#),
+            "locker: {name}"
+        );
+
+        // Reacquiring without info clears what the previous holder recorded,
+        // rather than attributing it to the new holder.
+        drop(guard);
+        let _guard = locker.try_lock("res", None).unwrap().unwrap();
+        assert_eq!(locker.holder_info("res"), None, "locker: {name}");
+    }
+}
+
+#[test]
+fn test_blocking_lock_waits_for_release() {
+    for (name, locker, _dir) in lockers() {
+        let guard = locker.lock("res", None).unwrap();
+
+        // A blocked waiter acquires the lock once (and only once) the
+        // holder releases it. The holder releases after a short delay; the
+        // waiter's acquisition succeeding at all proves it waited through
+        // the held period.
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                let _guard = locker.lock("res", None).unwrap();
+                tx.send(()).unwrap();
+            });
+
+            // The waiter must not acquire while the guard is held.
+            assert!(
+                rx.recv_timeout(Duration::from_millis(100)).is_err(),
+                "locker: {name}: waiter acquired a held lock"
+            );
+
+            drop(guard);
+            assert!(
+                rx.recv_timeout(Duration::from_secs(5)).is_ok(),
+                "locker: {name}: waiter never acquired after release"
+            );
+        });
+    }
+}
+
+#[test]
+fn test_fs_remove_on_drop() {
+    let dir = Utf8TempDir::new().unwrap();
+    let keeping = FsResourceLocker::new(dir.path().to_owned());
+    let removing = FsResourceLocker::new(dir.path().to_owned()).with_remove_on_drop();
+
+    let guard = keeping.try_lock("kept", None).unwrap().unwrap();
+    drop(guard);
+    assert!(dir.path().join("kept.lock").exists());
+
+    let guard = removing.try_lock("removed", None).unwrap().unwrap();
+    assert!(dir.path().join("removed.lock").exists());
+    drop(guard);
+    assert!(!dir.path().join("removed.lock").exists());
+}
+
+#[test]
+fn test_fs_blocking_lock_refused_when_removing_on_drop() {
+    let dir = Utf8TempDir::new().unwrap();
+    let locker = FsResourceLocker::new(dir.path().to_owned()).with_remove_on_drop();
+
+    // Refused outright, and before the lock file is created: a blocking waiter
+    // would park on an inode a concurrent drop is about to unlink.
+    let error = locker.lock("res", None).unwrap_err();
+    assert_eq!(error.resource, "res");
+    assert!(!dir.path().join("res.lock").exists());
+}
+
+#[test]
+fn test_fs_leftover_lock_file_does_not_block() {
+    // A lock file left behind by a killed process (OS lock already
+    // released) must not block the next acquisition.
+    let dir = Utf8TempDir::new().unwrap();
+    std::fs::write(dir.path().join("res.lock"), "stale").unwrap();
+
+    let locker = FsResourceLocker::new(dir.path().to_owned());
+    assert!(!locker.is_held("res"));
+    assert!(locker.try_lock("res", None).unwrap().is_some());
+}
+
+#[test]
+fn test_null_locker_never_holds() {
+    let locker = NullResourceLocker;
+
+    let _guard = locker.try_lock("res", Some("info")).unwrap().unwrap();
+    // Even while a guard exists, nothing registers as held: the null
+    // locker provides no exclusion at all.
+    assert!(!locker.is_held("res"));
+    assert_eq!(locker.holder_info("res"), None);
+    assert!(locker.try_lock("res", None).unwrap().is_some());
+}

--- a/docs/ticket/0gnv6ez-unlinking-a-conversation-lock-file-on-release-can-leave-two.md
+++ b/docs/ticket/0gnv6ez-unlinking-a-conversation-lock-file-on-release-can-leave-two.md
@@ -1,0 +1,89 @@
+# Unlinking a conversation lock file on release can leave two holders
+
+- **Status**: Todo
+- **Kind**: Bug
+- **Authors**: jp
+- **Date**: 2026-09-10
+- **Label**: domain=storage
+- **Label**: package=jp_storage
+- **Label**: package=jp_workspace
+- **Label**: type=bug
+
+Conversation lock files are unlinked while other processes may be acquiring
+them, so two processes can hold write exclusion on the same conversation at the
+same time.
+The exclusion is advisory on an *inode*, and the pathname is what every
+acquisition resolves; unlinking separates the two.
+
+## The interleaving
+
+`FsResourceGuard::drop` (`crates/jp_storage/src/resource_lock.rs`) closes the
+file handle, releasing the `flock`, and then unlinks the path:
+
+1. A closes its handle.
+   The OS lock on inode I is released; the path still resolves to I.
+2. B opens the path, gets I, and takes the lock.
+   B is a legitimate holder.
+3. A unlinks the path.
+   B now holds a lock on an unlinked inode, and the presence marker for the
+   conversation is gone.
+4. C opens the path, creating inode J, and takes the lock.
+
+B and C both report success and can write the same conversation with no
+exclusion between them.
+`is_conversation_locked` also reports the conversation unlocked while B holds
+it, because `lock_file_path` decides on `exists()`.
+
+The window in step 2 is the few instructions between the close and the unlink,
+so `try_lock` narrows it but does not close it.
+A *blocking* acquisition turns it into a certainty, which is why
+`FsResourceLocker::lock` refuses to run with `remove_on_drop` set.
+
+## Two unlink sites, not one
+
+- Guard drop, above.
+  `try_lock_conversation` opts into it with `with_remove_on_drop`, because the
+  lock file doubles as the presence marker that `is_conversation_locked` and the
+  orphan scan read.
+- `Workspace::cleanup_stale_files`
+  (`crates/jp_workspace/src/session_mapping.rs`) unlinks every path returned by
+  `Storage::list_orphaned_lock_files`, and runs at the end of every invocation.
+  The orphan test is itself an open-then-`flock`, so it can unlink a file
+  another process locked between the two.
+
+## Plausible input
+
+Two `jp` invocations against the same conversation, one releasing as the other
+acquires — `jp query` finishing while a second `jp query` or `jp c rm` waits on
+the same id.
+Contention is ordinary; landing inside the close/unlink window is rare.
+The damage neither stays put nor shows itself: two unserialized writers against
+a conversation's durable state, reported as success by both.
+
+## Direction
+
+Make conversation lock files stable inodes, never unlinked while acquisition can
+run, and find another representation for the presence marker that
+`is_conversation_locked` and the orphan scan depend on.
+That means:
+
+- Drop `with_remove_on_drop` from `try_lock_conversation`, and with it the
+  option on `FsResourceLocker` if nothing else wants it.
+- Decide what "no lock file exists" means once files persist —
+  `Storage::lock_file_path` currently signals the write location through
+  `Err(path)` on the strength of `exists()`.
+- Stop `cleanup_stale_files` from unlinking lock files, or bound when it may.
+
+RFD 106 designs the ID allocator lock around exactly this property ("The lock
+file is never unlinked, so it is a stable inode and the release-then-unlink
+hazard does not apply to it") and scopes the conversation-lock case out ("that
+is a pre-existing bug, out of scope here").
+This ticket is that case.
+
+## Testing
+
+A regression test has to control the interleaving rather than run the steps in
+sequence — the existing `test_fs_remove_on_drop` acquires and drops in order
+and never overlaps.
+Something that holds the guard's drop between the close and the unlink while a
+second acquisition runs, or three coordinated processes.


### PR DESCRIPTION
Conversation locks were the only cross-process locking in the tree, and
their mechanics were welded to their policy: OS advisory locks, guard
lifetimes, holder-info serialization, and the conversation-id naming all
lived in one module. A second consumer could not reuse the locking
without also inheriting conversations.

`ResourceLocker` is that mechanism on its own: acquire a named resource,
release on drop, probe whether it is held, and read opaque holder info.
Three implementations back it. The filesystem locker keeps one
`<resource>.lock` per resource under a directory it owns, held through
`flock` or `LockFileEx`. The in-memory locker serializes within a
process, and blocking waiters park on a condition variable. The null
locker grants everything, for flows that deliberately run without
exclusion.

`lock.rs` becomes the domain layer above it: conversation ids as
resource names, `LockInfo` as the holder diagnostics, and the
user-versus-workspace placement policy. The in-memory storage backend
drops its bespoke lock set and guard in favour of the shared locker, so
both backends now produce guards the same way.

One mechanic is worth naming, because it is a trap. Removing the lock
file on guard drop is never fully sound: the OS lock releases when the
handle closes, so a contender that opens the path before the unlink
locks an inode about to disappear while the next acquisition locks a
fresh file at the same path. A non-blocking acquisition bounds that to
the close/unlink window; a blocking waiter is already parked on the
doomed inode when the unlink lands, so `lock` refuses to run with
`with_remove_on_drop`. Conversation lock files double as presence
markers for the orphan scan, so they take that option and inherit the
residual window; RFD 106 names it the release-then-unlink defect and
T-0gnv6ez tracks the fix.