### PR TITLE
feat(llm, cli, anthropic): Add Anthropic subscription auth with fallback

### DIFF
--- a/.config/supply-chain/audits.toml
+++ b/.config/supply-chain/audits.toml
@@ -51,6 +51,16 @@ who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 version = "0.1.3"
 
+[[audits.deadpool]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-run"
+version = "0.12.3"
+
+[[audits.deadpool-runtime]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-run"
+version = "0.1.4"
+
 [[audits.dtoa-short]]
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
@@ -81,10 +91,25 @@ who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 version = "0.1.5"
 
+[[audits.getrandom]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.2 -> 0.4.3"
+
 [[audits.hashlink]]
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 delta = "0.11.0 -> 0.12.1"
+
+[[audits.hermit-abi]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.2 -> 0.3.3"
+
+[[audits.hermit-abi]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-run"
+delta = "0.3.2 -> 0.3.3"
 
 [[audits.htmd]]
 who = "Jean Mertz <git@jeanmertz.com>"
@@ -195,6 +220,11 @@ delta = "0.38.4 -> 0.39.2"
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 delta = "0.39.2 -> 0.41.0"
+
+[[audits.r-efi]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-deploy"
+delta = "5.3.0 -> 6.0.0"
 
 [[audits.ra-ap-rustc_lexer]]
 who = "Jean Mertz <git@jeanmertz.com>"
@@ -380,6 +410,11 @@ version = "1.22.0"
 who = "Jean Mertz <git@jeanmertz.com>"
 criteria = "safe-to-deploy"
 version = "0.2.3"
+
+[[audits.wiremock]]
+who = "Jean Mertz <git@jeanmertz.com>"
+criteria = "safe-to-run"
+version = "0.6.5"
 
 [[audits.xml5ever]]
 who = "Jean Mertz <git@jeanmertz.com>"

--- a/.config/supply-chain/imports.lock
+++ b/.config/supply-chain/imports.lock
@@ -1425,6 +1425,12 @@ who = "Pat Hickey <pat@moreproductive.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.28 -> 0.3.31"
 
+[[audits.bytecode-alliance.audits.getrandom]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.1 -> 0.4.2"
+notes = "Nothing awry in this update, standard updates for some platforms and other misc things."
+
 [[audits.bytecode-alliance.audits.gimli]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -1442,6 +1448,17 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.4.1 -> 0.5.0"
 notes = "Minor changes for a `no_std` upgrade but otherwise everything looks as expected."
+
+[[audits.bytecode-alliance.audits.hermit-abi]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+version = "0.1.19"
+
+[[audits.bytecode-alliance.audits.hermit-abi]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.9 -> 0.5.2"
+notes = "API updates and looks like libc, nothing new here."
 
 [[audits.bytecode-alliance.audits.http-body]]
 who = "Pat Hickey <phickey@fastly.com>"
@@ -2153,6 +2170,18 @@ version = "0.2.19"
 notes = "Contains a single line of float-to-int unsafe with decent safety comments"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.num_cpus]]
+who = "Android Legacy"
+criteria = "safe-to-run"
+version = "1.13.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.num_cpus]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+delta = "1.13.0 -> 1.16.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
 [[audits.google.audits.pin-project-lite]]
 who = "David Koloski <dkoloski@google.com>"
 criteria = "safe-to-deploy"
@@ -2710,6 +2739,21 @@ delta = "1.0.0 -> 1.0.1"
 who = "J.C. Jones <jc@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "1.0.1 -> 1.0.3"
+
+[[audits.isrg.audits.getrandom]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.4 -> 0.4.0"
+
+[[audits.isrg.audits.getrandom]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.4.1"
+
+[[audits.isrg.audits.hermit-abi]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-run"
+delta = "0.2.6 -> 0.3.1"
 
 [[audits.isrg.audits.libbz2-rs-sys]]
 who = "Ameer Ghani <inahga@divviup.org>"
@@ -3356,6 +3400,12 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.10.0 -> 0.11.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hermit-abi]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.19 -> 0.2.6"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.iana-time-zone]]
@@ -4161,11 +4211,29 @@ criteria = "safe-to-deploy"
 delta = "0.3.2 -> 0.3.3"
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
+[[audits.zcash.audits.hermit-abi]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.3.1 -> 0.3.2"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.hermit-abi]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.3 -> 0.3.9"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
 [[audits.zcash.audits.http-body]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "1.0.0 -> 1.0.1"
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.num_cpus]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.16.0 -> 1.17.0"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.quinn-udp]]
 who = "Jack Grigg <jack@electriccoin.co>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2468,7 +2468,6 @@ dependencies = [
 name = "jp_credentials"
 version = "0.1.0"
 dependencies = [
- "assert_matches",
  "camino",
  "camino-tempfile",
  "chrono",
@@ -2479,7 +2478,6 @@ dependencies = [
  "serde_json",
  "test-log",
  "thiserror 2.0.20",
- "tracing",
 ]
 
 [[package]]
@@ -4134,7 +4132,6 @@ dependencies = [
 name = "schematic"
 version = "0.19.4"
 dependencies = [
- "convert_case 0.11.0",
  "indexmap",
  "json-strip-comments",
  "schematic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,19 +171,23 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-anthropic"
 version = "0.6.0"
-source = "git+https://github.com/JeanMertz/async-anthropic#8c12222078fe90f9e8f15fb078790a6d86ea42c9"
 dependencies = [
+ "async-trait",
  "backon",
  "derive_builder",
+ "eventsource-stream",
+ "futures",
  "reqwest",
- "reqwest-eventsource",
  "secrecy",
  "serde",
  "serde_json",
+ "test-log",
  "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tracing",
+ "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -949,6 +953,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,9 +1506,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -1638,6 +1671,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "htmd"
@@ -2299,6 +2338,7 @@ dependencies = [
  "comfy-table",
  "comrak",
  "crossterm",
+ "datetime_literal",
  "dhat",
  "duct",
  "fancy-regex 0.19.0",
@@ -2319,6 +2359,7 @@ dependencies = [
  "jp_attachment_mcp_resources",
  "jp_config",
  "jp_conversation",
+ "jp_credentials",
  "jp_editor",
  "jp_id",
  "jp_inquire",
@@ -2424,6 +2465,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "jp_credentials"
+version = "0.1.0"
+dependencies = [
+ "assert_matches",
+ "camino",
+ "camino-tempfile",
+ "chrono",
+ "datetime_literal",
+ "jp_config",
+ "jp_storage",
+ "serde",
+ "serde_json",
+ "test-log",
+ "thiserror 2.0.20",
+ "tracing",
+]
+
+[[package]]
 name = "jp_editor"
 version = "0.1.0"
 dependencies = [
@@ -2513,6 +2572,7 @@ dependencies = [
  "base64",
  "camino",
  "chrono",
+ "datetime_literal",
  "eventsource-stream",
  "futures",
  "gemini_client_rs",
@@ -2523,8 +2583,10 @@ dependencies = [
  "jp_attachment",
  "jp_config",
  "jp_conversation",
+ "jp_credentials",
  "jp_mcp",
  "jp_openrouter",
+ "jp_storage",
  "jp_test",
  "jp_tool",
  "minijinja",
@@ -2537,12 +2599,14 @@ dependencies = [
  "reqwest-eventsource",
  "serde",
  "serde_json",
+ "sha2",
  "test-log",
  "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3098,6 +3162,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3550,6 +3624,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ra-ap-rustc_lexer"
@@ -5306,6 +5386,7 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -5863,6 +5944,29 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ jp_attachment_internal = { path = "crates/jp_attachment_internal" }
 jp_attachment_mcp_resources = { path = "crates/jp_attachment_mcp_resources" }
 jp_config = { path = "crates/jp_config" }
 jp_conversation = { path = "crates/jp_conversation" }
+jp_credentials = { path = "crates/jp_credentials" }
 jp_editor = { path = "crates/jp_editor" }
 jp_github = { path = "crates/jp_github" }
 jp_id = { path = "crates/jp_id" }
@@ -41,6 +42,7 @@ jp_tool = { path = "crates/jp_tool" }
 jp_workspace = { path = "crates/jp_workspace" }
 
 comfort = { path = "crates/contrib/comfort" }
+async-anthropic = { path = "crates/contrib/async-anthropic" }
 grizzly = { path = "crates/contrib/grizzly", default-features = false }
 schematic = { path = "crates/contrib/schematic", default-features = false }
 ticket = { path = "crates/internal/ticket" }
@@ -49,11 +51,10 @@ xct2cli = { path = "crates/contrib/xct2cli" }
 addr2line = { version = "0.26" }
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng", "std", "serde"] }
 assert_matches = { version = "1", default-features = false }
-async-anthropic = { git = "https://github.com/JeanMertz/async-anthropic", default-features = false }
 async-stream = { version = "0.3", default-features = false }
 async-trait = { version = "0.1", default-features = false }
 axum = { version = "0.8", default-features = false }
-backon = { git = "https://github.com/JeanMertz/backon", default-features = false } # <https://github.com/JeanMertz/async-anthropic/blob/5edba470a3aa912de2c9e815bdd71dfc20fdf54f/Cargo.toml#L23-L31>
+backon = { git = "https://github.com/JeanMertz/backon", default-features = false } # fork: adds `ExponentialBuilder` getters used by `crates/contrib/async-anthropic`
 base64 = { version = "0.22", default-features = false }
 camino = { version = "1", default-features = false }
 camino-tempfile = { version = "1", default-features = false }
@@ -69,6 +70,7 @@ crossbeam-channel = { version = "0.5", default-features = false }
 crossterm = { version = "0.29", default-features = false }
 darling = { version = "0.23", default-features = false }
 datetime_literal = { version = "0.1", default-features = false }
+derive_builder = { version = "0.20", default-features = false }
 dhat = { version = "0.3", default-features = false }
 directories = { version = "6", default-features = false }
 duct = { version = "1", default-features = false }
@@ -129,6 +131,7 @@ rustc-demangle = { version = "0.1", default-features = false }
 saphyr = { git = "https://github.com/JeanMertz/saphyr", branch = "jean/fix-multinewline-endings", default-features = false } # <https://github.com/saphyr-rs/saphyr/pull/90>
 schemars = { version = "1.0.0-alpha.17", default-features = false }
 scraper = { version = "0.25", default-features = false }
+secrecy = { version = "0.10", default-features = false }
 semver = { version = "1", default-features = false }
 serde = { version = "1", default-features = false }
 serde-content = { version = "0.1", default-features = false }
@@ -162,9 +165,11 @@ unicode-segmentation = { version = "1", default-features = false }
 unicode-width = { version = "0.2", default-features = false }
 url = { version = "2", default-features = false }
 vt100 = { version = "0.16", default-features = false }
+uuid = { version = "1", default-features = false }
 vte = { version = "0.14", default-features = false }
 which = { version = "8", default-features = false }
 windows-sys = { version = "0.61", default-features = false }
+wiremock = { version = "0.6", default-features = false }
 zip = { version = "8", default-features = false }
 
 [patch.crates-io]

--- a/crates/contrib/async-anthropic/Cargo.toml
+++ b/crates/contrib/async-anthropic/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+description = "Anthropic Rust Client."
+edition = "2024"
+license = "MIT"
+name = "async-anthropic"
+publish = false
+version = "0.6.0"
+
+[dependencies]
+backon = { workspace = true, features = ["tokio", "tokio-sleep"] }
+derive_builder = { workspace = true, features = ["std"] }
+eventsource-stream = { workspace = true }
+futures = { workspace = true }
+reqwest = { workspace = true, features = ["json", "stream"] }
+secrecy = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tracing = { workspace = true, features = ["attributes"] }
+uuid = { workspace = true, features = ["v4"] }
+
+[dev-dependencies]
+async-trait = { workspace = true }
+test-log = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+wiremock = { workspace = true }
+
+[lints]
+workspace = true
+
+[lib]
+doctest = false

--- a/crates/contrib/async-anthropic/LICENSE
+++ b/crates/contrib/async-anthropic/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Kayode Ojo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/contrib/async-anthropic/README.md
+++ b/crates/contrib/async-anthropic/README.md
@@ -1,9 +1,16 @@
 > [!NOTE]
-> Originally the client was forked from [`anthropic-sdk`](https://github.com/Mixpeal/anthropic-sdk) which no longer seems to be maintained. There might still be some references, even though the code has been rewritten from scratch.
+> Originally the client was forked from [`anthropic-sdk`] which no longer seems
+> to be maintained.
+> There might still be some references, even though the code has been rewritten
+> from scratch.
 
 ## async-anthropic
 
-A client for the anthropic messages api, written in Rust. There are plenty of clients on crates.io, but we figured we needed another one. Specifically, a straightforward builder api, robust error handling, and room to grow. Tests are also nice.
+A client for the anthropic messages api, written in Rust.
+There are plenty of clients on crates.io, but we figured we needed another one.
+Specifically, a straightforward builder api, robust error handling, and room to
+grow.
+Tests are also nice.
 
 ### Features
 
@@ -11,7 +18,7 @@ A client for the anthropic messages api, written in Rust. There are plenty of cl
 - [x] Models API
 - [x] Tool use
 - [x] Support all API parameters
-- [x] Automatic [backoff](https://crates.io/crates/backoff)
+- [x] Automatic [backoff]
 - [x] Tracing
 - [x] Streaming
 - [ ] Non-text messages
@@ -52,4 +59,10 @@ See `/examples` for more examples.
 
 ### Contributing
 
-Contributions are welcome! This project was quickly drafted together to add anthropic support to other bosun projects, and several features are missing. If you'd like to contribute, please open an issue or a pull request.
+Contributions are welcome!
+This project was quickly drafted together to add anthropic support to other
+bosun projects, and several features are missing.
+If you'd like to contribute, please open an issue or a pull request.
+
+[`anthropic-sdk`]: https://github.com/Mixpeal/anthropic-sdk
+[backoff]: https://crates.io/crates/backoff

--- a/crates/contrib/async-anthropic/README.md
+++ b/crates/contrib/async-anthropic/README.md
@@ -1,0 +1,55 @@
+> [!NOTE]
+> Originally the client was forked from [`anthropic-sdk`](https://github.com/Mixpeal/anthropic-sdk) which no longer seems to be maintained. There might still be some references, even though the code has been rewritten from scratch.
+
+## async-anthropic
+
+A client for the anthropic messages api, written in Rust. There are plenty of clients on crates.io, but we figured we needed another one. Specifically, a straightforward builder api, robust error handling, and room to grow. Tests are also nice.
+
+### Features
+
+- [x] Messages API
+- [x] Models API
+- [x] Tool use
+- [x] Support all API parameters
+- [x] Automatic [backoff](https://crates.io/crates/backoff)
+- [x] Tracing
+- [x] Streaming
+- [ ] Non-text messages
+
+### Installation
+
+Add the project with `cargo`:
+
+```bash
+cargo add async-anthropic
+```
+
+### Usage
+
+#### Basic Usage
+
+For non-streaming responses, you can use the SDK as follows:
+
+```rust
+    let client = Client::default();
+
+    let request = CreateMessagesRequestBuilder::default()
+        .model("claude-3-5-sonnet-20241022")
+        .messages(vec![MessageBuilder::default()
+            .role(MessageRole::User)
+            .content("Hello claude!!")
+            .build()
+            .unwrap()])
+        .build()
+        .unwrap();
+
+    let response = client.messages().create(request).await?;
+
+    println!("{:?}", response);
+```
+
+See `/examples` for more examples.
+
+### Contributing
+
+Contributions are welcome! This project was quickly drafted together to add anthropic support to other bosun projects, and several features are missing. If you'd like to contribute, please open an issue or a pull request.

--- a/crates/contrib/async-anthropic/src/bearer.rs
+++ b/crates/contrib/async-anthropic/src/bearer.rs
@@ -1,0 +1,143 @@
+//! Bearer-token (OAuth) authentication mode.
+//!
+//! Anthropic's subscription plans authenticate with an OAuth bearer token
+//! instead of an API key, and only accept requests that carry the Claude Code
+//! client fingerprint alongside the token.
+//! This module holds that fingerprint as named constants and assembles the
+//! request headers for bearer mode.
+//!
+//! The constants mirror the reference implementation pinned by RFD 090:
+//! <https://github.com/can1357/oh-my-pi/blob/75bdb20212871221406e119745136edcb2197653/packages/ai/src/providers/anthropic.ts>
+//!
+//! How much of the fingerprint Anthropic actually enforces is an open
+//! measurement (RFD 090, Phase 1); trim or extend these constants once that
+//! measurement lands.
+
+use reqwest::header::{HeaderMap, HeaderValue};
+
+/// Beta identifier that switches the API into OAuth mode.
+///
+/// Required on every bearer-token request.
+pub const OAUTH_BETA: &str = "oauth-2025-04-20";
+
+/// Claude Code beta set sent alongside [`OAUTH_BETA`] on bearer requests.
+pub const CLAUDE_CODE_BETAS: &[&str] = &[
+    "claude-code-20250219",
+    "interleaved-thinking-2025-05-14",
+    "context-management-2025-06-27",
+];
+
+/// Claude Code CLI version impersonated by the fingerprint.
+pub const CLAUDE_CODE_VERSION: &str = "2.1.165";
+
+/// Claude Agent SDK version embedded in the user agent.
+pub const CLAUDE_AGENT_SDK_VERSION: &str = "0.3.165";
+
+/// Claude client version sent as `anthropic-client-version`.
+pub const CLAUDE_CLIENT_VERSION: &str = "1.11187.4";
+
+/// Client identity: `x-app` header value.
+pub const X_APP: &str = "cli";
+
+/// Client identity: `anthropic-client-platform` header value.
+pub const CLIENT_PLATFORM: &str = "desktop_app";
+
+/// Stainless SDK fingerprint headers with static values.
+///
+/// The Anthropic TypeScript SDK stamps every request with `X-Stainless-*`
+/// telemetry; Claude Code inherits them, so they are part of the observable
+/// fingerprint.
+pub const STAINLESS_HEADERS: &[(&str, &str)] = &[
+    ("x-stainless-retry-count", "0"),
+    ("x-stainless-runtime-version", "v24.3.0"),
+    ("x-stainless-package-version", "0.94.0"),
+    ("x-stainless-runtime", "node"),
+    ("x-stainless-lang", "js"),
+    ("x-stainless-timeout", "900"),
+];
+
+/// Build the Claude Code user agent string.
+#[must_use]
+pub fn user_agent() -> String {
+    format!(
+        "claude-cli/{CLAUDE_CODE_VERSION} (external, local-agent, \
+         agent-sdk/{CLAUDE_AGENT_SDK_VERSION})"
+    )
+}
+
+/// Map the compile-time OS to the `X-Stainless-OS` header value.
+#[must_use]
+pub fn stainless_os() -> String {
+    match std::env::consts::OS {
+        "macos" => "MacOS".to_owned(),
+        "windows" => "Windows".to_owned(),
+        "linux" => "Linux".to_owned(),
+        "freebsd" => "FreeBSD".to_owned(),
+        other => format!("Other::{other}"),
+    }
+}
+
+/// Map the compile-time architecture to the `X-Stainless-Arch` header value.
+#[must_use]
+pub fn stainless_arch() -> String {
+    match std::env::consts::ARCH {
+        "x86_64" => "x64".to_owned(),
+        "aarch64" => "arm64".to_owned(),
+        "x86" => "x86".to_owned(),
+        other => format!("other::{other}"),
+    }
+}
+
+/// Merge the fingerprint betas with user-configured extras.
+///
+/// Fingerprint betas come first and cannot be removed; extras are appended in
+/// order, with duplicates (of the fingerprint set or each other) dropped.
+#[must_use]
+pub fn merge_betas(extra: Option<&str>) -> String {
+    let mut merged: Vec<&str> = Vec::new();
+    let base = std::iter::once(OAUTH_BETA).chain(CLAUDE_CODE_BETAS.iter().copied());
+    let extras = extra
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    for beta in base.chain(extras) {
+        if !merged.contains(&beta) {
+            merged.push(beta);
+        }
+    }
+
+    merged.join(",")
+}
+
+/// Assemble the bearer-mode request headers.
+///
+/// Emits `Authorization: Bearer <token>` (never `x-api-key`), the merged
+/// `anthropic-beta` set, and the Claude Code client fingerprint, including a
+/// fresh `x-client-request-id` per call.
+pub(crate) fn headers(token: &str, version: &str, extra_betas: Option<&str>) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    let mut insert = |name: &'static str, value: String| {
+        if let Ok(value) = HeaderValue::from_str(&value) {
+            headers.insert(name, value);
+        }
+    };
+
+    insert("authorization", format!("Bearer {token}"));
+    insert("anthropic-version", version.to_owned());
+    insert("anthropic-beta", merge_betas(extra_betas));
+    insert("anthropic-dangerous-direct-browser-access", "true".into());
+    insert("anthropic-client-platform", CLIENT_PLATFORM.to_owned());
+    insert("anthropic-client-version", CLAUDE_CLIENT_VERSION.to_owned());
+    insert("user-agent", user_agent());
+    insert("x-app", X_APP.to_owned());
+    insert("x-client-request-id", uuid::Uuid::new_v4().to_string());
+    insert("x-stainless-os", stainless_os());
+    insert("x-stainless-arch", stainless_arch());
+    for (name, value) in STAINLESS_HEADERS {
+        insert(name, (*value).to_owned());
+    }
+
+    headers
+}

--- a/crates/contrib/async-anthropic/src/client.rs
+++ b/crates/contrib/async-anthropic/src/client.rs
@@ -1,0 +1,460 @@
+use std::{pin::Pin, time::Duration};
+
+use backon::{ExponentialBuilder, Retryable as _};
+use derive_builder::Builder;
+use eventsource_stream::Eventsource as _;
+use futures::StreamExt as _;
+use reqwest::StatusCode;
+use secrecy::ExposeSecret;
+use serde::{Serialize, de::DeserializeOwned};
+use tokio_stream::Stream;
+
+use crate::{
+    bearer,
+    errors::{
+        AnthropicError, ApiError, ApiErrorEnvelope, UnifiedRateLimit, map_deserialization_error,
+    },
+    messages::Messages,
+    models::Models,
+};
+
+const BASE_URL: &str = "https://api.anthropic.com";
+
+/// Main entry point for the Anthropic API
+///
+/// By default will use the `ANTHROPIC_API_KEY` environment variable
+///
+/// # Example
+///
+/// ```no_run
+/// # use async_anthropic::types::*;
+/// # async fn run() {
+/// let client = async_anthropic::Client::default();
+///
+/// let request = CreateMessagesRequestBuilder::default()
+///     .model("claude-3.5-sonnet")
+///     .messages(vec![
+///         MessageBuilder::default()
+///             .role(MessageRole::User)
+///             .content("Hello world!")
+///             .build()
+///             .unwrap(),
+///     ])
+///     .build()
+///     .unwrap();
+///
+/// client.messages().create(request).await.unwrap();
+/// # }
+/// ```
+#[derive(Clone, Debug, Builder)]
+#[builder(setter(into, strip_option))]
+pub struct Client {
+    #[builder(default)]
+    http_client: reqwest::Client,
+    #[builder(default)]
+    base_url: String,
+    #[builder(default = default_api_key())]
+    api_key: secrecy::SecretString,
+    /// OAuth bearer token for subscription (Claude Pro/Max) accounts.
+    ///
+    /// When set, requests authenticate with `Authorization: Bearer <token>` and
+    /// carry the Claude Code request fingerprint (see [`bearer`]); `api_key` is
+    /// ignored and `x-api-key` is never sent.
+    /// User-configured `beta` values merge after the fingerprint's own beta set
+    /// and can neither remove nor duplicate its entries.
+    #[builder(default)]
+    auth_token: Option<secrecy::SecretString>,
+    #[builder(default)]
+    version: String,
+    #[builder(default)]
+    beta: Option<String>,
+    #[builder(default)]
+    backoff: ExponentialBuilder,
+}
+
+impl Default for Client {
+    fn default() -> Self {
+        // Load backoff settings from configuration
+        let backoff = ExponentialBuilder::default()
+            .with_min_delay(Duration::from_secs(15))
+            .with_factor(2.0)
+            .with_jitter()
+            .with_max_delay(Duration::from_mins(2));
+
+        Self {
+            http_client: reqwest::Client::new(),
+            api_key: default_api_key(), // Default env?
+            auth_token: None,
+            version: "2023-06-01".to_string(),
+            beta: None,
+            base_url: BASE_URL.to_string(),
+            backoff,
+        }
+    }
+}
+
+fn default_api_key() -> secrecy::SecretString {
+    if cfg!(test) {
+        return "test".into();
+    }
+    std::env::var("ANTHROPIC_API_KEY")
+        .unwrap_or_else(|_| {
+            tracing::warn!("Default Anthropic client initialized without api key");
+            String::new()
+        })
+        .into()
+}
+
+impl Client {
+    /// Build a new client from an API key
+    pub fn from_api_key(api_key: impl Into<secrecy::SecretString>) -> Self {
+        Self {
+            api_key: api_key.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Create a new client builder
+    #[must_use]
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder::default()
+    }
+
+    /// Set a custom backoff strategy
+    #[must_use]
+    pub fn with_backoff(mut self, backoff: ExponentialBuilder) -> Self {
+        self.backoff = backoff;
+        self
+    }
+
+    /// Call the messages api
+    #[must_use]
+    pub fn messages(&self) -> Messages<'_> {
+        Messages::new(self)
+    }
+
+    #[must_use]
+    pub fn models(&self) -> Models<'_> {
+        Models::new(self)
+    }
+
+    /// Build the request headers, folding `betas` into the client's own set.
+    ///
+    /// `betas` are the extras a single request asked for; they join the
+    /// client-wide `beta` value in order, without duplicates.
+    fn headers(&self, betas: &[String]) -> reqwest::header::HeaderMap {
+        let mut extras: Vec<&str> = self
+            .beta
+            .iter()
+            .flat_map(|beta| beta.split(','))
+            .map(str::trim)
+            .filter(|beta| !beta.is_empty())
+            .collect();
+
+        for beta in betas {
+            let beta = beta.trim();
+            if !beta.is_empty() && !extras.contains(&beta) {
+                extras.push(beta);
+            }
+        }
+
+        let extras = extras.join(",");
+        let extras = (!extras.is_empty()).then_some(extras);
+
+        if let Some(token) = &self.auth_token {
+            // The fingerprint's own betas lead and can be neither removed nor
+            // duplicated by these; see `bearer::merge_betas`.
+            return bearer::headers(token.expose_secret(), &self.version, extras.as_deref());
+        }
+
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert("x-api-key", self.api_key.expose_secret().parse().unwrap());
+        headers.insert("anthropic-version", self.version.parse().unwrap());
+        if let Some(extras) = extras {
+            headers.insert("anthropic-beta", extras.parse().unwrap());
+        }
+
+        headers
+    }
+
+    fn format_url(&self, path: &str) -> String {
+        format!(
+            "{}/{}",
+            &self.base_url.trim_end_matches('/'),
+            &path.trim_start_matches('/')
+        )
+    }
+
+    pub async fn get<O>(&self, path: &str) -> Result<O, AnthropicError>
+    where
+        O: DeserializeOwned,
+    {
+        let request = || async {
+            let response = self
+                .http_client
+                .get(self.format_url(path))
+                .headers(self.headers(&[]))
+                .send()
+                .await
+                .map_err(AnthropicError::Network)?;
+
+            handle_response(response).await
+        };
+
+        request
+            .retry(self.backoff)
+            .sleep(tokio::time::sleep)
+            // A spent quota is not throttling: waiting cannot help, and the
+            // caller may have another credential that can serve the request
+            // now. Only capacity throttling is retried in place.
+            .when(|e| {
+                matches!(e, AnthropicError::RateLimit { limits, .. } if !limits.is_quota_rejection())
+            })
+            .adjust(|err, dur| match err {
+                AnthropicError::RateLimit { retry_after, .. } => {
+                    retry_after.map(Duration::from_secs).or(dur)
+                }
+                _ => dur,
+            })
+            .await
+    }
+
+    /// Make post request to the API
+    ///
+    /// This includes all headers and error handling
+    pub async fn post<I, O>(
+        &self,
+        path: &str,
+        request: I,
+        betas: &[String],
+    ) -> Result<O, AnthropicError>
+    where
+        I: Serialize,
+        O: DeserializeOwned,
+    {
+        let request = || async {
+            // `headers()` already carries the `anthropic-beta` value.
+            let request = self
+                .http_client
+                .post(self.format_url(path))
+                .headers(self.headers(betas))
+                .json(&request);
+
+            let response = request.send().await.map_err(AnthropicError::Network)?;
+
+            handle_response(response).await
+        };
+
+        request
+            .retry(self.backoff)
+            .sleep(tokio::time::sleep)
+            // A spent quota is not throttling: waiting cannot help, and the
+            // caller may have another credential that can serve the request
+            // now. Only capacity throttling is retried in place.
+            .when(|e| {
+                matches!(e, AnthropicError::RateLimit { limits, .. } if !limits.is_quota_rejection())
+            })
+            .adjust(|err, dur| match err {
+                AnthropicError::RateLimit { retry_after, .. } => {
+                    retry_after.map(Duration::from_secs).or(dur)
+                }
+                _ => dur,
+            })
+            .await
+    }
+
+    /// Open a server-sent-event stream.
+    ///
+    /// Returns the response's quota headers alongside the event stream: the
+    /// unified rate-limit headers ride on every response, including successful
+    /// ones, and are the only place a subscription's usage state is reported.
+    ///
+    /// The stream is not reconnected on failure.
+    /// Anthropic's message endpoint sends no SSE event ids, so a reconnect
+    /// cannot resume: it would issue a fresh completion whose content restarts
+    /// from the beginning.
+    /// Recovery belongs to the caller, which can rebuild the request from
+    /// whatever it already received.
+    pub(crate) async fn post_stream<I, O, const N: usize>(
+        &self,
+        path: &str,
+        request: I,
+        event_types: [&'static str; N],
+        betas: &[String],
+    ) -> Result<StreamResponse<O>, AnthropicError>
+    where
+        I: Serialize,
+        O: DeserializeOwned + Send + 'static,
+    {
+        let response = self
+            .http_client
+            .post(self.format_url(path))
+            .headers(self.headers(betas))
+            .header(reqwest::header::ACCEPT, "text/event-stream")
+            .json(&request)
+            .send()
+            .await
+            .map_err(AnthropicError::Network)?;
+
+        // Read the quota headers before the body is consumed, on success as
+        // well as failure.
+        let limits = UnifiedRateLimit::from_headers(response.headers());
+
+        if response.status() != StatusCode::OK {
+            return Err(response_error(response).await);
+        }
+
+        Ok(StreamResponse {
+            limits,
+            stream: stream(response, event_types),
+        })
+    }
+}
+
+/// A server-sent-event stream plus the quota state its response reported.
+pub struct StreamResponse<O> {
+    /// The unified rate-limit headers the response carried.
+    pub limits: UnifiedRateLimit,
+
+    /// The parsed events.
+    pub stream: Pin<Box<dyn Stream<Item = Result<O, AnthropicError>> + Send>>,
+}
+
+async fn handle_response<O>(response: reqwest::Response) -> Result<O, AnthropicError>
+where
+    O: DeserializeOwned,
+{
+    if response.status() == StatusCode::OK {
+        return response.json::<O>().await.map_err(AnthropicError::Network);
+    }
+
+    Err(response_error(response).await)
+}
+
+/// Classify a non-success response.
+///
+/// Shared by the buffered and streaming paths so one place decides what a
+/// status means.
+async fn response_error(response: reqwest::Response) -> AnthropicError {
+    let status = response.status();
+
+    // 529 is the status code for overloaded requests
+    let overloaded_status = StatusCode::from_u16(529).expect("529 is a valid status code");
+
+    if status == StatusCode::TOO_MANY_REQUESTS || status == overloaded_status {
+        let retry_after = response
+            .headers()
+            .get("Retry-After")
+            .and_then(|h| h.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok());
+
+        // Read the quota headers before consuming the body: they are
+        // the only thing that distinguishes a spent usage window from
+        // capacity throttling, and the body often says nothing.
+        let limits = UnifiedRateLimit::from_headers(response.headers());
+
+        let text = response.text().await.unwrap_or_default();
+        tracing::warn!(?limits, "Rate limited: {text}");
+
+        return AnthropicError::RateLimit {
+            retry_after,
+            limits,
+        };
+    }
+
+    // The credential was refused. The status is what makes this actionable,
+    // and it is lost once the body is parsed into the generic error envelope.
+    if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
+        let text = response.text().await.unwrap_or_default();
+        tracing::warn!(%status, "Authentication rejected: {text}");
+
+        let error = serde_json::from_str::<ApiErrorEnvelope>(&text).map_or_else(
+            |_| ApiError {
+                error_type: "authentication_error".to_owned(),
+                message: Some(text),
+            },
+            |envelope| envelope.error,
+        );
+
+        return AnthropicError::Auth {
+            status: status.as_u16(),
+            error,
+        };
+    }
+
+    let text = response.text().await.unwrap_or_default();
+    match serde_json::from_str::<ApiErrorEnvelope>(&text) {
+        Ok(envelope) => AnthropicError::Api(envelope.error),
+        Err(_) => AnthropicError::Unknown(text),
+    }
+}
+
+/// Parse an SSE response body into typed events.
+///
+/// The stream is driven by the caller rather than by a background task, so a
+/// dropped stream stops reading the body instead of continuing to consume it.
+fn stream<O, const N: usize>(
+    response: reqwest::Response,
+    event_types: [&'static str; N],
+) -> Pin<Box<dyn Stream<Item = Result<O, AnthropicError>> + Send>>
+where
+    O: DeserializeOwned + Send + 'static,
+{
+    let events = response
+        .bytes_stream()
+        .eventsource()
+        .map(move |event| {
+            tracing::trace!("Streaming event: {event:?}");
+            match event {
+                Ok(message) => decode_event(&message, &event_types),
+                Err(error) => Err(AnthropicError::StreamTransport(error.to_string())),
+            }
+        })
+        // A failure ends the stream: whatever follows belongs to a response
+        // the caller has already been told is broken.
+        .scan(false, |finished, item| {
+            if *finished {
+                return futures::future::ready(None);
+            }
+
+            *finished = item.is_err();
+            futures::future::ready(Some(item))
+        });
+
+    Box::pin(events)
+}
+
+/// Decode one server-sent event into `O`.
+///
+/// An `error` event carries an API error rather than a payload; an event whose
+/// type the caller did not ask for is a protocol surprise rather than data.
+fn decode_event<O, const N: usize>(
+    message: &eventsource_stream::Event,
+    event_types: &[&'static str; N],
+) -> Result<O, AnthropicError>
+where
+    O: DeserializeOwned,
+{
+    let event = message.event.as_str();
+
+    if event == "error" {
+        return Err(
+            match serde_json::from_str::<ApiErrorEnvelope>(&message.data) {
+                Ok(envelope) => AnthropicError::Api(envelope.error),
+                Err(_) => match serde_json::from_str::<ApiError>(&message.data) {
+                    Ok(error) => AnthropicError::Api(error),
+                    Err(error) => map_deserialization_error(error, message.data.as_bytes()),
+                },
+            },
+        );
+    }
+
+    if !event_types.contains(&event) {
+        return Err(AnthropicError::StreamTransport(format!(
+            "unknown event type: {event}"
+        )));
+    }
+
+    serde_json::from_str::<O>(&message.data)
+        .map_err(|error| map_deserialization_error(error, message.data.as_bytes()))
+}

--- a/crates/contrib/async-anthropic/src/errors.rs
+++ b/crates/contrib/async-anthropic/src/errors.rs
@@ -1,0 +1,359 @@
+use reqwest::header::HeaderMap;
+#[cfg(test)]
+use reqwest::header::{HeaderName, HeaderValue};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum AnthropicError {
+    #[error("network error: {0}")]
+    Network(#[from] reqwest::Error),
+
+    #[error("api error: {0}")]
+    Api(#[from] ApiError),
+
+    /// The request was rejected with `429`.
+    ///
+    /// `limits` carries Anthropic's unified rate-limit headers, which
+    /// distinguish a quota rejection from ordinary throttling; see
+    /// [`UnifiedRateLimit`].
+    #[error("rate limited (retry after {} seconds)", retry_after.unwrap_or_default())]
+    RateLimit {
+        retry_after: Option<u64>,
+        limits: UnifiedRateLimit,
+    },
+
+    /// The request was rejected with `401` or `403`.
+    ///
+    /// Kept separate from [`Api`] because the status is what makes it
+    /// actionable: the credential itself was refused, so the caller
+    /// re-authenticates rather than retries.
+    ///
+    /// [`Api`]: Self::Api
+    #[error("authentication rejected ({status}): {error}")]
+    Auth { status: u16, error: ApiError },
+
+    #[error("failed to deserialize response: {0}")]
+    Deserialization(#[from] serde_json::Error),
+
+    #[error("stream transport error: {0}")]
+    StreamTransport(String),
+
+    #[error("unknown error: {0}")]
+    Unknown(String),
+}
+
+/// Anthropic's unified rate-limit headers.
+///
+/// A subscription account's usage windows are reported here rather than in the
+/// error body: the same `429 rate_limit_error` covers a spent usage window,
+/// ordinary capacity throttling, and a rejected request, so only these headers
+/// tell them apart.
+///
+/// See:
+/// <https://support.claude.com/en/articles/11145838-using-claude-code-with-your-pro-or-max-plan>
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct UnifiedRateLimit {
+    /// `allowed`, `allowed_warning`, or `rejected`.
+    pub status: Option<String>,
+
+    /// The window that is exhausted: `five_hour`, `seven_day`,
+    /// `seven_day_opus`, or `seven_day_sonnet`.
+    ///
+    /// The first two cover the whole account; the others cover one model
+    /// family.
+    pub representative_claim: Option<String>,
+
+    /// When the exhausted window resets, as Unix seconds.
+    pub reset: Option<u64>,
+
+    /// Whether paid spillover ("extra usage") can serve the request: `allowed`,
+    /// `allowed_warning`, or `rejected`.
+    pub overage_status: Option<String>,
+
+    /// When the paid spillover allowance resets, as Unix seconds.
+    pub overage_reset: Option<u64>,
+
+    /// Why paid spillover could not serve the request, when it could not.
+    ///
+    /// Reported by the unified limiter, e.g. `out_of_credits`,
+    /// `org_level_disabled`, `seat_tier_zero_credit_limit`.
+    /// Absent when spillover is available.
+    pub overage_disabled_reason: Option<String>,
+
+    /// Per-window utilization, as a fraction of the allowance consumed.
+    ///
+    /// Reported on every response, not only on a rejection.
+    pub windows: Vec<WindowUtilization>,
+}
+
+/// How much of one usage window has been consumed.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct WindowUtilization {
+    /// The window this describes: `five_hour` or `seven_day`.
+    pub claim: String,
+
+    /// The fraction of the window's allowance consumed, from 0 to 1.
+    pub utilization: Option<f64>,
+
+    /// When this window resets, as Unix seconds.
+    pub reset: Option<u64>,
+
+    /// The warning threshold this window has crossed, when it has crossed one.
+    ///
+    /// Presence is the signal: the provider only sends it once usage passes a
+    /// threshold it wants the client to surface.
+    pub surpassed_threshold: Option<f64>,
+}
+
+impl UnifiedRateLimit {
+    /// Read the unified headers from a response.
+    #[must_use]
+    pub fn from_headers(headers: &HeaderMap) -> Self {
+        let string = |name: &str| {
+            headers
+                .get(name)
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_owned)
+        };
+        let number = |name: &str| {
+            headers
+                .get(name)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse().ok())
+        };
+
+        let float = |name: &str| {
+            headers
+                .get(name)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse().ok())
+        };
+
+        // The per-window headers are abbreviated (`5h`, `7d`) while the
+        // window names elsewhere are spelled out; normalize to the spelled-out
+        // form so one vocabulary reaches callers.
+        let windows = [("5h", "five_hour"), ("7d", "seven_day")]
+            .into_iter()
+            .map(|(abbrev, claim)| WindowUtilization {
+                claim: claim.to_owned(),
+                utilization: float(&format!("anthropic-ratelimit-unified-{abbrev}-utilization")),
+                reset: number(&format!("anthropic-ratelimit-unified-{abbrev}-reset")),
+                surpassed_threshold: float(&format!(
+                    "anthropic-ratelimit-unified-{abbrev}-surpassed-threshold"
+                )),
+            })
+            .filter(|window| window.utilization.is_some() || window.reset.is_some())
+            .collect();
+
+        Self {
+            status: string("anthropic-ratelimit-unified-status"),
+            representative_claim: string("anthropic-ratelimit-unified-representative-claim"),
+            reset: number("anthropic-ratelimit-unified-reset"),
+            overage_status: string("anthropic-ratelimit-unified-overage-status"),
+            overage_reset: number("anthropic-ratelimit-unified-overage-reset"),
+            overage_disabled_reason: string("anthropic-ratelimit-unified-overage-disabled-reason"),
+            windows,
+        }
+    }
+
+    /// Whether the subscription allowance is spent.
+    ///
+    /// A response can report this while still succeeding: paid spillover keeps
+    /// serving requests past the window when the account has extra usage
+    /// enabled, so a `200` carrying this state means the request was billed
+    /// rather than covered by the allowance.
+    #[must_use]
+    pub fn is_rejected(&self) -> bool {
+        self.status.as_deref() == Some("rejected")
+    }
+
+    /// The window that has crossed a warning threshold, if any.
+    #[must_use]
+    pub fn warning(&self) -> Option<&WindowUtilization> {
+        self.windows
+            .iter()
+            .find(|window| window.surpassed_threshold.is_some())
+    }
+
+    /// Whether this rejection is a quota limit rather than throttling.
+    ///
+    /// A rejection that names the exhausted window, or reports on paid
+    /// spillover, is about an allowance being spent.
+    /// One that carries neither is not a quota limit at all, however much its
+    /// status code resembles one.
+    #[must_use]
+    pub fn is_quota_rejection(&self) -> bool {
+        self.representative_claim.is_some() || self.overage_status.is_some()
+    }
+
+    /// Whether none of the unified headers were present.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+/// The wire-format envelope for Anthropic API errors.
+///
+/// ```json
+/// {
+///     "type": "error",
+///     "error": {
+///         "type": "overloaded_error",
+///         "message": "Overloaded"
+///     }
+/// }
+/// ```
+///
+/// The top-level `type` is always `"error"` and is discarded during
+/// deserialization.
+/// Only the inner [`ApiError`] is kept.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ApiErrorEnvelope {
+    pub error: ApiError,
+}
+
+/// An error returned by the Anthropic API.
+///
+/// Represents the inner `error` object from the standard error envelope.
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq, Serialize)]
+pub struct ApiError {
+    /// The error type, e.g. `"overloaded_error"`, `"rate_limit_error"`,
+    /// `"invalid_request_error"`.
+    #[serde(rename = "type")]
+    pub error_type: String,
+
+    /// Human-readable error message.
+    pub message: Option<String>,
+}
+
+impl std::fmt::Display for ApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}: {}",
+            self.error_type,
+            self.message.as_deref().unwrap_or("(no message)")
+        )
+    }
+}
+
+impl std::error::Error for ApiError {}
+
+pub(crate) fn map_deserialization_error(e: serde_json::Error, _bytes: &[u8]) -> AnthropicError {
+    AnthropicError::Deserialization(e)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        for (name, value) in pairs {
+            headers.insert(
+                HeaderName::from_bytes(name.as_bytes()).unwrap(),
+                HeaderValue::from_str(value).unwrap(),
+            );
+        }
+        headers
+    }
+
+    #[test]
+    fn test_no_unified_headers_is_empty() {
+        let limits = UnifiedRateLimit::from_headers(&headers(&[("retry-after", "30")]));
+
+        assert!(limits.is_empty());
+        assert!(!limits.is_quota_rejection());
+        assert!(!limits.is_rejected());
+        assert_eq!(limits.warning(), None);
+    }
+
+    /// The per-window headers are abbreviated on the wire but named in full
+    /// everywhere else, so parsing normalizes them.
+    #[test]
+    fn test_window_utilization_is_parsed_under_its_full_name() {
+        let limits = UnifiedRateLimit::from_headers(&headers(&[
+            ("anthropic-ratelimit-unified-status", "allowed"),
+            ("anthropic-ratelimit-unified-5h-utilization", "0.42"),
+            ("anthropic-ratelimit-unified-5h-reset", "1780000000"),
+            ("anthropic-ratelimit-unified-7d-utilization", "0.9"),
+            ("anthropic-ratelimit-unified-7d-reset", "1780600000"),
+        ]));
+
+        assert_eq!(limits.windows, vec![
+            WindowUtilization {
+                claim: "five_hour".to_owned(),
+                utilization: Some(0.42),
+                reset: Some(1_780_000_000),
+                surpassed_threshold: None,
+            },
+            WindowUtilization {
+                claim: "seven_day".to_owned(),
+                utilization: Some(0.9),
+                reset: Some(1_780_600_000),
+                surpassed_threshold: None,
+            },
+        ]);
+
+        // No threshold was crossed, so there is nothing to warn about even
+        // though one window is at 90%.
+        assert_eq!(limits.warning(), None);
+    }
+
+    /// A window is only worth warning about once the provider says a threshold
+    /// was crossed; the fraction alone is not the signal.
+    #[test]
+    fn test_surpassed_threshold_marks_the_warning_window() {
+        let limits = UnifiedRateLimit::from_headers(&headers(&[
+            ("anthropic-ratelimit-unified-status", "allowed_warning"),
+            ("anthropic-ratelimit-unified-5h-utilization", "0.2"),
+            ("anthropic-ratelimit-unified-5h-reset", "1780000000"),
+            ("anthropic-ratelimit-unified-7d-utilization", "0.75"),
+            ("anthropic-ratelimit-unified-7d-reset", "1780600000"),
+            ("anthropic-ratelimit-unified-7d-surpassed-threshold", "0.75"),
+        ]));
+
+        let warning = limits.warning().expect("the weekly window crossed one");
+        assert_eq!(warning.claim, "seven_day");
+        assert_eq!(warning.surpassed_threshold, Some(0.75));
+    }
+
+    /// A spent window reported on a response that still succeeded: paid extra
+    /// usage served it.
+    #[test]
+    fn test_rejected_status_is_readable_without_a_rejection() {
+        let limits = UnifiedRateLimit::from_headers(&headers(&[
+            ("anthropic-ratelimit-unified-status", "rejected"),
+            (
+                "anthropic-ratelimit-unified-representative-claim",
+                "seven_day",
+            ),
+            ("anthropic-ratelimit-unified-reset", "1780600000"),
+            ("anthropic-ratelimit-unified-overage-status", "allowed"),
+        ]));
+
+        assert!(limits.is_rejected());
+        assert!(limits.is_quota_rejection());
+        assert_eq!(limits.representative_claim.as_deref(), Some("seven_day"));
+    }
+
+    #[test]
+    fn test_overage_disabled_reason_is_parsed() {
+        let limits = UnifiedRateLimit::from_headers(&headers(&[
+            ("anthropic-ratelimit-unified-status", "rejected"),
+            ("anthropic-ratelimit-unified-overage-status", "rejected"),
+            (
+                "anthropic-ratelimit-unified-overage-disabled-reason",
+                "out_of_credits",
+            ),
+        ]));
+
+        assert_eq!(
+            limits.overage_disabled_reason.as_deref(),
+            Some("out_of_credits")
+        );
+    }
+}

--- a/crates/contrib/async-anthropic/src/lib.rs
+++ b/crates/contrib/async-anthropic/src/lib.rs
@@ -1,3 +1,8 @@
+#![allow(
+    rustdoc::private_intra_doc_links,
+    reason = "we don't host the docs, and use them mainly for LSP integration"
+)]
+
 pub mod bearer;
 mod client;
 pub mod errors;

--- a/crates/contrib/async-anthropic/src/lib.rs
+++ b/crates/contrib/async-anthropic/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod bearer;
+mod client;
+pub mod errors;
+pub mod messages;
+pub mod models;
+pub mod types;
+pub use client::Client;

--- a/crates/contrib/async-anthropic/src/messages.rs
+++ b/crates/contrib/async-anthropic/src/messages.rs
@@ -1,0 +1,73 @@
+use crate::{
+    Client,
+    client::StreamResponse,
+    errors::AnthropicError,
+    types::{CreateMessagesRequest, CreateMessagesResponse, MessagesStreamEvent},
+};
+
+pub const DEFAULT_MAX_TOKENS: i32 = 2048;
+
+#[derive(Debug, Clone)]
+pub struct Messages<'c> {
+    client: &'c Client,
+}
+
+impl Messages<'_> {
+    #[must_use]
+    pub fn new(client: &Client) -> Messages<'_> {
+        Messages { client }
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub async fn create(
+        &self,
+        request: impl Into<CreateMessagesRequest>,
+    ) -> Result<CreateMessagesResponse, AnthropicError> {
+        let mut request = request.into();
+        request.stream = false;
+
+        // Betas ride in the `anthropic-beta` header, not the body.
+        let betas = std::mem::take(&mut request.betas);
+
+        self.client.post("/v1/messages", request, &betas).await
+    }
+
+    /// Stream a message completion.
+    ///
+    /// The returned [`StreamResponse`] carries the response's quota headers
+    /// alongside its events, so a caller can read the subscription's usage
+    /// state from a successful request rather than waiting for a rejection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the request is rejected before streaming begins,
+    /// which is where a spent quota or a refused credential surfaces.
+    #[tracing::instrument(skip_all)]
+    pub async fn create_stream(
+        &self,
+        request: impl Into<CreateMessagesRequest>,
+    ) -> Result<StreamResponse<MessagesStreamEvent>, AnthropicError> {
+        let mut request = request.into();
+        request.stream = true;
+
+        // Betas ride in the `anthropic-beta` header, not the body.
+        let betas = std::mem::take(&mut request.betas);
+
+        self.client
+            .post_stream(
+                "/v1/messages",
+                request,
+                [
+                    "ping",
+                    "message_start",
+                    "message_delta",
+                    "message_stop",
+                    "content_block_start",
+                    "content_block_delta",
+                    "content_block_stop",
+                ],
+                &betas,
+            )
+            .await
+    }
+}

--- a/crates/contrib/async-anthropic/src/models.rs
+++ b/crates/contrib/async-anthropic/src/models.rs
@@ -1,0 +1,31 @@
+use crate::{
+    Client,
+    errors::AnthropicError,
+    types::{GetModelResponse, ListModelsResponse},
+};
+
+pub const DEFAULT_MAX_TOKENS: i32 = 2048;
+
+#[derive(Debug, Clone)]
+pub struct Models<'c> {
+    client: &'c Client,
+}
+
+impl Models<'_> {
+    #[must_use]
+    pub fn new(client: &Client) -> Models<'_> {
+        Models { client }
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub async fn list(&self) -> Result<ListModelsResponse, AnthropicError> {
+        self.client.get("/v1/models").await
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub async fn get(&self, model_id: impl AsRef<str>) -> Result<GetModelResponse, AnthropicError> {
+        self.client
+            .get(&format!("/v1/models/{}", model_id.as_ref()))
+            .await
+    }
+}

--- a/crates/contrib/async-anthropic/src/types.rs
+++ b/crates/contrib/async-anthropic/src/types.rs
@@ -1,0 +1,1336 @@
+use std::{
+    collections::BTreeMap,
+    num::NonZeroU32,
+    ops::{Deref, DerefMut},
+};
+
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize, Serializer};
+use serde_json::{Map, Value};
+
+use crate::messages;
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct Usage {
+    pub input_tokens: Option<u32>,
+    pub output_tokens: Option<u32>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub enum ToolChoice {
+    None,
+    Auto {
+        disable_parallel_tool_use: bool,
+    },
+    Any {
+        disable_parallel_tool_use: bool,
+    },
+    Tool {
+        name: String,
+        disable_parallel_tool_use: bool,
+    },
+}
+
+impl ToolChoice {
+    /// Instruct the model to not use any tools.
+    #[must_use]
+    pub fn none() -> Self {
+        ToolChoice::None
+    }
+
+    /// Instruct the model to use zero, one, or more tools.
+    #[must_use]
+    pub fn auto() -> Self {
+        ToolChoice::Auto {
+            disable_parallel_tool_use: false,
+        }
+    }
+
+    /// Instruct the model to use one, or more tools.
+    #[must_use]
+    pub fn any() -> Self {
+        ToolChoice::Any {
+            disable_parallel_tool_use: false,
+        }
+    }
+
+    /// Instruct the model to use the specified tool.
+    #[must_use]
+    pub fn tool(name: String) -> Self {
+        ToolChoice::Tool {
+            name,
+            disable_parallel_tool_use: false,
+        }
+    }
+
+    /// Enable or disable parallel tool use for this tool choice.
+    #[must_use]
+    pub fn with_disable_parallel_tool_use(self, disable_parallel_tool_use: bool) -> Self {
+        match self {
+            ToolChoice::None => ToolChoice::None,
+            ToolChoice::Auto { .. } => ToolChoice::Auto {
+                disable_parallel_tool_use,
+            },
+            ToolChoice::Any { .. } => ToolChoice::Any {
+                disable_parallel_tool_use,
+            },
+            ToolChoice::Tool { name, .. } => ToolChoice::Tool {
+                name,
+                disable_parallel_tool_use,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ThinkingDisplay {
+    Summarized,
+    Omitted,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ExtendedThinking {
+    Enabled {
+        budget_tokens: u32,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        display: Option<ThinkingDisplay>,
+    },
+    Disabled,
+    Adaptive {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        display: Option<ThinkingDisplay>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Builder, PartialEq, Default)]
+#[builder(setter(into, strip_option), default)]
+pub struct Message {
+    pub role: MessageRole,
+    pub content: MessageContentList,
+}
+
+impl Message {
+    /// Returns all the tool uses in the message
+    #[must_use]
+    pub fn tool_uses(&self) -> Vec<ToolUse> {
+        self.content
+            .0
+            .iter()
+            .filter_map(|c| match c {
+                MessageContent::ToolUse(tool_use) => Some(tool_use.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Returns the first text content in the message
+    #[must_use]
+    pub fn text(&self) -> Option<String> {
+        self.content.0.iter().find_map(|c| match c {
+            MessageContent::Text(text) => Some(text.text.clone()),
+            _ => None,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct MessageContentList(pub Vec<MessageContent>);
+
+impl Deref for MessageContentList {
+    type Target = Vec<MessageContent>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for MessageContentList {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageRole {
+    #[default]
+    User,
+    Assistant,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Builder)]
+#[builder(setter(into, strip_option))]
+pub struct CreateMessagesRequest {
+    pub model: String,
+    pub messages: Vec<Message>,
+    #[builder(default = messages::DEFAULT_MAX_TOKENS)]
+    pub max_tokens: i32,
+    #[builder(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<ExtendedThinking>,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub metadata: serde_json::Map<String, Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[builder(default)]
+    pub stop_sequences: Vec<String>,
+    #[builder(default = "false")]
+    pub stream: bool, // Optional default false
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub temperature: Option<f32>, // 0 < x < 1
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub tool_choice: Option<ToolChoice>,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<Tool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub top_k: Option<u32>, // > 0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub top_p: Option<f32>, // 0 < x < 1
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub system: Option<System>,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub context_management: serde_json::Map<String, Value>,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_config: Option<OutputConfig>,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<ServiceTier>,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub speed: Option<Speed>,
+
+    /// Beta features to enable for this request only.
+    ///
+    /// Merged with the client's own `beta` value into the `anthropic-beta`
+    /// header.
+    /// Carried as a header, so it is deliberately kept out of the request body.
+    #[builder(default)]
+    #[serde(skip)]
+    pub betas: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OutputConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<Effort>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format: Option<JsonOutputFormat>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum JsonOutputFormat {
+    JsonSchema { schema: Map<String, Value> },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum Effort {
+    Low,
+    Medium,
+    High,
+    #[serde(rename = "xhigh")]
+    XHigh,
+    Max,
+}
+
+/// Which service tiers may serve the request.
+///
+/// Only meaningful for organizations with an existing Priority Tier capacity
+/// commitment; other organizations always run at standard tier.
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceTier {
+    /// Use Priority Tier capacity when available, falling back to standard.
+    #[default]
+    Auto,
+    /// Use standard capacity only, leaving the Priority Tier commitment
+    /// untouched.
+    StandardOnly,
+}
+
+/// Inference speed for the request.
+///
+/// `Fast` requires the `fast-mode-2026-02-01` beta header and is supported on
+/// Claude Opus 5 and Opus 4.8 only; other models return an error.
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Speed {
+    Fast,
+    #[default]
+    Standard,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Tool {
+    Custom(CustomTool),
+
+    #[serde(untagged)]
+    Bash(ToolBash),
+
+    #[serde(untagged)]
+    CodeExecution(ToolCodeExecution),
+
+    #[serde(untagged)]
+    ComputerUse(ToolComputerUse),
+
+    #[serde(untagged)]
+    TextEditor(ToolTextEditor),
+
+    #[serde(untagged)]
+    WebSearch(ToolWebSearch),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[builder(setter(into, strip_option))]
+pub struct CustomTool {
+    pub name: String,
+    #[builder(default)]
+    pub input_schema: ToolInputSchema,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub strict: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, Builder)]
+#[builder(setter(into, strip_option), default)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolInputSchema {
+    #[serde(rename = "type")]
+    pub kind: ToolInputSchemaKind,
+    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub properties: serde_json::Map<String, Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub additional_properties: Option<bool>,
+
+    /// Remaining schema keywords, carried through verbatim.
+    ///
+    /// `input_schema` is a JSON Schema document, so it may hold keywords this
+    /// struct does not model: `$defs` and `definitions` for referenced
+    /// subschemas, `$schema`, `title`, and the type-specific constraints the
+    /// API accepts.
+    /// The official SDKs allow the same extras.
+    ///
+    /// Keys here serialize alongside the fields above, so avoid repeating
+    /// `type`, `properties`, `required`, or `additionalProperties`.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, Value>,
+}
+
+impl From<serde_json::Map<String, Value>> for ToolInputSchema {
+    /// Adopt a complete JSON Schema document, keeping every keyword.
+    fn from(mut schema: serde_json::Map<String, Value>) -> Self {
+        schema.remove("type");
+
+        let properties = schema
+            .remove("properties")
+            .and_then(|v| match v {
+                Value::Object(map) => Some(map),
+                _ => None,
+            })
+            .unwrap_or_default();
+
+        let required = schema
+            .remove("required")
+            .and_then(|v| match v {
+                Value::Array(items) => Some(items),
+                _ => None,
+            })
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|v| v.as_str().map(str::to_owned))
+            .collect();
+
+        let additional_properties = schema
+            .remove("additionalProperties")
+            .and_then(|v| v.as_bool());
+
+        Self {
+            kind: ToolInputSchemaKind::Object,
+            properties,
+            required,
+            additional_properties,
+            extra: schema,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ToolInputSchemaKind {
+    #[default]
+    #[serde(with = "tags::object")]
+    Object,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ToolBash {
+    Bash20241022(ToolBash20241022),
+    Bash20250124(ToolBash20250124),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Builder)]
+#[builder(setter(into, strip_option), default)]
+pub struct ToolBash20241022 {
+    pub name: ToolBashName,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Builder)]
+#[builder(setter(into, strip_option), default)]
+pub struct ToolBash20250124 {
+    #[builder(setter(skip))]
+    pub name: ToolBashName,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ToolBashName {
+    #[default]
+    #[serde(with = "tags::bash")]
+    Bash,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ToolCodeExecution {
+    CodeExecution20250522(ToolCodeExecution20250522),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize, Builder)]
+#[builder(setter(into, strip_option), default)]
+pub struct ToolCodeExecution20250522 {
+    pub name: ToolCodeExecutionName,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ToolCodeExecutionName {
+    #[default]
+    #[serde(with = "tags::code_execution")]
+    CodeExecution,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ToolComputerUse {
+    ComputerUse20241022(ToolComputerUse20241022),
+    ComputerUse20250124(ToolComputerUse20250124),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[builder(setter(into, strip_option))]
+pub struct ToolComputerUse20241022 {
+    #[builder(default)]
+    pub name: ToolComputerUseName,
+    pub display_height_px: NonZeroU32,
+    pub display_width_px: NonZeroU32,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_number: Option<u32>,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Builder)]
+#[builder(setter(into, strip_option), default)]
+pub struct ToolComputerUse20250124 {
+    pub name: ToolComputerUseName,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum ToolComputerUseName {
+    #[default]
+    #[serde(with = "tags::computer_use")]
+    ComputerUse,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ToolTextEditor {
+    TextEditor20241022(ToolTextEditor20241022),
+    TextEditor20250124(ToolTextEditor20250124),
+    TextEditor20250429(ToolTextEditor20250429),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Builder)]
+#[builder(setter(into, strip_option), default)]
+pub struct ToolTextEditor20241022 {
+    pub name: ToolTextEditorName,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Builder)]
+#[builder(setter(into, strip_option), default)]
+pub struct ToolTextEditor20250124 {
+    pub name: ToolTextEditorName,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Builder)]
+#[builder(setter(into, strip_option), default)]
+pub struct ToolTextEditor20250429 {
+    pub name: ToolTextEditorBasedEditName,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum ToolTextEditorName {
+    #[default]
+    #[serde(with = "tags::str_replace_editor")]
+    StrReplaceEditor,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum ToolTextEditorBasedEditName {
+    #[default]
+    #[serde(with = "tags::str_replace_based_edit_tool")]
+    StrReplaceBasedEditTool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ToolWebSearch {
+    WebSearch20250305(ToolWebSearch20250305),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Builder)]
+#[builder(setter(into, strip_option), default)]
+pub struct ToolWebSearch20250305 {
+    pub name: ToolWebSearchName,
+    #[serde(flatten)]
+    pub allowed_or_blocked_domains: Option<WebSearchAllowedOrBlockedDomains>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_uses: Option<NonZeroU32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_location: Option<WebSearchUserLocation>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum WebSearchAllowedOrBlockedDomains {
+    #[serde(rename = "allowed_domains")]
+    Allowed(Vec<String>),
+    #[serde(rename = "blocked_domains")]
+    Blocked(Vec<String>),
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, Builder)]
+#[builder(setter(into, strip_option), default)]
+pub struct WebSearchUserLocation {
+    #[serde(rename = "type")]
+    pub kind: WebSearchUserLocationKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub city: Option<String>,
+    #[serde(rename = "country", default, skip_serializing_if = "Option::is_none")]
+    pub country_iso: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    #[serde(rename = "timezone", default, skip_serializing_if = "Option::is_none")]
+    pub timezone_iana: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum WebSearchUserLocationKind {
+    #[default]
+    #[serde(with = "tags::approximate")]
+    Approximate,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum ToolWebSearchName {
+    #[default]
+    #[serde(with = "tags::web_search")]
+    WebSearch,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum System {
+    Content(Vec<SystemContent>),
+    String(String),
+}
+
+impl From<String> for System {
+    fn from(s: String) -> Self {
+        System::String(s)
+    }
+}
+
+impl From<Text> for System {
+    fn from(text: Text) -> Self {
+        System::Content(vec![SystemContent::Text(text)])
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SystemContent {
+    Text(Text),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Builder)]
+#[builder(setter(into, strip_option))]
+pub struct CreateMessagesResponse {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub content: Vec<MessageContent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_sequence: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage: Option<Usage>,
+}
+
+impl CreateMessagesResponse {
+    /// Returns the content as Messages so they are more easily reusable
+    #[must_use]
+    pub fn messages(&self) -> Vec<Message> {
+        self.content
+            .iter()
+            .map(|c| Message {
+                role: MessageRole::Assistant,
+                content: c.clone().into(),
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MessageContent {
+    ToolUse(ToolUse),
+    ToolResult(ToolResult),
+    Text(Text),
+    Thinking(Thinking),
+    Document(Document),
+
+    /// See Anthropic's docs for more information:
+    ///
+    /// > Occasionally Claude’s internal reasoning will be flagged by our
+    /// > safety systems.
+    /// > When this occurs, we encrypt some or all of the thinking block and
+    /// > return it to you as a redacted_thinking block. redacted_thinking
+    /// > blocks are decrypted when passed back to the API, allowing Claude to
+    /// > continue its response without losing context.
+    ///
+    /// See:
+    /// <https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#thinking-redaction>
+    RedactedThinking {
+        data: String,
+    },
+}
+
+impl MessageContent {
+    #[must_use]
+    pub fn as_tool_use(&self) -> Option<&ToolUse> {
+        if let MessageContent::ToolUse(tool_use) = self {
+            Some(tool_use)
+        } else {
+            None
+        }
+    }
+
+    #[must_use]
+    pub fn as_tool_result(&self) -> Option<&ToolResult> {
+        if let MessageContent::ToolResult(tool_result) = self {
+            Some(tool_result)
+        } else {
+            None
+        }
+    }
+
+    #[must_use]
+    pub fn as_text(&self) -> Option<&Text> {
+        if let MessageContent::Text(text) = self {
+            Some(text)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Builder)]
+#[builder(setter(into, strip_option), default)]
+pub struct ToolUse {
+    pub id: String,
+    pub input: Value,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+impl From<ToolUse> for MessageContent {
+    fn from(tool_use: ToolUse) -> Self {
+        MessageContent::ToolUse(tool_use)
+    }
+}
+
+impl From<ToolUse> for MessageContentList {
+    fn from(tool_use: ToolUse) -> Self {
+        MessageContentList(vec![tool_use.into()])
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Builder)]
+#[builder(setter(into, strip_option), default)]
+pub struct ToolResult {
+    pub tool_use_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    pub is_error: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+impl From<ToolResult> for MessageContent {
+    fn from(tool_result: ToolResult) -> Self {
+        MessageContent::ToolResult(tool_result)
+    }
+}
+
+impl From<ToolResult> for MessageContentList {
+    fn from(tool_result: ToolResult) -> Self {
+        MessageContentList(vec![tool_result.into()])
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Builder)]
+#[builder(setter(into, strip_option), default)]
+pub struct Text {
+    pub text: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+impl<S: AsRef<str>> From<S> for Text {
+    fn from(s: S) -> Self {
+        Text {
+            text: s.as_ref().to_string(),
+            cache_control: None,
+        }
+    }
+}
+
+impl From<Text> for MessageContent {
+    fn from(text: Text) -> Self {
+        MessageContent::Text(text)
+    }
+}
+
+impl From<Text> for MessageContentList {
+    fn from(text: Text) -> Self {
+        MessageContentList(vec![text.into()])
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize, Builder)]
+#[serde(rename_all = "snake_case")]
+#[builder(setter(into, strip_option), default)]
+pub struct CacheControl {
+    #[serde(rename = "type")]
+    pub kind: CacheControlKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<CacheControlTtl>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CacheControlKind {
+    #[default]
+    #[serde(with = "tags::ephemeral")]
+    Ephemeral,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CacheControlTtl {
+    #[default]
+    #[serde(with = "tags::ttl_5m")]
+    Ttl5Minutes,
+    #[serde(with = "tags::ttl_1h")]
+    Ttl1Hour,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Builder)]
+#[builder(setter(into, strip_option), default)]
+pub struct Thinking {
+    pub thinking: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+}
+
+impl Thinking {
+    #[must_use]
+    pub fn with_signature(mut self, signature: String) -> Self {
+        self.signature = Some(signature);
+        self
+    }
+}
+
+impl<S: AsRef<str>> From<S> for Thinking {
+    fn from(s: S) -> Self {
+        Thinking {
+            thinking: s.as_ref().to_string(),
+            signature: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Document {
+    pub source: DocumentSource,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub citations: Option<CitationsConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CitationsConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum DocumentSource {
+    Base64 {
+        data: String,
+        media_type: PdfMediaType,
+    },
+    Text {
+        data: String,
+        media_type: PlainTextMediaType,
+    },
+    Content {
+        content: DocumentSourceContent,
+    },
+    Url {
+        url: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum PdfMediaType {
+    #[default]
+    #[serde(with = "tags::application_pdf")]
+    ApplicationPdf,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum PlainTextMediaType {
+    #[default]
+    #[serde(with = "tags::text_plain")]
+    TextPlain,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum DocumentSourceContent {
+    String(String),
+    Blocks(Vec<ContentBlockSourceContent>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContentBlockSourceContent {
+    Text {
+        text: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
+    Image {
+        source: ImageSource,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ImageSource {
+    Base64 {
+        data: String,
+        media_type: ImageMediaType,
+    },
+    Url {
+        url: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub enum ImageMediaType {
+    #[serde(rename = "image/jpeg")]
+    Jpeg,
+    #[serde(rename = "image/png")]
+    Png,
+    #[serde(rename = "image/gif")]
+    Gif,
+    #[serde(rename = "image/webp")]
+    Webp,
+}
+
+impl From<Document> for MessageContent {
+    fn from(document: Document) -> Self {
+        MessageContent::Document(document)
+    }
+}
+
+impl From<Document> for MessageContentList {
+    fn from(document: Document) -> Self {
+        MessageContentList(vec![document.into()])
+    }
+}
+
+impl From<Thinking> for MessageContent {
+    fn from(thinking: Thinking) -> Self {
+        MessageContent::Thinking(thinking)
+    }
+}
+
+impl From<Thinking> for MessageContentList {
+    fn from(thinking: Thinking) -> Self {
+        MessageContentList(vec![thinking.into()])
+    }
+}
+
+impl<S: AsRef<str>> From<S> for MessageContent {
+    fn from(s: S) -> Self {
+        MessageContent::Text(Text {
+            text: s.as_ref().to_string(),
+            cache_control: None,
+        })
+    }
+}
+
+impl<S: AsRef<str>> From<S> for Message {
+    fn from(s: S) -> Self {
+        MessageBuilder::default()
+            .role(MessageRole::User)
+            .content(s.as_ref().to_string())
+            .build()
+            .expect("infallible")
+    }
+}
+
+// Any single AsRef<str> can be converted to a MessageContent, in a list as a single item
+impl<S: AsRef<str>> From<S> for MessageContentList {
+    fn from(s: S) -> Self {
+        MessageContentList(vec![s.as_ref().into()])
+    }
+}
+
+impl From<MessageContent> for MessageContentList {
+    fn from(content: MessageContent) -> Self {
+        MessageContentList(vec![content])
+    }
+}
+
+impl Serialize for ToolChoice {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            ToolChoice::None => serde::Serialize::serialize(
+                &serde_json::json!({
+                  "type": "none",
+                }),
+                serializer,
+            ),
+            ToolChoice::Auto {
+                disable_parallel_tool_use,
+            } => serde::Serialize::serialize(
+                &serde_json::json!({
+                  "type": "auto",
+                  "disable_parallel_tool_use": disable_parallel_tool_use,
+                }),
+                serializer,
+            ),
+            ToolChoice::Any {
+                disable_parallel_tool_use,
+            } => serde::Serialize::serialize(
+                &serde_json::json!({
+                  "type": "any",
+                  "disable_parallel_tool_use": disable_parallel_tool_use,
+                }),
+                serializer,
+            ),
+            ToolChoice::Tool {
+                name,
+                disable_parallel_tool_use,
+            } => serde::Serialize::serialize(
+                &serde_json::json!({
+                    "type": "tool",
+                    "name": name,
+                    "disable_parallel_tool_use": disable_parallel_tool_use
+                }),
+                serializer,
+            ),
+        }
+    }
+}
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum ContentBlockDelta {
+    TextDelta { text: String },
+    ThinkingDelta { thinking: String },
+    SignatureDelta { signature: String },
+    InputJsonDelta { partial_json: String },
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub struct MessageDelta {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_sequence: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_details: Option<StopDetails>,
+}
+
+/// Detail object Anthropic attaches to a refusal stop.
+/// Present only when `stop_reason == "refusal"`; `None` for every other stop
+/// reason.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StopDetails {
+    /// Always `"refusal"` today.
+    #[serde(rename = "type")]
+    pub kind: String,
+
+    /// Policy area that fired (`"cyber"`, `"bio"`, `"frontier_llm"`,
+    /// `"reasoning_extraction"`, …).
+    /// `None` when the refusal is uncategorized.
+    pub category: Option<String>,
+
+    /// Human-readable reason.
+    /// Display it; don't parse it.
+    pub explanation: Option<String>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum MessagesStreamEvent {
+    MessageStart {
+        message: MessageStart,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        usage: Option<Usage>,
+    },
+    ContentBlockStart {
+        index: usize,
+        content_block: MessageContent,
+    },
+    ContentBlockDelta {
+        index: usize,
+        delta: ContentBlockDelta,
+    },
+    ContentBlockStop {
+        index: usize,
+    },
+    MessageDelta {
+        delta: MessageDelta,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        usage: Option<Usage>,
+    },
+    MessageStop,
+    Ping,
+}
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct MessageStart {
+    pub id: String,
+    pub model: String,
+    pub role: String,
+    pub content: Vec<MessageContent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_sequence: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage: Option<Usage>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct ListModelsResponse {
+    #[serde(default)]
+    pub data: Vec<Model>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_id: Option<String>,
+    pub has_more: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_id: Option<String>,
+}
+
+/// A leaf capability flag: `{ "supported": bool }`.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Default)]
+pub struct Capability {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supported: Option<bool>,
+}
+
+/// A capability with a top-level `supported` flag plus named sub-capabilities
+/// (`effort` levels, `context_management` strategies).
+///
+/// Unknown sub-keys land in `entries`, so new levels/strategies the API adds
+/// never break deserialization.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Default)]
+pub struct CapabilityGroup {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supported: Option<bool>,
+    #[serde(flatten)]
+    pub entries: BTreeMap<String, Capability>,
+}
+
+impl CapabilityGroup {
+    /// Whether the named sub-capability is present and supported.
+    #[must_use]
+    pub fn supports(&self, key: &str) -> bool {
+        self.entries
+            .get(key)
+            .is_some_and(|c| c.supported.unwrap_or(false))
+    }
+}
+
+/// The `thinking` capability: a `supported` flag plus supported `types`
+/// (`adaptive`, `enabled`, ...).
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Default)]
+pub struct ThinkingCapability {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supported: Option<bool>,
+    #[serde(default)]
+    pub types: BTreeMap<String, Capability>,
+}
+
+impl ThinkingCapability {
+    /// Whether the named thinking type is present and supported.
+    #[must_use]
+    pub fn supports(&self, ty: &str) -> bool {
+        self.types
+            .get(ty)
+            .is_some_and(|c| c.supported.unwrap_or(false))
+    }
+}
+
+/// The `capabilities` object on a model.
+/// Every field defaults so a model that omits a capability (or the API adding
+/// new ones) never breaks parsing.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Default)]
+pub struct ModelCapabilities {
+    #[serde(default)]
+    pub batch: Capability,
+    #[serde(default)]
+    pub citations: Capability,
+    #[serde(default)]
+    pub code_execution: Capability,
+    #[serde(default)]
+    pub context_management: CapabilityGroup,
+    #[serde(default)]
+    pub effort: CapabilityGroup,
+    #[serde(default)]
+    pub image_input: Capability,
+    #[serde(default)]
+    pub pdf_input: Capability,
+    #[serde(default)]
+    pub structured_outputs: Capability,
+    #[serde(default)]
+    pub thinking: ThinkingCapability,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct Model {
+    pub created_at: String,
+    pub display_name: String,
+    pub id: String,
+    #[serde(rename = "type")]
+    pub model_type: String,
+
+    #[serde(default)]
+    pub max_input_tokens: u32,
+    #[serde(default)]
+    pub max_tokens: u32,
+    #[serde(default)]
+    pub capabilities: ModelCapabilities,
+}
+
+pub type GetModelResponse = Model;
+
+macro_rules! named_unit_variant {
+    ($variant:tt) => {
+        named_unit_variant!($variant, stringify!($variant));
+    };
+    ($variant:ident, $name:expr) => {
+        pub mod $variant {
+            use serde::{Deserializer, Serializer, de};
+
+            pub fn serialize<S: Serializer>(ser: S) -> Result<S::Ok, S::Error> {
+                ser.serialize_str($name)
+            }
+
+            pub fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<(), D::Error> {
+                struct V;
+                impl<'de> de::Visitor<'de> for V {
+                    type Value = ();
+
+                    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        f.write_str(concat!("\"", $name, "\""))
+                    }
+
+                    fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+                        if value == $name {
+                            Ok(())
+                        } else {
+                            Err(E::invalid_value(de::Unexpected::Str(value), &self))
+                        }
+                    }
+                }
+
+                de.deserialize_str(V)
+            }
+        }
+    };
+}
+
+mod tags {
+    named_unit_variant!(ttl_5m, "5m");
+    named_unit_variant!(ttl_1h, "1h");
+    named_unit_variant!(ephemeral);
+    named_unit_variant!(computer_use);
+    named_unit_variant!(code_execution);
+    named_unit_variant!(bash);
+    named_unit_variant!(object);
+    named_unit_variant!(str_replace_editor);
+    named_unit_variant!(str_replace_based_edit_tool);
+    named_unit_variant!(web_search);
+    named_unit_variant!(approximate);
+    named_unit_variant!(application_pdf, "application/pdf");
+    named_unit_variant!(text_plain, "text/plain");
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test_log::test(tokio::test)]
+    async fn test_deserialize_response() {
+        let response = json!({
+          "id": "msg_01KkaCASJuaAgTWD2wqdbwC8",
+          "type": "message",
+          "role": "assistant",
+          "model": "claude-3-5-sonnet-20241022",
+          "content": [
+            {
+              "type": "text",
+              "text": "Hi! How can I help you today?"
+            }
+          ],
+          "stop_reason": "end_turn",
+          "stop_sequence": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "output_tokens": 12
+          }
+        })
+        .to_string();
+
+        let response = serde_json::from_str::<CreateMessagesResponse>(&response).unwrap();
+
+        let usage = response.usage.as_ref().unwrap();
+
+        assert_eq!(usage.input_tokens, Some(10));
+        assert_eq!(usage.output_tokens, Some(12));
+        assert_eq!(
+            response.id,
+            Some("msg_01KkaCASJuaAgTWD2wqdbwC8".to_string())
+        );
+        assert_eq!(
+            response.model,
+            Some("claude-3-5-sonnet-20241022".to_string())
+        );
+        assert_eq!(response.stop_reason, Some("end_turn".to_string()));
+        assert_eq!(response.stop_sequence, None);
+        assert_eq!(
+            response
+                .messages()
+                .first()
+                .unwrap()
+                .content
+                .first()
+                .unwrap()
+                .as_text(),
+            Some(&Text {
+                text: "Hi! How can I help you today?".to_string(),
+                cache_control: None,
+            })
+        );
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_from_str() {
+        let message: Message = "Hello world!".into();
+
+        assert_eq!(message, Message {
+            role: MessageRole::User,
+            content: MessageContentList(vec![MessageContent::Text(Text {
+                text: "Hello world!".to_string(),
+                cache_control: None,
+            })]),
+        });
+
+        assert_eq!(message.text(), Some("Hello world!".to_string()));
+    }
+}

--- a/crates/contrib/async-anthropic/tests/bearer.rs
+++ b/crates/contrib/async-anthropic/tests/bearer.rs
@@ -1,0 +1,142 @@
+//! Wire-level assertions for the bearer (OAuth) authentication mode.
+
+use async_anthropic::{Client, bearer, types::ListModelsResponse};
+use wiremock::{
+    Mock, MockServer, Request, ResponseTemplate,
+    matchers::{method, path},
+};
+
+fn empty_models_response() -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(&ListModelsResponse {
+        data: vec![],
+        first_id: None,
+        has_more: false,
+        last_id: None,
+    })
+}
+
+async fn capture_models_request(client: &Client, server: &MockServer) -> Request {
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .respond_with(empty_models_response())
+        .expect(1)
+        .mount(server)
+        .await;
+
+    client.models().list().await.unwrap();
+
+    server
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn test_bearer_mode_headers() {
+    let server = MockServer::start().await;
+    let client = Client::builder()
+        .auth_token("oauth-access-token")
+        .base_url(server.uri())
+        .version("2023-06-01")
+        .build()
+        .unwrap();
+
+    let request = capture_models_request(&client, &server).await;
+    let header = |name: &str| {
+        request
+            .headers
+            .get(name)
+            .map(|v| v.to_str().unwrap().to_owned())
+    };
+
+    assert_eq!(
+        header("authorization").as_deref(),
+        Some("Bearer oauth-access-token")
+    );
+    assert_eq!(header("x-api-key"), None);
+    assert_eq!(
+        header("anthropic-beta").as_deref(),
+        Some(
+            "oauth-2025-04-20,claude-code-20250219,interleaved-thinking-2025-05-14,\
+             context-management-2025-06-27"
+        )
+    );
+    assert_eq!(header("anthropic-version").as_deref(), Some("2023-06-01"));
+    assert_eq!(header("x-app").as_deref(), Some("cli"));
+    assert_eq!(
+        header("anthropic-client-platform").as_deref(),
+        Some("desktop_app")
+    );
+    assert_eq!(
+        header("anthropic-client-version").as_deref(),
+        Some("1.11187.4")
+    );
+    assert_eq!(
+        header("user-agent").as_deref(),
+        Some("claude-cli/2.1.165 (external, local-agent, agent-sdk/0.3.165)")
+    );
+    assert_eq!(header("x-stainless-lang").as_deref(), Some("js"));
+    assert!(header("x-client-request-id").is_some_and(|v| !v.is_empty()));
+}
+
+#[tokio::test]
+async fn test_bearer_mode_merges_user_betas_without_duplicates() {
+    let server = MockServer::start().await;
+    let client = Client::builder()
+        .auth_token("oauth-access-token")
+        // One duplicate of a fingerprint beta, one genuine extra.
+        .beta("interleaved-thinking-2025-05-14,structured-outputs-2025-10-27")
+        .base_url(server.uri())
+        .version("2023-06-01")
+        .build()
+        .unwrap();
+
+    let request = capture_models_request(&client, &server).await;
+    let betas = request
+        .headers
+        .get("anthropic-beta")
+        .unwrap()
+        .to_str()
+        .unwrap();
+
+    assert_eq!(
+        betas,
+        "oauth-2025-04-20,claude-code-20250219,interleaved-thinking-2025-05-14,\
+         context-management-2025-06-27,structured-outputs-2025-10-27"
+    );
+}
+
+#[tokio::test]
+async fn test_api_key_mode_sends_no_fingerprint() {
+    let server = MockServer::start().await;
+    let client = Client::builder()
+        .api_key("test-api-key")
+        .base_url(server.uri())
+        .version("2023-06-01")
+        .build()
+        .unwrap();
+
+    let request = capture_models_request(&client, &server).await;
+
+    assert_eq!(
+        request.headers.get("x-api-key").unwrap().to_str().unwrap(),
+        "test-api-key"
+    );
+    assert!(request.headers.get("authorization").is_none());
+    assert!(request.headers.get("x-app").is_none());
+    assert!(request.headers.get("anthropic-client-platform").is_none());
+    assert!(request.headers.get("x-client-request-id").is_none());
+    assert!(request.headers.get("anthropic-beta").is_none());
+}
+
+#[test]
+fn test_merge_betas_with_no_extras() {
+    assert_eq!(
+        bearer::merge_betas(None),
+        "oauth-2025-04-20,claude-code-20250219,interleaved-thinking-2025-05-14,\
+         context-management-2025-06-27"
+    );
+}

--- a/crates/contrib/async-anthropic/tests/messages.rs
+++ b/crates/contrib/async-anthropic/tests/messages.rs
@@ -1,0 +1,328 @@
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use async_anthropic::{
+    Client,
+    errors::{AnthropicError, ApiError},
+    types::{CreateMessagesRequestBuilder, MessageBuilder, MessageContent, MessageRole},
+};
+use async_trait::async_trait;
+use backon::ExponentialBuilder;
+use serde_json::json;
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path},
+};
+
+// Helper trait for setting up and tearing down mock server
+#[async_trait]
+pub trait MockApp {
+    async fn setup() -> MockServer;
+}
+
+struct TestSetup;
+
+#[async_trait]
+impl MockApp for TestSetup {
+    async fn setup() -> MockServer {
+        MockServer::start().await
+    }
+}
+
+#[tokio::test]
+async fn test_client_build_request() {
+    let secret_key = "test_secret";
+
+    let request = Client::builder().api_key(secret_key).build();
+
+    assert!(request.is_ok());
+}
+
+#[test_log::test(tokio::test)]
+async fn test_successful_request_execution() {
+    let server = TestSetup::setup().await;
+    let secret_key = "test_secret";
+
+    // Mock successful response
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content": [{"type": "text", "text": "mocked response"}]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = Client::builder()
+        .api_key(secret_key)
+        .base_url(server.uri())
+        .build()
+        .unwrap();
+
+    let request = CreateMessagesRequestBuilder::default()
+        .model("test-model".to_string())
+        .stream(true)
+        .messages(vec![
+            MessageBuilder::default()
+                .role(MessageRole::User)
+                .content("Hello world!")
+                .build()
+                .unwrap(),
+        ])
+        .build()
+        .unwrap();
+
+    let result = client.messages().create(request).await.unwrap();
+
+    if let MessageContent::Text(text) = &result.content[0] {
+        assert_eq!(text.text, "mocked response");
+    }
+}
+
+#[tokio::test]
+async fn test_with_backoff_basic() {
+    let server = TestSetup::setup().await;
+    let secret_key = "test_secret";
+
+    // Mock 429 Too Many Requests, expecting retries
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .set_body_string("Too Many Requests")
+                .set_delay(Duration::from_millis(10)),
+        )
+        .up_to_n_times(20)
+        .expect(1..)
+        .mount(&server)
+        .await;
+
+    let backoff = ExponentialBuilder::default()
+        .with_min_delay(Duration::from_millis(10))
+        .with_factor(2.0)
+        .with_max_delay(Duration::from_millis(100));
+
+    let client = Client::builder()
+        .base_url(server.uri())
+        .api_key(secret_key)
+        .build()
+        .unwrap()
+        .with_backoff(backoff);
+
+    let request = CreateMessagesRequestBuilder::default()
+        .model("test-model".to_string())
+        .stream(true)
+        .messages(vec![
+            MessageBuilder::default()
+                .role(MessageRole::User)
+                .content("Hello world!")
+                .build()
+                .unwrap(),
+        ])
+        .build()
+        .unwrap();
+
+    let result = client.messages().create(request).await;
+
+    assert!(result.is_err());
+    assert!(
+        matches!(
+            result.as_ref().unwrap_err(),
+            AnthropicError::RateLimit { .. }
+        ),
+        "actual: {:?}",
+        &result
+    );
+}
+
+pub struct RetryResponder {
+    num_calls_before_success: Arc<Mutex<u64>>,
+    calls_made: Arc<Mutex<u64>>,
+}
+
+impl RetryResponder {
+    #[must_use]
+    pub fn new(num_calls_before_success: u64) -> Self {
+        Self {
+            num_calls_before_success: Arc::new(Mutex::new(num_calls_before_success)),
+            calls_made: Arc::new(Mutex::new(0)),
+        }
+    }
+}
+
+impl wiremock::Respond for RetryResponder {
+    fn respond(&self, _: &wiremock::Request) -> ResponseTemplate {
+        let i = *self.calls_made.lock().unwrap();
+        let succ_calls = *self.num_calls_before_success.lock().unwrap();
+
+        if i < succ_calls {
+            *self.calls_made.lock().unwrap() += 1;
+            ResponseTemplate::new(429)
+                .set_body_string("Too Many Requests")
+                .set_delay(Duration::from_millis(10))
+        } else {
+            ResponseTemplate::new(200).set_body_json(json!({
+                "content": [{"type": "text", "text": "retried response"}]
+            }))
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_default_backoff_retries() {
+    let server = TestSetup::setup().await;
+    let secret_key = "test_secret";
+
+    let bad_calls = 3;
+    let expected_calls = bad_calls + 1; // + 1 good call at the end
+
+    let rr = RetryResponder::new(bad_calls);
+
+    // Mock 429 Too Many Requests, expecting retries
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(rr)
+        .expect(expected_calls)
+        .mount(&server)
+        .await;
+
+    let backoff = ExponentialBuilder::default()
+        .with_min_delay(Duration::from_millis(10))
+        .with_factor(2.0)
+        .with_max_delay(Duration::from_millis(200));
+
+    let client = Client::builder()
+        .base_url(server.uri())
+        .api_key(secret_key)
+        .build()
+        .unwrap()
+        .with_backoff(backoff);
+
+    let request = CreateMessagesRequestBuilder::default()
+        .model("test-model".to_string())
+        .stream(true)
+        .messages(vec![
+            MessageBuilder::default()
+                .role(MessageRole::User)
+                .content("Hello world!")
+                .build()
+                .unwrap(),
+        ])
+        .build()
+        .unwrap();
+
+    let result = client.messages().create(request).await;
+    assert!(result.is_ok());
+    let result = result.unwrap();
+
+    if let MessageContent::Text(text) = &result.content[0] {
+        assert_eq!(text.text, "retried response");
+    }
+}
+
+#[tokio::test]
+async fn test_error_handling_bad_request() {
+    let server = TestSetup::setup().await;
+    let secret_key = "test_secret";
+
+    // Mock 400 Bad Request response
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "message": "Bad request"
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = Client::builder()
+        .base_url(server.uri())
+        .api_key(secret_key)
+        .build()
+        .unwrap();
+
+    let request = CreateMessagesRequestBuilder::default()
+        .model("test-model".to_string())
+        .stream(true)
+        .messages(vec![
+            MessageBuilder::default()
+                .role(MessageRole::User)
+                .content("Hello world!")
+                .build()
+                .unwrap(),
+        ])
+        .build()
+        .unwrap();
+
+    let result = client.messages().create(request).await;
+
+    assert!(result.is_err());
+    assert!(
+        matches!(
+            result.as_ref().unwrap_err(),
+            AnthropicError::Api(ApiError { error_type, .. }) if error_type == "invalid_request_error"
+        ),
+        "actual: {:?}",
+        &result
+    );
+}
+
+#[tokio::test]
+async fn test_error_handling_unauthorized() {
+    let server = TestSetup::setup().await;
+    let secret_key = "test_secret";
+
+    // Mock 401 Unauthorized response
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "type": "error",
+            "error": {
+                "type": "authentication_error",
+                "message": "Unauthorized"
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = Client::builder()
+        .base_url(server.uri())
+        .api_key(secret_key)
+        .build()
+        .unwrap();
+
+    let request = CreateMessagesRequestBuilder::default()
+        .model("test-model".to_string())
+        .stream(true)
+        .messages(vec![
+            MessageBuilder::default()
+                .role(MessageRole::User)
+                .content("Hello world!")
+                .build()
+                .unwrap(),
+        ])
+        .build()
+        .unwrap();
+
+    let result = client.messages().create(request).await;
+
+    assert!(result.is_err());
+    assert!(
+        matches!(
+            result.as_ref().unwrap_err(),
+            AnthropicError::Auth {
+                status: 401,
+                error: ApiError { error_type, .. },
+            } if error_type == "authentication_error"
+        ),
+        "actual: {:?}",
+        &result
+    );
+}

--- a/crates/contrib/async-anthropic/tests/models.rs
+++ b/crates/contrib/async-anthropic/tests/models.rs
@@ -1,0 +1,164 @@
+use async_anthropic::{
+    Client,
+    errors::{AnthropicError, ApiError},
+    types::{GetModelResponse, ListModelsResponse, ModelCapabilities},
+};
+use async_trait::async_trait;
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path},
+};
+
+#[async_trait]
+pub trait MockApp {
+    async fn setup() -> MockServer;
+}
+
+struct TestSetup;
+
+#[async_trait]
+impl MockApp for TestSetup {
+    async fn setup() -> MockServer {
+        MockServer::start().await
+    }
+}
+
+#[tokio::test]
+async fn test_successful_list_models_request() {
+    let server = TestSetup::setup().await;
+    let secret_key = "test_secret";
+
+    // Mock successful list models response
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(&ListModelsResponse {
+                data: vec![],
+                first_id: Some("model_1".to_string()),
+                has_more: false,
+                last_id: Some("model_2".to_string()),
+            }),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = Client::builder()
+        .api_key(secret_key)
+        .base_url(server.uri())
+        .build()
+        .unwrap();
+
+    let result = client.models().list().await.unwrap();
+    assert_eq!(result.first_id, Some("model_1".to_string()));
+}
+
+#[tokio::test]
+async fn test_successful_get_model_request() {
+    let server = TestSetup::setup().await;
+    let secret_key = "test_secret";
+
+    // Mock successful get model response
+    Mock::given(method("GET"))
+        .and(path("/v1/models/model-id"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&GetModelResponse {
+            created_at: "2023-10-10T00:00:00Z".to_string(),
+            display_name: "Test Model".to_string(),
+            id: "model-id".to_string(),
+            model_type: "test-type".to_string(),
+            max_input_tokens: 200_000,
+            max_tokens: 8192,
+            capabilities: ModelCapabilities::default(),
+        }))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = Client::builder()
+        .api_key(secret_key)
+        .base_url(server.uri())
+        .build()
+        .unwrap();
+
+    let result = client.models().get("model-id").await.unwrap();
+    assert_eq!(result.id, "model-id");
+}
+
+#[tokio::test]
+async fn test_error_handling_bad_request() {
+    let server = TestSetup::setup().await;
+    let secret_key = "test_secret";
+
+    // Mock 400 Bad Request response
+    Mock::given(method("GET"))
+        .and(path("/v1/models/model-id"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "message": "Bad request"
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = Client::builder()
+        .base_url(server.uri())
+        .api_key(secret_key)
+        .build()
+        .unwrap();
+
+    let result = client.models().get("model-id").await;
+
+    assert!(result.is_err());
+    assert!(
+        matches!(
+            result.as_ref().unwrap_err(),
+            AnthropicError::Api(ApiError { error_type, .. }) if error_type == "invalid_request_error"
+        ),
+        "actual: {:?}",
+        &result
+    );
+}
+
+#[tokio::test]
+async fn test_error_handling_unauthorized() {
+    let server = TestSetup::setup().await;
+    let secret_key = "test_secret";
+
+    // Mock 401 Unauthorized response
+    Mock::given(method("GET"))
+        .and(path("/v1/models/model-id"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "type": "error",
+            "error": {
+                "type": "authentication_error",
+                "message": "Unauthorized"
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = Client::builder()
+        .base_url(server.uri())
+        .api_key(secret_key)
+        .build()
+        .unwrap();
+
+    let result = client.models().get("model-id").await;
+
+    assert!(result.is_err());
+    assert!(
+        matches!(
+            result.as_ref().unwrap_err(),
+            AnthropicError::Auth {
+                status: 401,
+                error: ApiError { error_type, .. },
+            } if error_type == "authentication_error"
+        ),
+        "actual: {:?}",
+        &result
+    );
+}

--- a/crates/contrib/schematic/Cargo.toml
+++ b/crates/contrib/schematic/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name = "schematic"
 description = "A layered serde configuration and schema library."
 edition = "2024"
 license = "MIT"
+name = "schematic"
 publish = false
 version = "0.19.4"
 
 [dependencies]
 schematic_macros = { path = "../schematic_macros" }
 schematic_types = { path = "../schematic_types" }
-serde-content = { workspace = true, features = ["serde", "std"] }
 serde = { workspace = true, features = ["derive", "std"] }
+serde-content = { workspace = true, features = ["serde", "std"] }
 thiserror = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 
@@ -18,7 +18,6 @@ tracing = { workspace = true, features = ["attributes"] }
 serde_path_to_error = { workspace = true, optional = true }
 
 # schema
-convert_case = { workspace = true, optional = true }
 indexmap = { workspace = true, optional = true, features = ["serde", "std"] }
 
 # json
@@ -39,7 +38,7 @@ schematic = { path = ".", features = ["schema"] }
 [features]
 default = ["config", "env"]
 config = ["dep:serde_path_to_error", "schematic_macros/config"]
-schema = ["dep:convert_case", "dep:indexmap", "schematic_macros/schema"]
+schema = ["dep:indexmap", "schematic_macros/schema"]
 schema_serde = ["schema", "schematic_types/serde"]
 
 # Features

--- a/crates/jp_cli/Cargo.toml
+++ b/crates/jp_cli/Cargo.toml
@@ -25,6 +25,7 @@ jp_attachment_internal = { workspace = true }
 jp_attachment_mcp_resources = { workspace = true }
 jp_config = { workspace = true }
 jp_conversation = { workspace = true }
+jp_credentials = { workspace = true }
 jp_editor = { workspace = true }
 jp_id = { workspace = true }
 jp_inquire = { workspace = true }
@@ -118,6 +119,7 @@ chrono = { workspace = true }
 [dev-dependencies]
 assert_matches = { workspace = true }
 camino-tempfile = { workspace = true }
+datetime_literal = { workspace = true }
 indoc = { workspace = true }
 insta = { workspace = true }
 pretty_assertions = { workspace = true, features = ["std"] }

--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -7,6 +7,7 @@ mod init;
 pub(crate) mod label;
 mod lock;
 pub(crate) mod plugin;
+mod provider;
 mod query;
 pub(crate) mod target;
 pub(crate) mod time;
@@ -56,6 +57,9 @@ pub(crate) enum Commands {
     #[command(visible_alias = "w", alias = "workspaces")]
     Workspace(workspace::Workspace),
 
+    /// Manage provider credentials.
+    Provider(provider::Provider),
+
     /// External plugin subcommand (`jp-<name>` on $PATH or registry).
     #[command(external_subcommand)]
     External(Vec<String>),
@@ -89,7 +93,7 @@ impl Commands {
             }
             Commands::Plugin(args) => args.run(ctx).await,
             Commands::External(args) => plugin::dispatch::run_external(&args, ctx).await,
-            Commands::Init(_) | Commands::Workspace(_) => {
+            Commands::Init(_) | Commands::Provider(_) | Commands::Workspace(_) => {
                 unreachable!("handled before workspace initialization")
             }
         }
@@ -106,6 +110,7 @@ impl Commands {
             | Commands::Attachment(_)
             | Commands::AttachmentAdd(_)
             | Commands::Plugin(_)
+            | Commands::Provider(_)
             | Commands::Workspace(_)
             | Commands::External(_) => ConversationLoadRequest::none(),
         }
@@ -118,7 +123,9 @@ impl Commands {
     /// it.
     pub(crate) fn workspace_requirement(&self) -> WorkspaceRequirement {
         match self {
-            Commands::Init(_) => WorkspaceRequirement::None,
+            // Credentials are user-global, so the auth commands need no
+            // workspace at all.
+            Commands::Init(_) | Commands::Provider(_) => WorkspaceRequirement::None,
             Commands::Workspace(args) => args.workspace_requirement(),
             Commands::Query(_)
             | Commands::Config(_)
@@ -148,6 +155,7 @@ impl Commands {
             Commands::Init(_) => "init",
             Commands::Conversation(_) => "conversation",
             Commands::Plugin(_) => "plugin",
+            Commands::Provider(_) => "provider",
             Commands::Workspace(_) => "workspace",
             Commands::External(args) => {
                 // Use first arg as the command name (it's the subcommand name).
@@ -181,6 +189,7 @@ impl IntoPartialAppConfig for Commands {
             Commands::Config(_)
             | Commands::Init(_)
             | Commands::Plugin(_)
+            | Commands::Provider(_)
             | Commands::Workspace(_)
             | Commands::External(_) => Ok(partial),
         }
@@ -203,6 +212,7 @@ impl IntoPartialAppConfig for Commands {
             | Commands::Conversation(_)
             | Commands::Init(_)
             | Commands::Plugin(_)
+            | Commands::Provider(_)
             | Commands::Workspace(_)
             | Commands::External(_) => Ok(partial),
         }
@@ -433,6 +443,7 @@ impl From<crate::error::Error> for Error {
         let metadata: Vec<(&str, String)> = match error {
             Command(error) => return error,
             Config(error) => return error.into(),
+            Credentials(error) => with_cause(&error, "Credential store error"),
             KeyValue(error) => return error.into(),
             Workspace(error) => return error.into(),
             Conversation(error) => return error.into(),
@@ -479,7 +490,7 @@ impl From<crate::error::Error> for Error {
             ]
             .into(),
             InquiryModelOverride { model, source } => {
-                let mut meta = with_cause(&source, "Inquiry model override is unusable");
+                let mut meta = with_cause(source.as_ref(), "Inquiry model override is unusable");
                 meta.insert(1, ("model", model));
                 meta.push((
                     "suggestion",
@@ -747,6 +758,7 @@ impl From<jp_llm::Error> for Error {
                 ("variable", variable),
             ]
             .into(),
+            CredentialChain(error) => with_cause(&error, "No usable credential"),
             InvalidResponse(error) => [
                 ("message", "Invalid response received".into()),
                 ("error", error),

--- a/crates/jp_cli/src/cmd/conversation/summarize.rs
+++ b/crates/jp_cli/src/cmd/conversation/summarize.rs
@@ -267,6 +267,7 @@ fn summarize_events(events: Vec<Event>) -> StreamOutcome {
             Event::Patch(mut p) => patches.append(&mut p),
             // `KeepAlive` is a liveness signal.
             Event::KeepAlive => {}
+            Event::Notice(notice) => tracing::warn!("{notice}"),
         }
     }
 

--- a/crates/jp_cli/src/cmd/provider.rs
+++ b/crates/jp_cli/src/cmd/provider.rs
@@ -1,0 +1,481 @@
+//! Provider credential management: `jp provider auth login|list|logout`.
+//!
+//! Credentials are user-global, so these commands bypass workspace discovery
+//! entirely (the same startup exception `jp init` uses) and work from any
+//! directory.
+//! `list` and `logout` require no TTY and are safe to script; `login` reads its
+//! setup token from stdin, never from process arguments.
+
+use std::{
+    fmt,
+    io::{self, BufRead as _, IsTerminal as _},
+    str::FromStr,
+};
+
+use chrono::{DateTime, Utc};
+use comfy_table::{Cell, Row};
+use jp_config::model::id::ProviderId;
+use jp_credentials::{
+    CATEGORY_LLM, CredentialSecret, CredentialStore, StoreError, StoredCredential,
+};
+use jp_printer::Printer;
+
+use crate::{
+    cmd::{Error, Output},
+    error::error_chain,
+    output::print_table,
+};
+
+/// `jp provider` subcommand group.
+#[derive(Debug, clap::Args)]
+pub(crate) struct Provider {
+    #[command(subcommand)]
+    command: ProviderCmd,
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum ProviderCmd {
+    /// Manage stored provider credentials.
+    Auth(Auth),
+}
+
+#[derive(Debug, clap::Args)]
+struct Auth {
+    #[command(subcommand)]
+    command: AuthCmd,
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum AuthCmd {
+    /// Log in to a provider and store the credential as a profile.
+    Login(Login),
+
+    /// List stored credential profiles and their state.
+    #[command(visible_alias = "ls")]
+    List(List),
+
+    /// Remove a stored credential profile.
+    Logout(Logout),
+}
+
+#[derive(Debug, clap::Args)]
+struct Login {
+    /// The provider to log in to.
+    ///
+    /// Only `llm.anthropic` is supported.
+    target: AuthTarget,
+
+    /// The profile name to store the credential under.
+    #[arg(long, default_value = "default")]
+    profile: String,
+
+    /// Store a long-lived setup token read from the first line of stdin,
+    /// instead of running the browser login.
+    ///
+    /// Run the provider's token command, then paste the value it prints at JP's
+    /// prompt; the prompt names the command and the token's shape.
+    /// A token command that runs interactively cannot be the source of a pipe,
+    /// since a pipeline's stages all start at once; piping from a
+    /// non-interactive source (a clipboard tool, a file) works.
+    #[arg(long)]
+    setup_token: bool,
+}
+
+#[derive(Debug, clap::Args)]
+struct List {}
+
+#[derive(Debug, clap::Args)]
+struct Logout {
+    /// The provider to log out of.
+    ///
+    /// Only `llm.anthropic` is supported.
+    target: AuthTarget,
+
+    /// The profile to remove.
+    ///
+    /// When omitted, removes the sole stored profile.
+    #[arg(long)]
+    profile: Option<String>,
+}
+
+/// A provider that supports stored credentials, as `<category>.<provider>`.
+///
+/// Parsing accepts exactly the providers for which [`jp_llm::provider_auth`]
+/// reports credential mechanics; the store key is derived from the provider id.
+#[derive(Debug, Clone, Copy)]
+struct AuthTarget {
+    provider: ProviderId,
+}
+
+impl AuthTarget {
+    /// The provider's key in the credential store.
+    fn store_key(self) -> String {
+        self.provider.to_string()
+    }
+}
+
+impl fmt::Display for AuthTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{CATEGORY_LLM}.{}", self.provider)
+    }
+}
+
+impl FromStr for AuthTarget {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let Some((category, provider)) = s.split_once('.') else {
+            return Err(format!(
+                "invalid provider {s:?}: expected `<category>.<provider>`, e.g. `llm.anthropic`"
+            ));
+        };
+
+        if category != CATEGORY_LLM {
+            return Err(format!(
+                "unsupported category {category:?}: only `llm` providers store credentials"
+            ));
+        }
+
+        let provider: ProviderId = provider
+            .parse()
+            .map_err(|_| format!("unknown provider {provider:?}"))?;
+
+        if jp_llm::provider_auth(provider).is_none() {
+            return Err(format!(
+                "provider `{s}` does not support stored credentials"
+            ));
+        }
+
+        Ok(Self { provider })
+    }
+}
+
+impl Provider {
+    /// Run the command against the user-global credential store.
+    ///
+    /// Runs before workspace discovery; only `login` needs an async runtime
+    /// (for identity recovery), built here on demand.
+    pub(crate) fn run(&self, printer: &Printer) -> Output {
+        let ProviderCmd::Auth(auth) = &self.command;
+        let store = CredentialStore::file_default().map_err(|e| store_error(&e))?;
+
+        match &auth.command {
+            AuthCmd::Login(args) => {
+                let runtime = crate::build_runtime(None, "jp-provider-auth")
+                    .map_err(crate::cmd::Error::from)?;
+                runtime.block_on(args.run(&store, printer))
+            }
+            AuthCmd::List(args) => args.run(&store, printer),
+            AuthCmd::Logout(args) => args.run(&store, printer),
+        }
+    }
+}
+
+impl Login {
+    async fn run(&self, store: &CredentialStore, printer: &Printer) -> Output {
+        let auth = jp_llm::provider_auth(self.target.provider)
+            .expect("AuthTarget parsing guarantees stored-credential support");
+
+        if !self.setup_token {
+            return Err(Error::from(format!(
+                "browser login is not implemented yet; pass a setup token on stdin with \
+                 `--setup-token`. {}",
+                auth.setup_token_hint()
+            )));
+        }
+
+        if self.profile.is_empty() || self.profile.chars().any(char::is_whitespace) {
+            return Err(Error::from(format!(
+                "invalid profile name {:?}: must be non-empty and contain no whitespace",
+                self.profile
+            )));
+        }
+
+        let token = read_setup_token(printer, auth.setup_token_hint())?;
+
+        // Best-effort identity recovery: a failure stores the profile
+        // unverified instead of blocking the login.
+        let identity = auth.recover_identity(&token).await;
+
+        let profile = self.profile.clone();
+        let target = self.target;
+        let (account_id, email, recovery_error) = match identity {
+            Ok(identity) => (identity.account_id, identity.email, None),
+            Err(error) => (None, None, Some(error_chain(error.as_ref()))),
+        };
+
+        store
+            .mutate(|document| {
+                // Refuse to store the same account under two profiles,
+                // keyed on the account UUID; without a UUID the check is
+                // skipped and the duplicate check runs if the identity is
+                // recovered later.
+                if let Some(account_id) = &account_id
+                    && let Some(profiles) = document.profiles(CATEGORY_LLM, &target.store_key())
+                    && let Some((existing, _)) = profiles.iter().find(|(name, credential)| {
+                        **name != profile && credential.account_id.as_deref() == Some(account_id)
+                    })
+                {
+                    return Err(StoreError::Rejected(format!(
+                        "account {account_id} is already stored as profile {existing:?}; run `jp \
+                         provider auth logout {target} --profile {existing}` first, or use that \
+                         profile"
+                    )));
+                }
+
+                document.insert_profile(
+                    CATEGORY_LLM,
+                    &target.store_key(),
+                    &profile,
+                    StoredCredential {
+                        secret: CredentialSecret::Token {
+                            token: token.clone(),
+                        },
+                        account_id: account_id.clone(),
+                        email: email.clone(),
+                        cooldowns: std::collections::BTreeMap::new(),
+                        needs_relogin: false,
+                    },
+                );
+
+                Ok(())
+            })
+            .map_err(|e| store_error(&e))?;
+
+        match (&account_id, recovery_error) {
+            (Some(account_id), _) => printer.println(format!(
+                "Linked {target} profile {:?} to {} (account {account_id}).",
+                self.profile,
+                email.as_deref().unwrap_or("<no email>"),
+            )),
+            // An unattributable credential is a normal outcome, not a
+            // misconfiguration: a credential whose scopes don't permit an
+            // identity lookup can still authenticate requests.
+            (None, error) => printer.println(format!(
+                "Stored {target} profile {:?}, unverified: JP could not determine which account \
+                 this credential belongs to, so duplicate-account detection is skipped for it. \
+                 The profile is usable. Details: {}",
+                self.profile,
+                error.unwrap_or_else(|| "no account identity in the response".to_owned()),
+            )),
+        }
+
+        Ok(())
+    }
+}
+
+impl List {
+    #[expect(clippy::unused_self)]
+    fn run(&self, store: &CredentialStore, printer: &Printer) -> Output {
+        let document = store.load().map_err(|e| store_error(&e))?;
+        let now = Utc::now();
+
+        let mut header = Row::new();
+        for label in ["Provider", "Profile", "Type", "Account", "State"] {
+            header.add_cell(Cell::new(label));
+        }
+
+        let mut rows = Vec::new();
+        let mut payload = Vec::new();
+
+        for (category, provider, profile, credential) in document.iter() {
+            let target = format!("{category}.{provider}");
+            let account = credential
+                .email
+                .as_deref()
+                .or(credential.account_id.as_deref());
+            let state = credential_state(credential, now);
+
+            let mut row = Row::new();
+            row.add_cell(Cell::new(&target));
+            row.add_cell(Cell::new(profile));
+            row.add_cell(Cell::new(credential.secret.kind()));
+            row.add_cell(Cell::new(account.unwrap_or_default()));
+            row.add_cell(Cell::new(&state));
+            rows.push(row);
+
+            // Keyed by column heading, matching what the table renders.
+            payload.push(serde_json::json!({
+                "Provider": target,
+                "Profile": profile,
+                "Type": credential.secret.kind(),
+                "Account": account.unwrap_or_default(),
+                "State": state,
+            }));
+        }
+
+        print_table(
+            printer,
+            header,
+            rows,
+            false,
+            &serde_json::Value::Array(payload),
+        );
+        Ok(())
+    }
+}
+
+impl Logout {
+    fn run(&self, store: &CredentialStore, printer: &Printer) -> Output {
+        let target = self.target;
+        let profile = self.profile.clone();
+
+        let removed = store
+            .mutate(|document| {
+                let profiles = document
+                    .profiles(CATEGORY_LLM, &target.store_key())
+                    .map(|profiles| profiles.keys().cloned().collect::<Vec<_>>())
+                    .unwrap_or_default();
+
+                let profile = match &profile {
+                    Some(profile) => profile.clone(),
+                    None if profiles.len() == 1 => profiles[0].clone(),
+                    None if profiles.is_empty() => {
+                        return Err(StoreError::Rejected(format!(
+                            "no stored profiles for {target}"
+                        )));
+                    }
+                    None => {
+                        return Err(StoreError::Rejected(format!(
+                            "multiple profiles stored for {target} ({}); name one with --profile \
+                             <name>",
+                            profiles.join(", ")
+                        )));
+                    }
+                };
+
+                document
+                    .remove_profile(CATEGORY_LLM, &target.store_key(), &profile)
+                    .ok_or_else(|| {
+                        StoreError::Rejected(format!(
+                            "no stored profile {profile:?} for {target}{}",
+                            if profiles.is_empty() {
+                                String::new()
+                            } else {
+                                format!(" (stored: {})", profiles.join(", "))
+                            }
+                        ))
+                    })?;
+
+                Ok(profile)
+            })
+            .map_err(|e| store_error(&e))?;
+
+        printer.println(format!("Removed {target} profile {removed:?}."));
+        Ok(())
+    }
+}
+
+/// Read the setup token from the first line of stdin.
+///
+/// Tokens are never accepted as process arguments, which leak into shell
+/// history and `ps` output.
+fn read_setup_token(printer: &Printer, hint: &str) -> Result<String, Error> {
+    if io::stdin().is_terminal() {
+        printer.eprintln(format!("Paste the setup token and press Enter.\n{hint}"));
+    }
+
+    let mut raw = String::new();
+    io::stdin()
+        .lock()
+        .read_line(&mut raw)
+        .map_err(|error| Error::from(format!("failed to read setup token from stdin: {error}")))?;
+
+    sanitize_setup_token(&raw, hint).map_err(Error::from)
+}
+
+/// Turn a raw line of token input into a usable token.
+///
+/// The token is sent to the provider as a bearer credential in an HTTP header,
+/// so it must survive that trip.
+/// ANSI styling from a decorated command run is stripped; input that still
+/// cannot be a bearer token is rejected here, naming what is wrong, rather than
+/// deep inside the HTTP client where it surfaces as an opaque `builder error`.
+///
+/// The rejected shapes are the ones a mis-captured pipeline produces: a
+/// progress line, a prompt, or a banner picked up instead of the token.
+/// The input is never echoed back, since a valid token is a secret.
+fn sanitize_setup_token(raw: &str, hint: &str) -> Result<String, String> {
+    let hint = format!("JP reads the token from the first line of stdin. {hint}");
+
+    // Interior carriage returns are checked before ANSI stripping, which
+    // discards them: a progress line that overwrites itself would otherwise
+    // have its segments spliced into one plausible-looking token.
+    let line = raw.trim_end_matches(['\n', '\r']);
+    if line.contains('\r') {
+        return Err(format!(
+            "the input is not a setup token: it contains a carriage return, so it looks like a \
+             progress line rather than a credential. {hint}"
+        ));
+    }
+
+    let token = strip_ansi_escapes::strip_str(line).trim().to_owned();
+
+    if token.is_empty() {
+        return Err("no setup token provided on stdin".to_owned());
+    }
+
+    // Bearer tokens are a single opaque string (RFC 6750): no whitespace, no
+    // control characters, no non-ASCII.
+    if token.chars().any(char::is_whitespace) {
+        return Err(format!(
+            "the input is not a setup token: it contains whitespace, so it looks like a prompt or \
+             a message rather than a credential. {hint}"
+        ));
+    }
+
+    if let Some(bad) = token.chars().find(|c| c.is_control() || !c.is_ascii()) {
+        return Err(format!(
+            "the input is not a setup token: it contains the character {bad:?}, which cannot be \
+             sent in an HTTP header. {hint}"
+        ));
+    }
+
+    Ok(token)
+}
+
+/// The display state of a stored credential, for `jp provider auth list`.
+///
+/// A static `token` credential has no expiry JP can inspect, so it is reported
+/// as plain `valid`, never as expired or refreshable.
+fn credential_state(credential: &StoredCredential, now: DateTime<Utc>) -> String {
+    let mut parts = vec![];
+
+    if credential.needs_relogin {
+        parts.push("needs re-login".to_owned());
+    } else if let CredentialSecret::Oauth { expires_at, .. } = &credential.secret {
+        if *expires_at <= now {
+            parts.push("expired".to_owned());
+        } else {
+            parts.push(format!("valid (expires {expires_at})"));
+        }
+    }
+
+    for (scope, expires) in &credential.cooldowns {
+        if *expires > now {
+            parts.push(format!("cooling down until {expires} ({scope})"));
+        }
+    }
+
+    if credential.account_id.is_none() {
+        parts.push(if credential.needs_relogin {
+            "unverified".to_owned()
+        } else {
+            "unverified (usable)".to_owned()
+        });
+    }
+
+    if parts.is_empty() {
+        return "valid".to_owned();
+    }
+
+    parts.join(", ")
+}
+
+fn store_error(error: &StoreError) -> Error {
+    Error::from(error.to_string())
+}
+
+#[cfg(test)]
+#[path = "provider_tests.rs"]
+mod tests;

--- a/crates/jp_cli/src/cmd/provider_tests.rs
+++ b/crates/jp_cli/src/cmd/provider_tests.rs
@@ -1,0 +1,344 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use camino_tempfile::Utf8TempDir;
+use datetime_literal::datetime;
+use jp_credentials::{FsCredentialBackend, PROVIDER_ANTHROPIC};
+use jp_printer::{OutputFormat, Printer};
+use jp_storage::resource_lock::FsResourceLocker;
+use test_log::test;
+
+use super::*;
+
+fn anthropic_target() -> AuthTarget {
+    AuthTarget {
+        provider: ProviderId::Anthropic,
+    }
+}
+
+fn token_profile(token: &str, account_id: Option<&str>) -> StoredCredential {
+    StoredCredential {
+        secret: CredentialSecret::Token {
+            token: token.to_owned(),
+        },
+        account_id: account_id.map(str::to_owned),
+        email: account_id.map(|_| "jean@example.com".to_owned()),
+        cooldowns: BTreeMap::new(),
+        needs_relogin: false,
+    }
+}
+
+fn store_at(dir: &Utf8TempDir) -> CredentialStore {
+    CredentialStore::new(
+        Arc::new(FsCredentialBackend::new(
+            dir.path().join("credentials.json"),
+        )),
+        Arc::new(FsResourceLocker::new(dir.path().to_owned())),
+    )
+}
+
+#[test]
+fn test_auth_target_parses_only_supported_providers() {
+    assert_eq!(
+        "llm.anthropic".parse::<AuthTarget>().unwrap().provider,
+        ProviderId::Anthropic
+    );
+
+    // Real providers without stored-credential support, unknown providers,
+    // unknown categories, and non-dotted forms are all rejected.
+    for input in ["llm.openai", "llm.bogus", "tts.anthropic", "anthropic"] {
+        assert!(input.parse::<AuthTarget>().is_err(), "input: {input:?}");
+    }
+}
+
+#[test]
+fn test_auth_target_store_key_matches_resolver_key() {
+    // `resolve` looks profiles up under this constant; the auth commands
+    // derive the same key from the provider id. The two must agree or
+    // logins would store profiles resolution never finds.
+    assert_eq!(anthropic_target().store_key(), PROVIDER_ANTHROPIC);
+}
+
+#[test]
+fn test_list_empty_store_renders_empty_json_array() {
+    let dir = Utf8TempDir::new().unwrap();
+    let (printer, out, _err) = Printer::memory(OutputFormat::Json);
+
+    List {}.run(&store_at(&dir), &printer).unwrap();
+    printer.shutdown();
+
+    assert_eq!(out.lock().trim(), "[]");
+}
+
+#[test]
+fn test_list_renders_profiles_and_states_as_json() {
+    let dir = Utf8TempDir::new().unwrap();
+    let store = store_at(&dir);
+
+    store
+        .mutate(|document| {
+            document.insert_profile(
+                CATEGORY_LLM,
+                PROVIDER_ANTHROPIC,
+                "personal",
+                token_profile("sk-a", Some("uuid-1")),
+            );
+            document.insert_profile(
+                CATEGORY_LLM,
+                PROVIDER_ANTHROPIC,
+                "ci",
+                token_profile("sk-b", None),
+            );
+            Ok(())
+        })
+        .unwrap();
+
+    let (printer, out, _err) = Printer::memory(OutputFormat::Json);
+    List {}.run(&store, &printer).unwrap();
+    printer.shutdown();
+
+    let expected = r#"[{"Provider":"llm.anthropic","Profile":"ci","Type":"token","Account":"","State":"unverified (usable)"},{"Provider":"llm.anthropic","Profile":"personal","Type":"token","Account":"jean@example.com","State":"valid"}]"#;
+    assert_eq!(out.lock().trim(), expected);
+}
+
+#[test]
+fn test_list_renders_markdown_table_when_piped() {
+    let dir = Utf8TempDir::new().unwrap();
+    let store = store_at(&dir);
+
+    store
+        .mutate(|document| {
+            document.insert_profile(
+                CATEGORY_LLM,
+                PROVIDER_ANTHROPIC,
+                "personal",
+                token_profile("sk-a", Some("uuid-1")),
+            );
+            Ok(())
+        })
+        .unwrap();
+
+    let (printer, out, _err) = Printer::memory(OutputFormat::Text);
+    List {}.run(&store, &printer).unwrap();
+    printer.shutdown();
+
+    let output = out.lock().clone();
+    assert!(
+        output.starts_with("| Provider "),
+        "expected a markdown table, got: {output}"
+    );
+    assert!(output.contains("| llm.anthropic |"), "{output}");
+}
+
+#[test]
+fn test_logout_removes_sole_profile_without_name() {
+    let dir = Utf8TempDir::new().unwrap();
+    let store = store_at(&dir);
+
+    store
+        .mutate(|document| {
+            document.insert_profile(
+                CATEGORY_LLM,
+                PROVIDER_ANTHROPIC,
+                "personal",
+                token_profile("sk-a", Some("uuid-1")),
+            );
+            Ok(())
+        })
+        .unwrap();
+
+    let (printer, out, _err) = Printer::memory(OutputFormat::Text);
+    Logout {
+        target: anthropic_target(),
+        profile: None,
+    }
+    .run(&store, &printer)
+    .unwrap();
+    printer.shutdown();
+
+    assert_eq!(
+        out.lock().trim(),
+        r#"Removed llm.anthropic profile "personal"."#
+    );
+    assert_eq!(store.load().unwrap().iter().count(), 0);
+}
+
+#[test]
+fn test_logout_requires_profile_name_when_ambiguous() {
+    let dir = Utf8TempDir::new().unwrap();
+    let store = store_at(&dir);
+
+    store
+        .mutate(|document| {
+            document.insert_profile(
+                CATEGORY_LLM,
+                PROVIDER_ANTHROPIC,
+                "personal",
+                token_profile("sk-a", Some("uuid-1")),
+            );
+            document.insert_profile(
+                CATEGORY_LLM,
+                PROVIDER_ANTHROPIC,
+                "work",
+                token_profile("sk-b", Some("uuid-2")),
+            );
+            Ok(())
+        })
+        .unwrap();
+
+    let (printer, _out, _err) = Printer::memory(OutputFormat::Text);
+    let error = Logout {
+        target: anthropic_target(),
+        profile: None,
+    }
+    .run(&store, &printer)
+    .unwrap_err();
+    printer.shutdown();
+
+    assert!(error.to_string().contains("multiple profiles stored"));
+    assert_eq!(store.load().unwrap().iter().count(), 2);
+}
+
+#[test]
+fn test_logout_unknown_profile_names_stored_ones() {
+    let dir = Utf8TempDir::new().unwrap();
+    let store = store_at(&dir);
+
+    store
+        .mutate(|document| {
+            document.insert_profile(
+                CATEGORY_LLM,
+                PROVIDER_ANTHROPIC,
+                "personal",
+                token_profile("sk-a", Some("uuid-1")),
+            );
+            Ok(())
+        })
+        .unwrap();
+
+    let (printer, _out, _err) = Printer::memory(OutputFormat::Text);
+    let error = Logout {
+        target: anthropic_target(),
+        profile: Some("work".to_owned()),
+    }
+    .run(&store, &printer)
+    .unwrap_err();
+    printer.shutdown();
+
+    let message = error.to_string();
+    assert!(message.contains(r#"no stored profile "work""#), "{message}");
+    assert!(message.contains("personal"), "{message}");
+}
+
+#[test]
+fn test_sanitize_setup_token() {
+    // Provider-supplied guidance, appended to every rejection so the user is
+    // told how to obtain a token for the provider they named.
+    const HINT: &str = "Run the token command and paste its value.";
+
+    // Plain tokens pass through, trimmed.
+    assert_eq!(
+        sanitize_setup_token("sk-ant-oat01-abc123\n", HINT).unwrap(),
+        "sk-ant-oat01-abc123"
+    );
+
+    // ANSI styling from a decorated `claude setup-token` run is stripped:
+    // the escapes are exactly what made the HTTP client reject the header.
+    assert_eq!(
+        sanitize_setup_token("\u{1b}[32msk-ant-oat01-abc123\u{1b}[0m\n", HINT).unwrap(),
+        "sk-ant-oat01-abc123"
+    );
+
+    // Empty input is named as such.
+    let error = sanitize_setup_token("   \n", HINT).unwrap_err();
+    assert_eq!(error, "no setup token provided on stdin");
+
+    // The exact failure a raw `claude setup-token` pipe produces: its first
+    // line is a colorized banner, whose ANSI escapes made the HTTP client
+    // reject the header with an opaque `builder error`. Stripping leaves
+    // the banner text, which the whitespace check names.
+    let error = sanitize_setup_token("\u{1b}[1mWelcome to Claude Code v2.1.92\u{1b}[0m\n", HINT)
+        .unwrap_err();
+    assert!(error.contains("contains whitespace"), "{error}");
+    // Every rejection carries the provider's own guidance.
+    assert!(error.contains("first line of stdin"), "{error}");
+    assert!(error.contains(HINT), "{error}");
+    // The input is never echoed back: a valid token is a secret.
+    assert!(
+        !error.contains("Welcome"),
+        "input must not be echoed: {error}"
+    );
+
+    // A spinner frame or other decoration left after ANSI stripping is
+    // rejected with the offending character, not passed on to fail opaquely
+    // inside the HTTP client.
+    let error = sanitize_setup_token("\u{280b}token\n", HINT).unwrap_err();
+    assert!(
+        error.contains("cannot be sent in an HTTP header"),
+        "{error}"
+    );
+    assert!(error.contains("'\u{280b}'"), "{error}");
+
+    // A spinner overwriting itself with a lone carriage return: ANSI
+    // stripping discards the `\r`, which would splice the segments into a
+    // plausible-looking token, so this is rejected before stripping.
+    let error = sanitize_setup_token("working\rsk-ant-oat01-abc\n", HINT).unwrap_err();
+    assert!(error.contains("contains a carriage return"), "{error}");
+
+    // A CRLF line ending is just a line ending, not an overwrite.
+    assert_eq!(
+        sanitize_setup_token("sk-ant-oat01-abc123\r\n", HINT).unwrap(),
+        "sk-ant-oat01-abc123"
+    );
+}
+
+#[test]
+fn test_credential_state_variants() {
+    let now = datetime!(2026-07-03 12:00:00 Z);
+
+    let valid = token_profile("sk-a", Some("uuid-1"));
+    assert_eq!(credential_state(&valid, now), "valid");
+
+    let unverified = token_profile("sk-a", None);
+    assert_eq!(credential_state(&unverified, now), "unverified (usable)");
+
+    let mut relogin = token_profile("sk-a", None);
+    relogin.needs_relogin = true;
+    assert_eq!(
+        credential_state(&relogin, now),
+        "needs re-login, unverified"
+    );
+
+    let mut cooling = token_profile("sk-a", Some("uuid-1"));
+    cooling
+        .cooldowns
+        .insert("opus".to_owned(), datetime!(2026-07-03 13:00:00 Z));
+    assert_eq!(
+        credential_state(&cooling, now),
+        "cooling down until 2026-07-03 13:00:00 UTC (opus)"
+    );
+
+    let mut oauth = StoredCredential {
+        secret: CredentialSecret::Oauth {
+            access_token: "at".to_owned(),
+            refresh_token: "rt".to_owned(),
+            expires_at: datetime!(2026-07-03 11:00:00 Z),
+        },
+        account_id: Some("uuid-1".to_owned()),
+        email: None,
+        cooldowns: BTreeMap::new(),
+        needs_relogin: false,
+    };
+    assert_eq!(credential_state(&oauth, now), "expired");
+
+    // A live OAuth credential reports its expiry; a static token has none
+    // to report and stays plain "valid".
+    oauth.secret = CredentialSecret::Oauth {
+        access_token: "at".to_owned(),
+        refresh_token: "rt".to_owned(),
+        expires_at: datetime!(2026-07-03 13:00:00 Z),
+    };
+    assert_eq!(
+        credential_state(&oauth, now),
+        "valid (expires 2026-07-03 13:00:00 UTC)"
+    );
+}

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -442,19 +442,17 @@ impl Query {
         }
 
         // Fail fast on provider misconfiguration (e.g. a missing API key
-        // environment variable) before any side-effectful work below:
-        // pre-query compaction can run a full summary LLM round-trip, MCP
-        // servers boot in background tasks, the editor may open to compose
-        // the request, and title generation and attachment loading are all
+        // environment variable, or a credential chain with no usable
+        // entry) before any side-effectful work below: pre-query
+        // compaction can run a full summary LLM round-trip, MCP servers
+        // boot in background tasks, the editor may open to compose the
+        // request, and title generation and attachment loading are all
         // wasted — and the title task alone can hold the run open for
         // seconds at teardown — when the request can never be sent.
         // `Query::run_turn` repeats this check implicitly when it constructs
         // the live provider.
-        provider::preflight(
-            cfg.assistant.model.id.resolved().provider,
-            &cfg.providers.llm,
-        )
-        .map_err(Error::from)?;
+        let model_id = cfg.assistant.model.id.resolved();
+        provider::preflight(model_id.provider, &cfg.providers.llm)?;
 
         // Compact the conversation before querying, if requested.
         if self.compact.should_compact() {
@@ -1056,10 +1054,12 @@ impl Query {
         mut turn_interrupt: TurnInterrupt,
     ) -> Result<()> {
         let model_id = cfg.assistant.model.id.resolved();
+
         let provider: Arc<dyn jp_llm::Provider> = Arc::from(provider::get_provider(
             model_id.provider,
             &cfg.providers.llm,
         )?);
+
         debug!(model = %model_id, "Fetching model details.");
 
         // A network round trip, and the last await before the turn loop starts

--- a/crates/jp_cli/src/cmd/query/turn/coordinator.rs
+++ b/crates/jp_cli/src/cmd/query/turn/coordinator.rs
@@ -376,6 +376,14 @@ impl TurnCoordinator {
             // Patch is handled by the caller before reaching here; KeepAlive is
             // a liveness signal with nothing to record or render.
             Event::Patch(_) | Event::KeepAlive => HandleEventOutcome::new(Action::Continue),
+
+            // A provider decision the user must see (a skipped credential, a
+            // credential switch): chrome on stderr, never part of the
+            // conversation.
+            Event::Notice(notice) => {
+                self.printer.eprintln(notice);
+                HandleEventOutcome::new(Action::Continue)
+            }
         }
     }
 

--- a/crates/jp_cli/src/cmd/query/turn_loop.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop.rs
@@ -466,6 +466,7 @@ pub(super) async fn run_turn_loop(
                                     .await
                                     {
                                         StreamErrorOutcome::Retry => break,
+
                                         StreamErrorOutcome::Fatal(error) => {
                                             // Persist any partial content
                                             // flushed before aborting, so a
@@ -545,7 +546,12 @@ pub(super) async fn run_turn_loop(
                             let advances_cycle = match &event {
                                 Event::Part { .. } => true,
                                 Event::Finished(reason) => *reason != FinishReason::Retry,
-                                Event::Flush { .. } | Event::Patch(_) | Event::KeepAlive => false,
+                                // A notice is chrome: it says nothing about
+                                // the provider having produced content.
+                                Event::Flush { .. }
+                                | Event::Patch(_)
+                                | Event::KeepAlive
+                                | Event::Notice(_) => false,
                             };
                             if !received_provider_event && advances_cycle {
                                 received_provider_event = true;
@@ -967,22 +973,21 @@ async fn build_inquiry_backend(
         // Attribute failures to the override: without this, e.g. a missing
         // API key environment variable renders identically to a main-model
         // failure and points the user at the wrong config.
+        let wrap_err =
+            |source: Box<dyn std::error::Error + Send + Sync>| Error::InquiryModelOverride {
+                model: inquiry_model_id.to_string(),
+                source,
+            };
+
         let inquiry_provider: Arc<dyn Provider> = Arc::from(
-            get_provider(inquiry_model_id.provider, &cfg.providers.llm).map_err(|source| {
-                Error::InquiryModelOverride {
-                    model: inquiry_model_id.to_string(),
-                    source,
-                }
-            })?,
+            get_provider(inquiry_model_id.provider, &cfg.providers.llm)
+                .map_err(|e| wrap_err(Box::new(e)))?,
         );
         debug!(model = %inquiry_model_id, "Fetching inquiry model details.");
         let inquiry_model = inquiry_provider
             .model_details(&inquiry_model_id.name)
             .await
-            .map_err(|source| Error::InquiryModelOverride {
-                model: inquiry_model_id.to_string(),
-                source,
-            })?;
+            .map_err(|e| wrap_err(Box::new(e)))?;
 
         if inquiry_model.structured_output == Some(false) {
             warn!(
@@ -1051,24 +1056,30 @@ async fn build_inquiry_overrides(
                 // this, e.g. a missing API key environment variable renders
                 // identically to a main-model failure and points the user at
                 // the wrong config.
-                let wrap_err = |source| Error::InquiryQuestionModelOverride {
-                    tool: tool_name.to_owned(),
-                    question: question_id.clone(),
-                    model: model_id.to_string(),
-                    source: Box::new(source),
+                let wrap_err = |source: Box<dyn std::error::Error + Send + Sync>| {
+                    Error::InquiryQuestionModelOverride {
+                        tool: tool_name.to_owned(),
+                        question: question_id.clone(),
+                        model: model_id.to_string(),
+                        source,
+                    }
                 };
 
                 let prov = if let Some(p) = providers.get(&model_id.provider) {
                     Arc::clone(p)
                 } else {
                     let p: Arc<dyn Provider> = Arc::from(
-                        get_provider(model_id.provider, &cfg.providers.llm).map_err(wrap_err)?,
+                        get_provider(model_id.provider, &cfg.providers.llm)
+                            .map_err(|e| wrap_err(Box::new(e)))?,
                     );
                     providers.insert(model_id.provider, Arc::clone(&p));
                     p
                 };
 
-                let details = prov.model_details(&model_id.name).await.map_err(wrap_err)?;
+                let details = prov
+                    .model_details(&model_id.name)
+                    .await
+                    .map_err(|e| wrap_err(Box::new(e)))?;
 
                 if details.structured_output == Some(false) {
                     warn!(

--- a/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
+++ b/crates/jp_cli/src/cmd/query/turn_loop_tests.rs
@@ -7765,7 +7765,7 @@ async fn test_inquiry_failure_marks_tool_as_error() {
 fn inquiry_model_override_error_names_the_override() {
     let error = Error::InquiryModelOverride {
         model: "openrouter/foo/bar".to_owned(),
-        source: LlmError::MissingEnv("OPENROUTER_API_KEY".to_owned()),
+        source: Box::new(LlmError::MissingEnv("OPENROUTER_API_KEY".to_owned())),
     };
 
     // The variant names the override and keeps the cause chain intact.

--- a/crates/jp_cli/src/config_pipeline.rs
+++ b/crates/jp_cli/src/config_pipeline.rs
@@ -503,9 +503,12 @@ fn apply_cfg_args(
     for arg in args {
         match arg {
             ResolvedCfgArg::KeyValue(kv) => {
+                // Assignment errors keep the offending value and the reason
+                // in their source chain; the outermost error is only a
+                // category (`parse error`).
                 partial
                     .assign(kv.clone())
-                    .map_err(|e| Error::CliConfig(e.to_string()))?;
+                    .map_err(|e| Error::CliConfig(crate::error::error_chain(e.as_ref())))?;
             }
             ResolvedCfgArg::Partials(entries) => {
                 for entry in entries {

--- a/crates/jp_cli/src/config_pipeline_tests.rs
+++ b/crates/jp_cli/src/config_pipeline_tests.rs
@@ -214,6 +214,30 @@ fn with_conversation_preserves_cfg_over_conversation() {
 }
 
 #[test]
+fn rejected_cfg_value_reports_the_underlying_reason() {
+    let mut pipeline = empty_pipeline();
+    pipeline.cfg_args.push(ResolvedCfgArg::KeyValue(
+        "providers.llm.anthropic.auth=bogus"
+            .parse::<KvAssignment>()
+            .unwrap(),
+    ));
+
+    let error = pipeline.partial_without_conversation().unwrap_err();
+    let message = error.to_string();
+
+    // The key plus the bare category the assignment error displays as are
+    // not enough to act on; the reason sits in its source chain.
+    assert!(
+        message.contains("providers.llm.anthropic.auth"),
+        "{message}"
+    );
+    assert!(
+        message.contains("unrecognized auth chain entry"),
+        "{message}"
+    );
+}
+
+#[test]
 fn conversation_layer_overrides_base() {
     let pipeline = empty_pipeline();
 

--- a/crates/jp_cli/src/error.rs
+++ b/crates/jp_cli/src/error.rs
@@ -8,6 +8,29 @@ use crate::cmd;
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
+/// Render an error and its cause chain as a single line.
+///
+/// Some errors keep every actionable detail in their source chain and display
+/// as a bare category on their own — `parse error` for a rejected `--cfg`
+/// value, `builder error` for a rejected HTTP header — so stringifying only
+/// the outermost error discards the reason.
+pub(crate) fn error_chain(error: &(dyn std::error::Error + 'static)) -> String {
+    let mut parts = vec![error.to_string()];
+    let mut source = error.source();
+
+    while let Some(error) = source {
+        let message = error.to_string();
+        // Wrappers that interpolate their source into their own Display
+        // would otherwise repeat it verbatim.
+        if !parts.last().is_some_and(|last| last.ends_with(&message)) {
+            parts.push(message);
+        }
+        source = error.source();
+    }
+
+    parts.join(": ")
+}
+
 /// CLI Error types
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
@@ -45,6 +68,9 @@ pub(crate) enum Error {
     #[error("LLM error")]
     Llm(#[from] jp_llm::Error),
 
+    #[error("Credential store error")]
+    Credentials(#[from] jp_credentials::StoreError),
+
     /// The inquiry model override (`conversation.inquiry.assistant.model`)
     /// could not be used.
     ///
@@ -55,7 +81,7 @@ pub(crate) enum Error {
     #[error("Inquiry model override '{model}' is unusable")]
     InquiryModelOverride {
         model: String,
-        source: jp_llm::Error,
+        source: Box<dyn std::error::Error + Send + Sync>,
     },
 
     /// A per-question inquiry model override (a `QuestionTarget::Assistant`
@@ -71,7 +97,7 @@ pub(crate) enum Error {
         tool: String,
         question: String,
         model: String,
-        source: Box<jp_llm::Error>,
+        source: Box<dyn std::error::Error + Send + Sync>,
     },
 
     /// Reading an `@path` argument value from disk failed.
@@ -239,3 +265,7 @@ pub(crate) enum Error {
     #[error("Title generation failed for {model}: {reason}")]
     TitleGeneration { model: String, reason: String },
 }
+
+#[cfg(test)]
+#[path = "error_tests.rs"]
+mod tests;

--- a/crates/jp_cli/src/error_tests.rs
+++ b/crates/jp_cli/src/error_tests.rs
@@ -1,0 +1,37 @@
+use test_log::test;
+
+use super::*;
+
+#[derive(Debug, thiserror::Error)]
+#[error("category")]
+struct Category(#[source] Detail);
+
+#[derive(Debug, thiserror::Error)]
+#[error("the actual reason")]
+struct Detail;
+
+/// A wrapper that interpolates its source into its own `Display`.
+#[derive(Debug, thiserror::Error)]
+#[error("some.key: {0}")]
+struct Interpolating(#[source] Category);
+
+#[test]
+fn test_error_chain_appends_sources() {
+    // A category-only error is useless on its own; the reason lives one
+    // level down.
+    assert_eq!(
+        error_chain(&Category(Detail)),
+        "category: the actual reason"
+    );
+    assert_eq!(error_chain(&Detail), "the actual reason");
+}
+
+#[test]
+fn test_error_chain_skips_already_interpolated_sources() {
+    // The outer error already ends with its source's message, so repeating
+    // it would read `some.key: category: category: the actual reason`.
+    assert_eq!(
+        error_chain(&Interpolating(Category(Detail))),
+        "some.key: category: the actual reason"
+    );
+}

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -607,6 +607,13 @@ fn run_inner(cli: Cli, format: OutputFormat) -> Result<()> {
         return output;
     }
 
+    // Credentials are user-global, so `jp provider auth` works anywhere:
+    // it bypasses workspace discovery entirely, the same startup exception
+    // `jp init` uses.
+    if let Commands::Provider(args) = &cli.command {
+        return args.run(&printer).map_err(Into::into);
+    }
+
     // The per-command workspace bootstrap requirement (RFD 087): commands
     // declaring `None` run without any workspace resolution or construction,
     // so the downstream consumers that assume a root do not run.

--- a/crates/jp_credentials/Cargo.toml
+++ b/crates/jp_credentials/Cargo.toml
@@ -22,10 +22,8 @@ chrono = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }
-tracing = { workspace = true }
 
 [dev-dependencies]
-assert_matches = { workspace = true }
 datetime_literal = { workspace = true }
 test-log = { workspace = true }
 

--- a/crates/jp_credentials/Cargo.toml
+++ b/crates/jp_credentials/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "jp_credentials"
+
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license-file.workspace = true
+publish.workspace = true
+readme.workspace = true
+repository.workspace = true
+version.workspace = true
+
+[dependencies]
+jp_config = { workspace = true }
+jp_storage = { workspace = true }
+
+camino = { workspace = true }
+camino-tempfile = { workspace = true }
+chrono = { workspace = true }
+serde = { workspace = true, features = ["std", "derive"] }
+serde_json = { workspace = true, features = ["std"] }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+assert_matches = { workspace = true }
+datetime_literal = { workspace = true }
+test-log = { workspace = true }
+
+[lints]
+workspace = true
+
+[lib]
+doctest = false

--- a/crates/jp_credentials/src/lib.rs
+++ b/crates/jp_credentials/src/lib.rs
@@ -1,0 +1,29 @@
+//! The core-owned credential store.
+//!
+//! Credentials for LLM providers live in a user-global store, managed with `jp
+//! provider auth login|list|logout` and consumed by each provider's own
+//! credential-chain resolution (`providers.llm.anthropic.auth`).
+//!
+//! This crate owns storage integrity — the document encoding, the schema
+//! version check, and the lock-mutate-persist cycle — and exposes it as an
+//! API: providers in core call it directly, and plugins reach the same
+//! operations through host protocol messages, so the on-disk format is never a
+//! cross-binary contract.
+//!
+//! Credential *policy* — which chain entry to use, when to skip, refresh, or
+//! switch — is provider-owned and lives with each provider implementation, so
+//! it migrates into a plugin together with the provider.
+
+pub mod store;
+
+pub use store::{
+    CredentialBackend, CredentialSecret, CredentialStore, DEFAULT_COOLDOWN, FsCredentialBackend,
+    InMemoryCredentialBackend, MAX_COOLDOWN, SCOPE_ACCOUNT, StoreDocument, StoreError,
+    StoredCredential, cooldown_until,
+};
+
+/// The store category for LLM provider credentials.
+pub const CATEGORY_LLM: &str = "llm";
+
+/// The sole provider implemented under [`CATEGORY_LLM`].
+pub const PROVIDER_ANTHROPIC: &str = "anthropic";

--- a/crates/jp_credentials/src/store.rs
+++ b/crates/jp_credentials/src/store.rs
@@ -1,0 +1,577 @@
+//! The user-global credential store.
+//!
+//! Credentials live in a single versioned JSON document, keyed by category
+//! (`llm`), provider (`anthropic`), and profile name.
+//! [`CredentialBackend`] abstracts where the serialized document is kept: the
+//! file backend is the baseline, and the macOS Keychain backend (RFD 090, Phase
+//! 4) swaps in behind the same interface.
+//!
+//! [`CredentialStore`] owns the semantics every backend shares: the document
+//! encoding and schema-version check, and the mutation cycle — acquire the
+//! cross-process lock, re-read, apply, persist.
+//! The lock is a [`ResourceLocker`] and stays file-based even for non-file
+//! backends, since e.g. the Keychain provides no locking of its own.
+
+use std::{
+    collections::BTreeMap,
+    fmt::Debug,
+    io::{self, Write as _},
+    sync::{Arc, Mutex},
+};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use camino_tempfile::NamedUtf8TempFile;
+use chrono::{DateTime, Utc};
+use jp_storage::resource_lock::{FsResourceLocker, LockError, ResourceLocker};
+use serde::{Deserialize, Serialize};
+
+/// The store filename inside JP's user data directory.
+pub const STORE_FILENAME: &str = "credentials.json";
+
+/// The resource name the store's mutation lock is held under.
+const LOCK_RESOURCE: &str = "credentials";
+
+/// How long a quota cooldown lasts when the provider reported no reset timing.
+///
+/// The costs are asymmetric, so this biases short: a too-short cooldown wastes
+/// one admission-rejected request per expiry and bills no tokens, while a
+/// too-long one spends per-token money while a recovered allowance sits idle.
+pub const DEFAULT_COOLDOWN: chrono::TimeDelta = chrono::TimeDelta::minutes(30);
+
+/// The longest cooldown that can be recorded, matching the longest usage window
+/// a subscription is known to use.
+///
+/// Caps observed reset timing so a misparsed timestamp cannot make a profile
+/// unusable indefinitely.
+pub const MAX_COOLDOWN: chrono::TimeDelta = chrono::TimeDelta::days(7);
+
+/// The cooldown scope covering every model on an account.
+pub const SCOPE_ACCOUNT: &str = "account";
+
+/// When a cooldown recorded now should expire.
+///
+/// Provider-reported timing wins when it is in the future, capped at
+/// [`MAX_COOLDOWN`]; otherwise [`DEFAULT_COOLDOWN`] applies.
+#[must_use]
+pub fn cooldown_until(reported: Option<DateTime<Utc>>, now: DateTime<Utc>) -> DateTime<Utc> {
+    match reported {
+        Some(reset) if reset > now => reset.min(now + MAX_COOLDOWN),
+        _ => now + DEFAULT_COOLDOWN,
+    }
+}
+
+/// The newest store schema this build can read and write.
+const STORE_VERSION: u32 = 1;
+
+/// Errors from loading or mutating the credential store.
+#[derive(Debug, thiserror::Error)]
+pub enum StoreError {
+    #[error("cannot locate the user data directory (no home directory?)")]
+    MissingDataDir,
+
+    #[error("failed to access credential store at {location}: {source}")]
+    Io {
+        location: String,
+        #[source]
+        source: io::Error,
+    },
+
+    #[error("malformed credential store at {location}: {source}")]
+    Malformed {
+        location: String,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error(
+        "credential store at {location} was written by a newer version of JP (schema version \
+         {found}, this build supports up to {STORE_VERSION})"
+    )]
+    NewerVersion { location: String, found: u32 },
+
+    #[error(transparent)]
+    Lock(#[from] LockError),
+
+    #[error("{0}")]
+    Rejected(String),
+}
+
+/// Where the serialized credential store document is kept.
+///
+/// A backend reads and writes the document as one opaque unit; the encoding,
+/// schema versioning, and locking are [`CredentialStore`] concerns, shared by
+/// every backend.
+///
+/// Implementations must uphold two contracts:
+///
+/// - [`persist`] is all-or-nothing: a crash mid-persist leaves either the
+///   previous or the new document, never a mix.
+/// - The document contains secrets and is protected at rest per platform idiom
+///   (owner-only file permissions, Keychain ACLs, ...).
+///
+/// [`persist`]: Self::persist
+pub trait CredentialBackend: Send + Sync + Debug {
+    /// Human-readable location for error messages.
+    fn describe(&self) -> String;
+
+    /// Read the serialized store document.
+    ///
+    /// `None` when no store exists yet.
+    fn load(&self) -> Result<Option<String>, StoreError>;
+
+    /// Persist the serialized document atomically.
+    fn persist(&self, document: &str) -> Result<(), StoreError>;
+}
+
+/// File-backed credential storage.
+///
+/// The document is written to a temp file (created with `0600` on Unix) and
+/// atomically renamed over the store; Windows relies on the default
+/// user-profile ACLs.
+#[derive(Debug, Clone)]
+pub struct FsCredentialBackend {
+    path: Utf8PathBuf,
+}
+
+impl FsCredentialBackend {
+    /// A backend storing the document at `path`.
+    pub fn new(path: impl Into<Utf8PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    fn io_err(&self, source: io::Error) -> StoreError {
+        StoreError::Io {
+            location: self.describe(),
+            source,
+        }
+    }
+}
+
+impl CredentialBackend for FsCredentialBackend {
+    fn describe(&self) -> String {
+        self.path.to_string()
+    }
+
+    fn load(&self) -> Result<Option<String>, StoreError> {
+        match std::fs::read_to_string(&self.path) {
+            Ok(content) => Ok(Some(content)),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(source) => Err(self.io_err(source)),
+        }
+    }
+
+    fn persist(&self, document: &str) -> Result<(), StoreError> {
+        let dir = self.path.parent().unwrap_or(Utf8Path::new("."));
+        std::fs::create_dir_all(dir).map_err(|e| self.io_err(e))?;
+
+        let mut temp = NamedUtf8TempFile::new_in(dir).map_err(|e| self.io_err(e))?;
+        restrict_permissions(temp.path()).map_err(|e| self.io_err(e))?;
+
+        temp.write_all(document.as_bytes())
+            .map_err(|e| self.io_err(e))?;
+        temp.as_file().sync_all().map_err(|e| self.io_err(e))?;
+        temp.persist(&self.path)
+            .map_err(|error| self.io_err(error.error))?;
+
+        Ok(())
+    }
+}
+
+/// In-memory credential storage, for tests.
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryCredentialBackend {
+    document: Arc<Mutex<Option<String>>>,
+}
+
+impl InMemoryCredentialBackend {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl CredentialBackend for InMemoryCredentialBackend {
+    fn describe(&self) -> String {
+        "<memory>".to_owned()
+    }
+
+    fn load(&self) -> Result<Option<String>, StoreError> {
+        Ok(self.document.lock().expect("poisoned").clone())
+    }
+
+    fn persist(&self, document: &str) -> Result<(), StoreError> {
+        *self.document.lock().expect("poisoned") = Some(document.to_owned());
+        Ok(())
+    }
+}
+
+/// Restrict `path` to owner read/write (`0600`).
+///
+/// No-op on non-Unix platforms, which fall back to the platform's default
+/// user-profile ACLs.
+fn restrict_permissions(path: &Utf8Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+
+    Ok(())
+}
+
+/// Handle to the credential store: a backend plus the shared semantics.
+#[derive(Debug, Clone)]
+pub struct CredentialStore {
+    backend: Arc<dyn CredentialBackend>,
+    locker: Arc<dyn ResourceLocker>,
+}
+
+impl CredentialStore {
+    /// The file-backed store at its default, user-global location.
+    pub fn file_default() -> Result<Self, StoreError> {
+        let dir = jp_config::fs::user_data_dir().ok_or(StoreError::MissingDataDir)?;
+
+        Ok(Self::new(
+            Arc::new(FsCredentialBackend::new(dir.join(STORE_FILENAME))),
+            // The mutation lock is file-based regardless of backend; it
+            // stays alongside the store in the user data directory.
+            Arc::new(FsResourceLocker::new(dir)),
+        ))
+    }
+
+    /// A store over an explicit backend and locker.
+    pub fn new(backend: Arc<dyn CredentialBackend>, locker: Arc<dyn ResourceLocker>) -> Self {
+        Self { backend, locker }
+    }
+
+    /// Read the store into a snapshot.
+    ///
+    /// A missing document is an empty store, not an error.
+    pub fn load(&self) -> Result<StoreDocument, StoreError> {
+        let Some(content) = self.backend.load()? else {
+            return Ok(StoreDocument::empty());
+        };
+
+        decode(&content, &self.backend.describe())
+    }
+
+    /// Mutate the store under the cross-process lock.
+    ///
+    /// The document is re-read after the lock is acquired, so `f` always
+    /// operates on the latest persisted state; a process holding a stale
+    /// snapshot must recheck its preconditions inside `f`.
+    /// An error from `f` leaves the store untouched.
+    pub fn mutate<T>(
+        &self,
+        f: impl FnOnce(&mut StoreDocument) -> Result<T, StoreError>,
+    ) -> Result<T, StoreError> {
+        let _guard = self.locker.lock(LOCK_RESOURCE, None)?;
+
+        let mut document = self.load()?;
+        let value = f(&mut document)?;
+
+        let content =
+            serde_json::to_string_pretty(&document).map_err(|source| StoreError::Malformed {
+                location: self.backend.describe(),
+                source,
+            })?;
+        self.backend.persist(&content)?;
+
+        Ok(value)
+    }
+}
+
+impl CredentialStore {
+    /// Record a quota cooldown against a stored profile.
+    ///
+    /// `scope` is the whole account ([`SCOPE_ACCOUNT`]) or a model family;
+    /// resolution skips the profile only for models the scope matches.
+    /// A later expiry never shortens an existing cooldown for the same scope,
+    /// so a concurrent process that saw a longer window wins.
+    ///
+    /// Returns whether the profile was found; a chain entry with no stored
+    /// profile (`api_key`) has nothing to record against.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the store cannot be read or written.
+    pub fn record_cooldown(
+        &self,
+        category: &str,
+        provider: &str,
+        profile: &str,
+        scope: &str,
+        until: DateTime<Utc>,
+    ) -> Result<bool, StoreError> {
+        self.update_profile(category, provider, profile, |credential| {
+            let entry = credential
+                .cooldowns
+                .entry(scope.to_owned())
+                .or_insert(until);
+            *entry = (*entry).max(until);
+        })
+    }
+
+    /// Mark a stored profile as needing a fresh login.
+    ///
+    /// Returns whether the profile was found.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the store cannot be read or written.
+    pub fn mark_needs_relogin(
+        &self,
+        category: &str,
+        provider: &str,
+        profile: &str,
+    ) -> Result<bool, StoreError> {
+        self.update_profile(category, provider, profile, |credential| {
+            credential.needs_relogin = true;
+        })
+    }
+
+    /// Apply `f` to a stored profile under the store lock.
+    ///
+    /// Returns whether the profile was found.
+    fn update_profile(
+        &self,
+        category: &str,
+        provider: &str,
+        profile: &str,
+        f: impl FnOnce(&mut StoredCredential),
+    ) -> Result<bool, StoreError> {
+        self.mutate(|document| {
+            let Some(credential) = document.profile_mut(category, provider, profile) else {
+                return Ok(false);
+            };
+
+            f(credential);
+            Ok(true)
+        })
+    }
+}
+
+/// Parse and version-check a serialized store document.
+fn decode(content: &str, location: &str) -> Result<StoreDocument, StoreError> {
+    let document: StoreDocument =
+        serde_json::from_str(content).map_err(|source| StoreError::Malformed {
+            location: location.to_owned(),
+            source,
+        })?;
+
+    if document.version > STORE_VERSION {
+        return Err(StoreError::NewerVersion {
+            location: location.to_owned(),
+            found: document.version,
+        });
+    }
+
+    Ok(document)
+}
+
+/// The store document: a schema version plus credentials nested by category,
+/// provider, and profile name.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StoreDocument {
+    version: u32,
+    #[serde(default)]
+    credentials: BTreeMap<String, BTreeMap<String, BTreeMap<String, StoredCredential>>>,
+}
+
+impl Default for StoreDocument {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl StoreDocument {
+    fn empty() -> Self {
+        Self {
+            version: STORE_VERSION,
+            credentials: BTreeMap::new(),
+        }
+    }
+
+    /// The profiles stored for a category/provider pair.
+    #[must_use]
+    pub fn profiles(
+        &self,
+        category: &str,
+        provider: &str,
+    ) -> Option<&BTreeMap<String, StoredCredential>> {
+        self.credentials.get(category)?.get(provider)
+    }
+
+    /// Mutable access to a stored profile.
+    pub fn profile_mut(
+        &mut self,
+        category: &str,
+        provider: &str,
+        profile: &str,
+    ) -> Option<&mut StoredCredential> {
+        self.credentials
+            .get_mut(category)?
+            .get_mut(provider)?
+            .get_mut(profile)
+    }
+
+    /// Insert or replace a profile.
+    pub fn insert_profile(
+        &mut self,
+        category: &str,
+        provider: &str,
+        profile: &str,
+        credential: StoredCredential,
+    ) {
+        self.credentials
+            .entry(category.to_owned())
+            .or_default()
+            .entry(provider.to_owned())
+            .or_default()
+            .insert(profile.to_owned(), credential);
+    }
+
+    /// Remove a profile, pruning empty parent maps.
+    ///
+    /// Returns the removed credential, or `None` when no such profile was
+    /// stored.
+    pub fn remove_profile(
+        &mut self,
+        category: &str,
+        provider: &str,
+        profile: &str,
+    ) -> Option<StoredCredential> {
+        let providers = self.credentials.get_mut(category)?;
+        let profiles = providers.get_mut(provider)?;
+        let removed = profiles.remove(profile);
+
+        if profiles.is_empty() {
+            providers.remove(provider);
+        }
+        if providers.is_empty() {
+            self.credentials.remove(category);
+        }
+
+        removed
+    }
+
+    /// Iterate all stored profiles as `(category, provider, profile,
+    /// credential)`.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str, &str, &StoredCredential)> {
+        self.credentials.iter().flat_map(|(category, providers)| {
+            providers.iter().flat_map(move |(provider, profiles)| {
+                profiles.iter().map(move |(profile, credential)| {
+                    (
+                        category.as_str(),
+                        provider.as_str(),
+                        profile.as_str(),
+                        credential,
+                    )
+                })
+            })
+        })
+    }
+}
+
+/// A stored credential: the secret material plus account identity, quota
+/// cooldowns, and re-login state.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StoredCredential {
+    /// The secret material, tagged by mechanism.
+    #[serde(flatten)]
+    pub secret: CredentialSecret,
+
+    /// The account UUID this credential belongs to.
+    ///
+    /// `None` marks the profile as unverified: identity recovery failed at
+    /// login and duplicate-account detection is skipped for it.
+    pub account_id: Option<String>,
+
+    /// The account email, when identity recovery reported one.
+    pub email: Option<String>,
+
+    /// Active quota cooldowns, keyed by scope: the whole account (`"account"`)
+    /// or a model family (`"opus"`, `"sonnet"`).
+    /// Values are the instant the cooldown expires.
+    #[serde(default)]
+    pub cooldowns: BTreeMap<String, DateTime<Utc>>,
+
+    /// Whether the credential was rejected by the provider and needs a fresh
+    /// `jp provider auth login`.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub needs_relogin: bool,
+}
+
+impl StoredCredential {
+    /// A cooldown scope covering `model` that has not yet expired.
+    #[must_use]
+    pub fn active_cooldown(
+        &self,
+        model: &str,
+        now: DateTime<Utc>,
+    ) -> Option<(&str, DateTime<Utc>)> {
+        self.cooldowns
+            .iter()
+            .filter(|(_, expires)| **expires > now)
+            .find(|(scope, _)| scope_covers(scope, model))
+            .map(|(scope, expires)| (scope.as_str(), *expires))
+    }
+}
+
+/// Whether a recorded cooldown scope covers `model`.
+///
+/// [`SCOPE_ACCOUNT`] and the account-wide usage windows (`five_hour`,
+/// `seven_day`) cover every model.
+/// A window naming a model family covers only that family, whether it is
+/// recorded as the provider reports it (`seven_day_opus`) or as the bare family
+/// name (`opus`).
+///
+/// An unrecognized scope covers only models whose name contains it, so a window
+/// this build does not know about cannot silently take a whole account out of
+/// use.
+fn scope_covers(scope: &str, model: &str) -> bool {
+    match scope {
+        SCOPE_ACCOUNT | "five_hour" | "seven_day" => true,
+        scope => {
+            let family = scope
+                .strip_prefix("seven_day_")
+                .or_else(|| scope.strip_prefix("five_hour_"))
+                .unwrap_or(scope);
+
+            model.contains(family)
+        }
+    }
+}
+
+/// The secret material of a credential, tagged by mechanism.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CredentialSecret {
+    /// A refreshable OAuth token pair.
+    Oauth {
+        access_token: String,
+        refresh_token: String,
+        expires_at: DateTime<Utc>,
+    },
+
+    /// A static bearer token (`claude setup-token` output) with no refresh flow
+    /// and no expiry JP can inspect.
+    Token { token: String },
+}
+
+impl CredentialSecret {
+    /// A short label for `jp provider auth list`.
+    #[must_use]
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Oauth { .. } => "oauth",
+            Self::Token { .. } => "token",
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "store_tests.rs"]
+mod tests;

--- a/crates/jp_credentials/src/store_tests.rs
+++ b/crates/jp_credentials/src/store_tests.rs
@@ -1,0 +1,305 @@
+use camino_tempfile::Utf8TempDir;
+use datetime_literal::datetime;
+use jp_storage::resource_lock::InMemoryResourceLocker;
+use test_log::test;
+
+use super::*;
+
+fn token_credential(token: &str) -> StoredCredential {
+    StoredCredential {
+        secret: CredentialSecret::Token {
+            token: token.to_owned(),
+        },
+        account_id: Some("11111111-1111-1111-1111-111111111111".to_owned()),
+        email: Some("jean@example.com".to_owned()),
+        cooldowns: BTreeMap::new(),
+        needs_relogin: false,
+    }
+}
+
+fn file_store(dir: &Utf8TempDir) -> CredentialStore {
+    CredentialStore::new(
+        Arc::new(FsCredentialBackend::new(dir.path().join(STORE_FILENAME))),
+        Arc::new(FsResourceLocker::new(dir.path().to_owned())),
+    )
+}
+
+fn memory_store() -> CredentialStore {
+    CredentialStore::new(
+        Arc::new(InMemoryCredentialBackend::new()),
+        Arc::new(InMemoryResourceLocker::new()),
+    )
+}
+
+/// The stores that must behave identically through `CredentialStore`.
+fn stores() -> Vec<(&'static str, CredentialStore, Option<Utf8TempDir>)> {
+    let dir = Utf8TempDir::new().unwrap();
+    let file = file_store(&dir);
+    vec![("fs", file, Some(dir)), ("memory", memory_store(), None)]
+}
+
+#[test]
+fn test_load_missing_store_is_empty() {
+    for (name, store, _dir) in stores() {
+        let document = store.load().unwrap();
+        assert_eq!(document.iter().count(), 0, "store: {name}");
+    }
+}
+
+#[test]
+fn test_mutate_roundtrip() {
+    for (name, store, _dir) in stores() {
+        store
+            .mutate(|document| {
+                document.insert_profile("llm", "anthropic", "personal", token_credential("sk-a"));
+                Ok(())
+            })
+            .unwrap();
+
+        let document = store.load().unwrap();
+        let profiles = document.profiles("llm", "anthropic").unwrap();
+        assert_eq!(profiles.len(), 1, "store: {name}");
+        assert_eq!(
+            profiles["personal"].secret,
+            CredentialSecret::Token {
+                token: "sk-a".to_owned()
+            },
+            "store: {name}"
+        );
+    }
+}
+
+#[test]
+fn test_mutate_error_leaves_store_untouched() {
+    for (name, store, _dir) in stores() {
+        store
+            .mutate(|document| {
+                document.insert_profile("llm", "anthropic", "personal", token_credential("sk-a"));
+                Ok(())
+            })
+            .unwrap();
+
+        let result = store.mutate(|document| {
+            document.remove_profile("llm", "anthropic", "personal");
+            Err::<(), _>(StoreError::Rejected("nope".to_owned()))
+        });
+
+        assert!(result.is_err(), "store: {name}");
+        let document = store.load().unwrap();
+        assert!(
+            document.profiles("llm", "anthropic").is_some(),
+            "store: {name}"
+        );
+    }
+}
+
+#[test]
+fn test_remove_profile_prunes_empty_maps() {
+    let mut document = StoreDocument::default();
+    document.insert_profile("llm", "anthropic", "personal", token_credential("sk-a"));
+
+    let removed = document.remove_profile("llm", "anthropic", "personal");
+    assert!(removed.is_some());
+    assert!(document.profiles("llm", "anthropic").is_none());
+    assert_eq!(document.iter().count(), 0);
+
+    assert!(
+        document
+            .remove_profile("llm", "anthropic", "personal")
+            .is_none()
+    );
+}
+
+#[test]
+fn test_rejects_newer_schema_version() {
+    let dir = Utf8TempDir::new().unwrap();
+    std::fs::write(
+        dir.path().join(STORE_FILENAME),
+        r#"{"version": 2, "credentials": {}}"#,
+    )
+    .unwrap();
+
+    let error = file_store(&dir).load().unwrap_err();
+    assert!(matches!(error, StoreError::NewerVersion { found: 2, .. }));
+}
+
+#[test]
+fn test_rejects_malformed_store() {
+    let dir = Utf8TempDir::new().unwrap();
+    std::fs::write(dir.path().join(STORE_FILENAME), "not json").unwrap();
+
+    let error = file_store(&dir).load().unwrap_err();
+    assert!(matches!(error, StoreError::Malformed { .. }));
+}
+
+#[test]
+fn test_wire_format_matches_rfd_shape() {
+    // The exact document shape from RFD 090's Credential store section.
+    let raw = r#"{
+        "version": 1,
+        "credentials": {
+            "llm": {
+                "anthropic": {
+                    "personal": {
+                        "type": "oauth",
+                        "access_token": "at",
+                        "refresh_token": "rt",
+                        "expires_at": "2026-07-03T12:00:00Z",
+                        "account_id": "11111111-1111-1111-1111-111111111111",
+                        "email": "jean@example.com",
+                        "cooldowns": {}
+                    },
+                    "ci": {
+                        "type": "token",
+                        "token": "sk-ant-xxx",
+                        "account_id": null,
+                        "email": null,
+                        "cooldowns": {}
+                    }
+                }
+            }
+        }
+    }"#;
+
+    let document: StoreDocument = serde_json::from_str(raw).unwrap();
+    let profiles = document.profiles("llm", "anthropic").unwrap();
+
+    assert_eq!(profiles["personal"].secret, CredentialSecret::Oauth {
+        access_token: "at".to_owned(),
+        refresh_token: "rt".to_owned(),
+        expires_at: datetime!(2026-07-03 12:00:00 Z),
+    });
+    assert_eq!(profiles["ci"].secret, CredentialSecret::Token {
+        token: "sk-ant-xxx".to_owned()
+    });
+    assert_eq!(profiles["ci"].account_id, None);
+    assert!(!profiles["ci"].needs_relogin);
+
+    // Round-trips without dropping fields.
+    let serialized = serde_json::to_value(&document).unwrap();
+    let reparsed: StoreDocument = serde_json::from_value(serialized).unwrap();
+    assert_eq!(reparsed, document);
+}
+
+#[test]
+fn test_active_cooldown_scoping() {
+    let mut credential = token_credential("sk-a");
+    let now = datetime!(2026-07-03 12:00:00 Z);
+    let future = datetime!(2026-07-03 13:00:00 Z);
+    let past = datetime!(2026-07-03 11:00:00 Z);
+
+    // No cooldowns: nothing matches.
+    assert_eq!(credential.active_cooldown("claude-opus-4-6", now), None);
+
+    // A model-family scope only blocks that family.
+    credential.cooldowns.insert("opus".to_owned(), future);
+    assert_eq!(
+        credential.active_cooldown("claude-opus-4-6", now),
+        Some(("opus", future))
+    );
+    assert_eq!(credential.active_cooldown("claude-haiku-4-5", now), None);
+
+    // An expired cooldown no longer matches.
+    credential.cooldowns.insert("opus".to_owned(), past);
+    assert_eq!(credential.active_cooldown("claude-opus-4-6", now), None);
+
+    // The account scope blocks every model.
+    credential.cooldowns.insert("account".to_owned(), future);
+    assert_eq!(
+        credential.active_cooldown("claude-haiku-4-5", now),
+        Some(("account", future))
+    );
+}
+
+#[test]
+fn test_cooldown_until_policy() {
+    let now = datetime!(2026-07-03 12:00:00 Z);
+
+    // No reported timing: the fixed default applies.
+    assert_eq!(cooldown_until(None, now), now + DEFAULT_COOLDOWN);
+
+    // Timing already in the past says nothing about the future window.
+    let past = datetime!(2026-07-03 11:00:00 Z);
+    assert_eq!(cooldown_until(Some(past), now), now + DEFAULT_COOLDOWN);
+
+    // Reported timing wins when it is in the future.
+    let reset = datetime!(2026-07-03 17:00:00 Z);
+    assert_eq!(cooldown_until(Some(reset), now), reset);
+
+    // A misparsed far-future timestamp cannot brick the profile.
+    let absurd = datetime!(2030-01-01 00:00:00 Z);
+    assert_eq!(cooldown_until(Some(absurd), now), now + MAX_COOLDOWN);
+}
+
+#[test]
+fn test_record_cooldown_and_relogin() {
+    for (name, store, _dir) in stores() {
+        store
+            .mutate(|document| {
+                document.insert_profile("llm", "anthropic", "personal", token_credential("sk-a"));
+                Ok(())
+            })
+            .unwrap();
+
+        let until = datetime!(2026-07-03 13:00:00 Z);
+        let found = store
+            .record_cooldown("llm", "anthropic", "personal", "opus", until)
+            .unwrap();
+        assert!(found, "store: {name}");
+
+        let document = store.load().unwrap();
+        let credential = &document.profiles("llm", "anthropic").unwrap()["personal"];
+        assert_eq!(credential.cooldowns["opus"], until, "store: {name}");
+        assert!(!credential.needs_relogin, "store: {name}");
+
+        // A shorter window never shortens a recorded cooldown: a process
+        // that saw the longer one must not be undercut.
+        let shorter = datetime!(2026-07-03 12:30:00 Z);
+        store
+            .record_cooldown("llm", "anthropic", "personal", "opus", shorter)
+            .unwrap();
+        let document = store.load().unwrap();
+        assert_eq!(
+            document.profiles("llm", "anthropic").unwrap()["personal"].cooldowns["opus"],
+            until,
+            "store: {name}"
+        );
+
+        // Re-login state is independent of cooldowns.
+        store
+            .mark_needs_relogin("llm", "anthropic", "personal")
+            .unwrap();
+        let document = store.load().unwrap();
+        let credential = &document.profiles("llm", "anthropic").unwrap()["personal"];
+        assert!(credential.needs_relogin, "store: {name}");
+        assert_eq!(credential.cooldowns["opus"], until, "store: {name}");
+
+        // A chain entry with no stored profile has nothing to record
+        // against, and that is not an error.
+        let found = store
+            .record_cooldown("llm", "anthropic", "absent", "account", until)
+            .unwrap();
+        assert!(!found, "store: {name}");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn test_store_file_permissions() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let dir = Utf8TempDir::new().unwrap();
+
+    file_store(&dir)
+        .mutate(|document| {
+            document.insert_profile("llm", "anthropic", "personal", token_credential("sk-a"));
+            Ok(())
+        })
+        .unwrap();
+
+    let mode = std::fs::metadata(dir.path().join(STORE_FILENAME))
+        .unwrap()
+        .permissions()
+        .mode();
+    assert_eq!(mode & 0o777, 0o600);
+}

--- a/crates/jp_llm/Cargo.toml
+++ b/crates/jp_llm/Cargo.toml
@@ -16,6 +16,7 @@ version.workspace = true
 jp_attachment = { workspace = true }
 jp_config = { workspace = true }
 jp_conversation = { workspace = true }
+jp_credentials = { workspace = true }
 jp_mcp = { workspace = true }
 jp_openrouter = { workspace = true }
 jp_tool = { workspace = true }
@@ -44,19 +45,23 @@ reqwest = { workspace = true }
 reqwest-eventsource = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
+datetime_literal = { workspace = true }
 eventsource-stream = { workspace = true }
 http = { workspace = true }
 infer = { workspace = true, features = ["std"] }
 insta = { workspace = true, features = ["json"] }
+jp_storage = { workspace = true }
 jp_test = { workspace = true }
 paste = { workspace = true }
 test-log = { workspace = true }

--- a/crates/jp_llm/src/credential.rs
+++ b/crates/jp_llm/src/credential.rs
@@ -1,0 +1,113 @@
+//! Resolved provider credentials and provider credential mechanics.
+//!
+//! A [`Credential`] is the outcome of a provider's own credential resolution:
+//! each provider with a credential chain walks it per request and authenticates
+//! with the credential it lands on.
+//! No other component consumes this type.
+//!
+//! The provider-specific mechanics behind stored credentials — identity
+//! recovery today, token exchange and refresh in later phases — live behind
+//! [`ProviderAuth`], dispatched by [`provider_auth`] the same way
+//! [`get_provider`] dispatches chat providers.
+//! The auth CLI (`jp provider auth`) reaches them through this seam; when a
+//! provider moves out of JP core and into a plugin, its `ProviderAuth`
+//! implementation migrates with it.
+//!
+//! [`get_provider`]: crate::provider::get_provider
+
+use std::fmt;
+
+use async_trait::async_trait;
+use jp_config::model::id::ProviderId;
+
+use crate::provider::anthropic;
+
+/// A resolved credential for an LLM provider.
+#[derive(Clone, PartialEq, Eq)]
+pub enum Credential {
+    /// A per-token API key, sent as `x-api-key`.
+    ApiKey(String),
+
+    /// A subscription OAuth bearer token, sent as `Authorization: Bearer`
+    /// together with the Claude Code request fingerprint.
+    Bearer(String),
+}
+
+impl Credential {
+    /// A short label for the credential's mechanism.
+    #[must_use]
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::ApiKey(_) => "api_key",
+            Self::Bearer(_) => "bearer",
+        }
+    }
+}
+
+/// Redacts the secret; only the mechanism is shown.
+impl fmt::Debug for Credential {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Credential::{}(REDACTED)", match self {
+            Self::ApiKey(_) => "ApiKey",
+            Self::Bearer(_) => "Bearer",
+        })
+    }
+}
+
+/// Account identity attached to a stored credential.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct AccountIdentity {
+    /// The provider-side account UUID, the key for duplicate-account detection.
+    pub account_id: Option<String>,
+
+    /// The account email, for display only.
+    pub email: Option<String>,
+}
+
+/// Provider-specific mechanics for stored credentials.
+///
+/// These flows run before any credential exists (logging in is what produces
+/// one), so they cannot live on [`Provider`], whose construction requires an
+/// already-resolved credential.
+///
+/// [`Provider`]: crate::Provider
+#[async_trait]
+pub trait ProviderAuth: Send + Sync {
+    /// How a user obtains a long-lived setup token for this provider.
+    ///
+    /// Surfaced verbatim when JP prompts for a token and when the input it
+    /// receives cannot be one, so it names the command to run, the shape of the
+    /// value to paste, and any constraint on scripting the step.
+    /// Provider-specific token vocabulary lives here rather than in the CLI,
+    /// which knows only that some providers accept setup tokens.
+    fn setup_token_hint(&self) -> &'static str;
+
+    /// Recover the account identity behind an access or setup token.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the provider cannot be reached or rejects the
+    /// token.
+    /// Callers treat a failure as "identity unknown", not as a fatal condition:
+    /// a credential without a recovered identity is stored unverified.
+    async fn recover_identity(
+        &self,
+        token: &str,
+    ) -> Result<AccountIdentity, Box<dyn std::error::Error + Send + Sync>>;
+}
+
+/// Get the credential mechanics for a provider.
+///
+/// Returns `None` for providers without stored-credential support; their
+/// constructors read their own environment variables instead.
+#[must_use]
+pub fn provider_auth(id: ProviderId) -> Option<Box<dyn ProviderAuth>> {
+    match id {
+        ProviderId::Anthropic => Some(Box::new(anthropic::auth::AnthropicAuth)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+#[path = "credential_tests.rs"]
+mod tests;

--- a/crates/jp_llm/src/credential_tests.rs
+++ b/crates/jp_llm/src/credential_tests.rs
@@ -1,0 +1,31 @@
+use jp_config::model::id::ProviderId;
+use test_log::test;
+
+use super::*;
+
+#[test]
+fn test_provider_auth_dispatch() {
+    // Anthropic is the only provider with stored-credential support.
+    assert!(provider_auth(ProviderId::Anthropic).is_some());
+
+    for id in [
+        ProviderId::Cerebras,
+        ProviderId::Google,
+        ProviderId::Llamacpp,
+        ProviderId::Ollama,
+        ProviderId::Openai,
+        ProviderId::Openrouter,
+        ProviderId::Test,
+    ] {
+        assert!(provider_auth(id).is_none(), "provider: {id}");
+    }
+}
+
+#[test]
+fn test_credential_debug_redacts_secrets() {
+    let api_key = Credential::ApiKey("sk-secret".to_owned());
+    let bearer = Credential::Bearer("oauth-secret".to_owned());
+
+    assert_eq!(format!("{api_key:?}"), "Credential::ApiKey(REDACTED)");
+    assert_eq!(format!("{bearer:?}"), "Credential::Bearer(REDACTED)");
+}

--- a/crates/jp_llm/src/error.rs
+++ b/crates/jp_llm/src/error.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use async_anthropic::errors::AnthropicError;
+use chrono::{DateTime, Utc};
 use jp_config::model::{id::ProviderId, parameters::ServiceTier};
 use reqwest::header::{HeaderMap, RETRY_AFTER};
 use serde_json::Value;
@@ -21,6 +22,22 @@ pub struct StreamError {
     /// If `Some`, the request can be retried after the specified duration.
     /// If `None`, the caller should use exponential backoff or not retry.
     pub retry_after: Option<Duration>,
+
+    /// When an exhausted quota resets, if the provider reported it.
+    ///
+    /// Distinct from [`retry_after`]: a quota cooldown spans a rolling usage
+    /// window measured in hours, which no backoff schedule should try to wait
+    /// out.
+    ///
+    /// [`retry_after`]: Self::retry_after
+    pub quota_reset: Option<DateTime<Utc>>,
+
+    /// What an exhausted quota applies to: the whole account (`"account"`) or a
+    /// model family (`"opus"`, `"sonnet"`).
+    ///
+    /// `None` when the provider gave no scope, which the caller treats as
+    /// account-wide.
+    pub quota_scope: Option<String>,
 
     /// Human-readable error message.
     message: String,
@@ -40,6 +57,8 @@ impl StreamError {
             kind,
             message: message.into(),
             retry_after: None,
+            quota_reset: None,
+            quota_scope: None,
             source: None,
         }
     }
@@ -60,10 +79,25 @@ impl StreamError {
     #[must_use]
     pub fn rate_limit(retry_after: Option<Duration>) -> Self {
         Self {
-            kind: StreamErrorKind::RateLimit,
             retry_after,
-            message: "Rate limited".into(),
-            source: None,
+            ..Self::new(StreamErrorKind::RateLimit, "Rate limited")
+        }
+    }
+
+    /// Create a subscription-window exhaustion error.
+    ///
+    /// `reset` is the provider-reported reset instant, when it gave one;
+    /// `scope` names what is exhausted (the whole account, or a model family).
+    #[must_use]
+    pub fn subscription_exhausted(
+        message: impl Into<String>,
+        reset: Option<DateTime<Utc>>,
+        scope: Option<String>,
+    ) -> Self {
+        Self {
+            quota_reset: reset,
+            quota_scope: scope,
+            ..Self::new(StreamErrorKind::SubscriptionExhausted, message)
         }
     }
 
@@ -136,6 +170,14 @@ impl StreamError {
     /// they end up classified as `Other` even though retrying usually succeeds.
     #[must_use]
     pub fn is_retryable(&self) -> bool {
+        // A spent or refused credential is never retryable in place: the
+        // same credential would fail the same way. It is retryable by
+        // switching credentials, which is a different decision (see
+        // `needs_credential_switch`).
+        if self.needs_credential_switch() {
+            return false;
+        }
+
         matches!(
             self.kind,
             StreamErrorKind::Timeout
@@ -145,6 +187,39 @@ impl StreamError {
         ) || self.retry_after.is_some()
             || (self.kind == StreamErrorKind::Other
                 && looks_like_transient_network_error(&self.message))
+    }
+
+    /// Whether the credential that produced this error is out of quota, so the
+    /// request can only succeed under a different credential.
+    ///
+    /// Covers both a subscription usage window and a per-token account's
+    /// billing limit.
+    #[must_use]
+    pub fn is_exhausted(&self) -> bool {
+        matches!(
+            self.kind,
+            StreamErrorKind::InsufficientQuota | StreamErrorKind::SubscriptionExhausted
+        )
+    }
+
+    /// Whether the provider refused the credential itself, so it needs
+    /// re-authorizing before it can be used again.
+    #[must_use]
+    pub fn is_auth_rejected(&self) -> bool {
+        self.kind == StreamErrorKind::AuthRejected
+    }
+
+    /// Whether the request can only proceed under a different credential,
+    /// because this one is spent or refused.
+    #[must_use]
+    pub fn needs_credential_switch(&self) -> bool {
+        self.is_exhausted() || self.is_auth_rejected()
+    }
+
+    /// Create a credential-rejection error.
+    #[must_use]
+    pub fn auth_rejected(message: impl Into<String>) -> Self {
+        Self::new(StreamErrorKind::AuthRejected, message)
     }
 }
 
@@ -354,6 +429,18 @@ pub enum StreamErrorKind {
     /// This is not retryable — the user needs to top up or change plans.
     InsufficientQuota,
 
+    /// A subscription account's rolling usage window is exhausted.
+    ///
+    /// Not retryable in place (the window is measured in hours), but the
+    /// request can proceed under the next credential in the chain.
+    SubscriptionExhausted,
+
+    /// The provider refused the credential itself (`401`/`403`).
+    ///
+    /// Retrying cannot help: the credential needs to be re-authorized, and the
+    /// request can only proceed under a different one.
+    AuthRejected,
+
     /// The request is larger than the model's context window.
     /// This is not retryable — the request has to shrink, or move to a model
     /// with a larger window.
@@ -378,6 +465,8 @@ impl StreamErrorKind {
             Self::RateLimit => "Rate limited",
             Self::Transient => "Server error",
             Self::InsufficientQuota => "Insufficient API quota",
+            Self::SubscriptionExhausted => "Subscription limit reached",
+            Self::AuthRejected => "Authentication rejected",
             Self::ContextWindowExceeded => "Context window exceeded",
             Self::OutputLimit => "Output limit exceeded",
             Self::Other => "Stream Error",
@@ -468,6 +557,10 @@ pub enum Error {
 
     #[error(transparent)]
     ModelId(#[from] jp_config::model::id::ModelIdError),
+
+    /// The provider's credential chain produced no usable credential.
+    #[error(transparent)]
+    CredentialChain(crate::provider::anthropic::resolve::ResolveError),
 }
 
 #[cfg(test)]
@@ -561,6 +654,19 @@ pub enum ToolError {
 impl From<jp_conversation::StreamError> for Error {
     fn from(error: jp_conversation::StreamError) -> Self {
         Self::Conversation(error.into())
+    }
+}
+
+impl From<crate::provider::anthropic::resolve::ResolveError> for Error {
+    fn from(error: crate::provider::anthropic::resolve::ResolveError) -> Self {
+        use crate::provider::anthropic::resolve::ResolveError;
+
+        // The single-entry `["api_key"]` chain fails the same way it did
+        // before credential chains existed.
+        match error {
+            ResolveError::MissingEnv(var) => Self::MissingEnv(var),
+            error => Self::CredentialChain(error),
+        }
     }
 }
 

--- a/crates/jp_llm/src/event.rs
+++ b/crates/jp_llm/src/event.rs
@@ -72,6 +72,14 @@ pub enum Event {
     /// Carries no content and is never persisted or rendered.
     /// It signals only that the connection is still alive.
     KeepAlive,
+
+    /// A user-facing notice from the provider, rendered as chrome on stderr.
+    ///
+    /// Announces provider-level decisions the user must see — a skipped
+    /// credential, a credential switch — without being part of the
+    /// conversation: a notice is never persisted and never reaches the
+    /// conversation stream.
+    Notice(String),
 }
 
 /// A chunk of streaming data from an LLM provider.

--- a/crates/jp_llm/src/event_builder.rs
+++ b/crates/jp_llm/src/event_builder.rs
@@ -65,7 +65,8 @@ pub fn structured_data(events: Vec<Event>) -> Option<Value> {
                 flushed.extend(builder.handle_flush(index, metadata));
             }
             Event::Finished(_) => flushed.extend(builder.drain()),
-            Event::Patch(_) | Event::KeepAlive => {}
+            // A notice is chrome, and carries no structured payload.
+            Event::Patch(_) | Event::KeepAlive | Event::Notice(_) => {}
         }
     }
 

--- a/crates/jp_llm/src/lib.rs
+++ b/crates/jp_llm/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod credential;
 pub mod error;
 pub mod event;
 pub mod event_builder;
@@ -13,6 +14,7 @@ pub mod window;
 #[cfg(test)]
 pub(crate) mod test;
 
+pub use credential::{AccountIdentity, Credential, ProviderAuth, provider_auth};
 pub use error::{Error, StreamError, StreamErrorKind, ToolError};
 pub use provider::Provider;
 pub use retry::{exponential_backoff, retry_delay};

--- a/crates/jp_llm/src/provider.rs
+++ b/crates/jp_llm/src/provider.rs
@@ -47,9 +47,20 @@ pub trait Provider: Send + Sync {
 }
 
 /// Get a provider by ID.
+///
+/// Every provider is constructed from its configuration alone and validates its
+/// own credentials during construction: an environment variable read, or a
+/// credential-chain preflight against the store.
+///
+/// # Errors
+///
+/// Returns an error when the provider cannot possibly authenticate, e.g.
+/// [`Error::MissingEnv`] when its API key environment variable is unset.
+///
+/// [`Error::MissingEnv`]: crate::Error::MissingEnv
 pub fn get_provider(id: ProviderId, config: &LlmProviderConfig) -> Result<Box<dyn Provider>> {
     let provider: Box<dyn Provider> = match id {
-        ProviderId::Anthropic => Box::new(Anthropic::try_from(&config.anthropic)?),
+        ProviderId::Anthropic => Box::new(Anthropic::new(&config.anthropic)?),
         ProviderId::Cerebras => Box::new(Cerebras::try_from(&config.cerebras)?),
         ProviderId::Google => Box::new(Google::try_from(&config.google)?),
         ProviderId::Llamacpp => Box::new(Llamacpp::try_from(&config.llamacpp)?),
@@ -69,7 +80,8 @@ pub fn get_provider(id: ProviderId, config: &LlmProviderConfig) -> Result<Box<dy
 /// Validate that a provider is able to accept requests: credentials present,
 /// configuration well-formed.
 ///
-/// Local and synchronous — performs no I/O.
+/// Synchronous and local: it reads the environment and, for a provider with a
+/// credential chain, a store snapshot — never the network.
 /// Constructing a provider implies this check passes: this *is*
 /// [`get_provider`] with the client thrown away, packaged as an explicit seam
 /// so callers can fail fast before starting side-effectful work (spawning
@@ -103,7 +115,14 @@ pub(crate) fn build_request_value(
 ) -> Result<serde_json::Value> {
     match id {
         ProviderId::Anthropic => {
-            Anthropic::try_from(&config.anthropic)?.request_value(model, query)
+            // A fixed dummy credential: request construction is independent
+            // of the credential's value, and tests must not read the
+            // environment or the store.
+            Anthropic::with_credential(
+                &config.anthropic,
+                crate::credential::Credential::ApiKey("test-api-key".to_owned()),
+            )
+            .request_value(model, query)
         }
         ProviderId::Cerebras => Cerebras::try_from(&config.cerebras)?.request_value(model, query),
         ProviderId::Google => Google::try_from(&config.google)?.request_value(model, query),

--- a/crates/jp_llm/src/provider/anthropic.rs
+++ b/crates/jp_llm/src/provider/anthropic.rs
@@ -1,7 +1,16 @@
-use std::{env, mem, ops::RangeInclusive, time::Duration};
+pub mod auth;
+pub mod oauth;
+pub mod resolve;
+
+use std::{
+    mem,
+    ops::RangeInclusive,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use async_anthropic::{
-    Client,
+    Client, bearer,
     errors::AnthropicError,
     messages::DEFAULT_MAX_TOKENS,
     types::{
@@ -12,7 +21,7 @@ use async_anthropic::{
 use async_stream::try_stream;
 use async_trait::async_trait;
 use base64::Engine as _;
-use chrono::NaiveDate;
+use chrono::{NaiveDate, Utc};
 use futures::{StreamExt as _, TryStreamExt as _, pin_mut, stream};
 use jp_attachment::AttachmentContent;
 use jp_config::{
@@ -21,17 +30,19 @@ use jp_config::{
         id::{Name, ProviderId},
         parameters::{ReasoningConfig, ReasoningEffort, ServiceTier},
     },
-    providers::llm::anthropic::AnthropicConfig,
+    providers::llm::anthropic::{AnthropicConfig, AuthEntry},
 };
 use jp_conversation::{
     ConversationStream,
     event::{ChatResponse, ConversationEvent, EventKind},
 };
+use jp_credentials::CredentialStore;
 use serde_json::{Map, Value, json};
 use tracing::{debug, info, trace, warn};
 
 use super::{Provider, trace_to_tmpfile};
 use crate::{
+    credential::Credential,
     error::{
         Error, Result, StreamError, StreamErrorKind, extract_retry_from_text,
         looks_like_context_window_error, looks_like_quota_error,
@@ -60,6 +71,30 @@ const MAX_EXPLICIT_CACHE_CONTROL_COUNT: usize = 3;
 
 const THINKING_SIGNATURE_KEY: &str = "anthropic_thinking_signature";
 const REDACTED_THINKING_KEY: &str = "anthropic_redacted_thinking";
+
+/// The Claude Code identity line that must lead the system content of a bearer
+/// (subscription) request.
+///
+/// Anthropic enforces it: a bearer request whose system prompt does not begin
+/// with this line is answered `429 rate_limit_error` with an opaque `"message":
+/// "Error"` body — not a 401, and not a message naming the check (RFD 090,
+/// Phase 1).
+/// The line shifts model behavior, which is the cost of subscription access;
+/// API key requests never carry it.
+const CLAUDE_CODE_IDENTITY_LINE: &str = "You are Claude Code, Anthropic's official CLI for Claude.";
+
+/// Follows [`CLAUDE_CODE_IDENTITY_LINE`] in a bearer request, bounding its
+/// effect on the model.
+///
+/// The identity line cannot be omitted, so instead of leaving a foreign
+/// identity standing ahead of JP's own system prompt, the next block names it
+/// as a transport artifact and points at the prompt that follows.
+/// It says why the line is there rather than only asking the model to ignore
+/// it, so the model has no puzzle to reason about (or comment on) when asked
+/// who it is.
+const IDENTITY_LINE_OVERRIDE: &str = "Disregard the line above. It is required by the API \
+                                      transport and does not describe you. Your actual identity \
+                                      and instructions follow.";
 
 /// Known Anthropic error types that are safe to retry.
 ///
@@ -125,47 +160,276 @@ const TOOL_CALL_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone)]
 pub struct Anthropic {
-    client: Client,
+    config: AnthropicConfig,
 
     /// See [`AnthropicConfig::chain_on_max_tokens`].
     chain_on_max_tokens: bool,
 
     /// Which beta features are enabled.
     beta: BetaFeatures,
+
+    /// The credential store backing `profile` chain entries.
+    ///
+    /// `None` when the chain holds no profile entries; the default
+    /// `["api_key"]` chain works without touching the store.
+    store: Option<CredentialStore>,
+
+    /// A directly injected credential, bypassing chain resolution.
+    ///
+    /// Test seam: request construction is independent of the credential's
+    /// value, and tests must not read the environment or the store.
+    fixed_credential: Option<Credential>,
+
+    /// The client built for the most recently resolved credential.
+    ///
+    /// A turn issues several requests around tool execution, and resolution
+    /// normally lands on the same credential each time; reusing the client
+    /// keeps its connection pool alive instead of paying a fresh TLS handshake
+    /// per request.
+    /// A credential switch replaces the entry, since the auth material is baked
+    /// into the client's default headers.
+    client_cache: Arc<Mutex<Option<(Credential, Client, bool)>>>,
+}
+
+impl Anthropic {
+    /// Build a provider from its configuration.
+    ///
+    /// Construction is the credential preflight: it verifies that at least one
+    /// entry of the `auth` chain could resolve, against a store snapshot and
+    /// the environment, so commands fail fast before starting side-effectful
+    /// work.
+    /// The actual credential is resolved anew before each request the provider
+    /// sends.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the chain, the store, or one of their entries is
+    /// config-shaped-broken, or when no chain entry can resolve.
+    pub fn new(config: &AnthropicConfig) -> Result<Self> {
+        let store = config
+            .auth
+            .iter()
+            .any(|entry| matches!(entry, AuthEntry::Profile(_)))
+            .then(CredentialStore::file_default)
+            .transpose()
+            .map_err(resolve::ResolveError::from)?;
+
+        let provider = Anthropic {
+            config: config.clone(),
+            beta: BetaFeatures(config.beta_headers.clone()),
+            chain_on_max_tokens: config.chain_on_max_tokens,
+            store,
+            fixed_credential: None,
+            client_cache: Arc::new(Mutex::new(None)),
+        };
+
+        // No model is named at construction, so only account-scoped cooldowns
+        // participate; per-request resolution applies the precise model scope.
+        if provider.fixed_credential.is_none() {
+            resolve::preflight(&provider.config, provider.store.as_ref(), "", Utc::now())?;
+        }
+
+        Ok(provider)
+    }
+
+    /// Build a provider around an explicit credential, bypassing the chain.
+    ///
+    /// Test seam: no environment or store access, no preflight.
+    #[cfg(test)]
+    pub(crate) fn with_credential(config: &AnthropicConfig, credential: Credential) -> Self {
+        Anthropic {
+            config: config.clone(),
+            beta: BetaFeatures(config.beta_headers.clone()),
+            chain_on_max_tokens: config.chain_on_max_tokens,
+            store: None,
+            fixed_credential: Some(credential),
+            client_cache: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Resolve the credential for a request against `model`.
+    ///
+    /// Refreshes an expired OAuth access token before returning it, so the
+    /// credential handed back is good for the request about to be sent.
+    async fn resolve(&self, model: &str) -> Result<resolve::Attempt> {
+        if let Some(credential) = &self.fixed_credential {
+            return Ok(resolve::Attempt {
+                credential: credential.clone(),
+                selected: None,
+                notices: vec![],
+            });
+        }
+
+        Ok(resolve::resolve(&self.config, self.store.as_ref(), model, Utc::now()).await?)
+    }
+
+    /// Record why the attempt's credential is out and move to the next one.
+    ///
+    /// Returns `None` when there is no chain to advance or nothing further in
+    /// it, which the caller surfaces as the original, now-terminal error.
+    async fn advance(
+        &self,
+        attempt: &resolve::Attempt,
+        error: &StreamError,
+        model: &str,
+    ) -> Option<resolve::Attempt> {
+        let spent = attempt.selected.as_ref()?;
+        resolve::advance(
+            &self.config,
+            self.store.as_ref(),
+            spent,
+            error,
+            model,
+            Utc::now(),
+        )
+        .await
+    }
+
+    /// Advance after a non-streaming request failed, or surface the failure.
+    async fn advance_or_fail(
+        &self,
+        attempt: &resolve::Attempt,
+        error: AnthropicError,
+        model: &str,
+    ) -> Result<resolve::Attempt> {
+        if !is_switchable(&error) {
+            return Err(error.into());
+        }
+
+        let error = StreamError::from(error);
+        match self.advance(attempt, &error, model).await {
+            Some(next) => Ok(next),
+            None => Err(Error::Stream(error)),
+        }
+    }
+
+    /// Build the HTTP client for a resolved credential.
+    ///
+    /// Returns the client and whether it authenticates with a bearer token.
+    /// Bearer requests carry the Claude Code fingerprint, including the
+    /// identity line leading the system content, so the flag feeds request
+    /// construction, not only the auth header.
+    fn client_for(&self, credential: &Credential) -> Result<(Client, bool)> {
+        let mut cache = self.client_cache.lock().expect("poisoned");
+        if let Some((cached, client, bearer)) = cache.as_ref()
+            && cached == credential
+        {
+            return Ok((client.clone(), *bearer));
+        }
+
+        let mut builder = Client::builder();
+        builder
+            .base_url(self.config.base_url.clone())
+            .version("2023-06-01");
+
+        let bearer = match credential {
+            Credential::ApiKey(key) => {
+                builder.api_key(key.clone());
+                false
+            }
+            Credential::Bearer(token) => {
+                builder.auth_token(token.clone());
+                true
+            }
+        };
+
+        if !self.config.beta_headers.is_empty() {
+            builder.beta(self.config.beta_headers.join(","));
+        }
+
+        // Bearer mode changes the request fingerprint, not just the auth
+        // header, so record which mode a request went out in and the beta
+        // set that accompanied it.
+        debug!(
+            bearer,
+            betas = %if bearer {
+                bearer::merge_betas(
+                    (!self.config.beta_headers.is_empty())
+                        .then(|| self.config.beta_headers.join(","))
+                        .as_deref(),
+                )
+            } else {
+                self.config.beta_headers.join(",")
+            },
+            "Constructing Anthropic client."
+        );
+
+        let client = builder
+            .build()
+            .map_err(|e| Error::Anthropic(AnthropicError::Unknown(e.to_string())))?;
+
+        *cache = Some((credential.clone(), client.clone(), bearer));
+
+        Ok((client, bearer))
+    }
+}
+
+/// Whether a failure means the credential is spent or refused, so the request
+/// can only proceed under a different credential.
+fn is_switchable(error: &AnthropicError) -> bool {
+    match error {
+        AnthropicError::Auth { .. } => true,
+        AnthropicError::RateLimit { limits, .. } => limits.is_quota_rejection(),
+        _ => false,
+    }
 }
 
 #[async_trait]
 impl Provider for Anthropic {
     async fn model_details(&self, name: &Name) -> Result<ModelDetails> {
-        let model = self.client.models().get(name).await?;
-        map_model(model)
+        let mut attempt = self.resolve(name).await?;
+
+        loop {
+            for notice in mem::take(&mut attempt.notices) {
+                warn!("{notice}");
+            }
+
+            let (client, _) = self.client_for(&attempt.credential)?;
+            match client.models().get(name).await {
+                Ok(model) => return map_model(model),
+                Err(error) => attempt = self.advance_or_fail(&attempt, error, name).await?,
+            }
+        }
     }
 
     async fn models(&self) -> Result<Vec<ModelDetails>> {
-        let mut all_models = vec![];
-        let mut after_id = None;
+        // No model is named, so only account-scoped cooldowns participate in
+        // resolution.
+        let mut attempt = self.resolve("").await?;
 
-        loop {
-            let path = match after_id {
-                Some(id) => format!("/v1/models?after_id={id}"),
-                None => "/v1/models".to_string(),
-            };
-
-            let models;
-            (after_id, models) = self
-                .client
-                .get::<ListModelsResponse>(&path)
-                .await
-                .map(|list| (list.has_more.then_some(list.last_id).flatten(), list.data))?;
-
-            all_models.extend(models);
-
-            if after_id.is_none() {
-                break;
+        'attempt: loop {
+            for notice in mem::take(&mut attempt.notices) {
+                warn!("{notice}");
             }
-        }
 
-        all_models.into_iter().map(map_model).collect::<Result<_>>()
+            let (client, _) = self.client_for(&attempt.credential)?;
+            let mut all_models = vec![];
+            let mut after_id = None;
+
+            loop {
+                let path = match after_id {
+                    Some(id) => format!("/v1/models?after_id={id}"),
+                    None => "/v1/models".to_string(),
+                };
+
+                let models;
+                (after_id, models) = match client.get::<ListModelsResponse>(&path).await {
+                    Ok(list) => (list.has_more.then_some(list.last_id).flatten(), list.data),
+                    Err(error) => {
+                        attempt = self.advance_or_fail(&attempt, error, "").await?;
+                        continue 'attempt;
+                    }
+                };
+
+                all_models.extend(models);
+
+                if after_id.is_none() {
+                    break;
+                }
+            }
+
+            return all_models.into_iter().map(map_model).collect::<Result<_>>();
+        }
     }
 
     async fn chat_completion_stream(
@@ -173,7 +437,6 @@ impl Provider for Anthropic {
         model: &ModelDetails,
         query: ChatQuery,
     ) -> Result<EventStream> {
-        let client = self.client.clone();
         let max_tokens_config = query
             .thread
             .events
@@ -183,36 +446,113 @@ impl Provider for Anthropic {
             .parameters
             .max_tokens;
 
-        let (request, is_structured, forced_tool) = create_request(model, query, true, &self.beta)?;
+        // The initial resolution happens here so a doomed request fails as an
+        // ordinary error before a stream exists; switches re-resolve inside
+        // the stream.
+        let attempt = self.resolve(model.name()).await?;
 
-        // Chaining is disabled for structured output — the provider guarantees
-        // schema compliance so the response won't hit max_tokens for a
-        // well-constrained schema.
-        //
-        // It is also disabled when the user has explicitly configured a max
-        // tokens value, or when chaining is disabled in the provider config.
-        let chain_on_max_tokens =
-            !is_structured && max_tokens_config.is_none() && self.chain_on_max_tokens;
-        let chains_remaining = if chain_on_max_tokens {
-            MAX_CHAIN_DEPTH
-        } else {
-            0
-        };
+        let this = self.clone();
+        let model = model.clone();
+        let stream = try_stream!({
+            let mut attempt = attempt;
 
-        debug!(stream = true, "Anthropic chat completion stream request.");
-        trace!(
-            request = %trace_to_tmpfile("jp-anthropic-request", &request),
-            "Request payload."
-        );
+            'attempt: loop {
+                for notice in mem::take(&mut attempt.notices) {
+                    yield Event::Notice(notice);
+                }
+
+                // Client and request are rebuilt per attempt: a bearer and an
+                // API key request differ in fingerprint, not only in the auth
+                // header.
+                let (client, bearer) = this
+                    .client_for(&attempt.credential)
+                    .map_err(|e| StreamError::other(e.to_string()))?;
+                let (request, is_structured, forced_tool) =
+                    create_request(&model, query.clone(), true, &this.beta, bearer)
+                        .map_err(|e| StreamError::other(e.to_string()))?;
+
+                // Chaining is disabled for structured output — the provider
+                // guarantees schema compliance so the response won't hit
+                // max_tokens for a well-constrained schema.
+                //
+                // It is also disabled when the user has explicitly configured
+                // a max tokens value, or when chaining is disabled in the
+                // provider config.
+                let chains_remaining =
+                    if !is_structured && max_tokens_config.is_none() && this.chain_on_max_tokens {
+                        MAX_CHAIN_DEPTH
+                    } else {
+                        0
+                    };
+
+                debug!(stream = true, "Anthropic chat completion stream request.");
+                trace!(
+                    request = %trace_to_tmpfile("jp-anthropic-request", &request),
+                    "Request payload."
+                );
+
+                let inner = call(
+                    client,
+                    request,
+                    chains_remaining,
+                    is_structured,
+                    forced_tool,
+                    resolve::QuotaWatch::new(this.store.as_ref(), attempt.selected.as_ref()),
+                );
+                pin_mut!(inner);
+
+                // Whether the request produced content: a switch is only
+                // silent at admission, before anything reached the stream.
+                let mut content_seen = false;
+
+                while let Some(item) = inner.next().await {
+                    match item {
+                        Ok(event) => {
+                            content_seen = content_seen
+                                || !matches!(event, Event::KeepAlive | Event::Notice(_));
+                            yield event;
+                        }
+                        Err(error) if error.needs_credential_switch() => {
+                            let Some(next) = this.advance(&attempt, &error, model.name()).await
+                            else {
+                                // Chain exhausted: the failure that prompted
+                                // the switch is terminal, reported as itself.
+                                Err(error)?;
+                                return;
+                            };
+
+                            if content_seen {
+                                // Mid-stream: partial content already reached
+                                // the caller, so an internal re-send would
+                                // duplicate it. The recorded outcome routes
+                                // the caller's retry onto the next credential;
+                                // surface the failure as retryable so the
+                                // existing retry flow (flush partial content,
+                                // rebuild the thread, fresh stream) takes it
+                                // from here.
+                                for notice in next.notices {
+                                    yield Event::Notice(notice);
+                                }
+                                Err(StreamError::transient(error.to_string()))?;
+                                return;
+                            }
+
+                            attempt = next;
+                            continue 'attempt;
+                        }
+                        Err(error) => {
+                            Err(error)?;
+                            return;
+                        }
+                    }
+                }
+
+                return;
+            }
+        });
 
         Ok(with_tool_call_keepalive(
-            call(
-                client,
-                request,
-                chains_remaining,
-                is_structured,
-                forced_tool,
-            ),
+            Box::pin(stream),
             TOOL_CALL_KEEPALIVE_INTERVAL,
         ))
     }
@@ -290,6 +630,7 @@ fn call(
     chains_remaining: u8,
     is_structured: bool,
     forced_tool_fallback: Option<ForcedToolFallback>,
+    watch: resolve::QuotaWatch,
 ) -> EventStream {
     Box::pin(try_stream!({
         // Buffer flushed ConversationEvents for chaining. When MaxTokens hits,
@@ -314,10 +655,22 @@ fn call(
         // tool).
         let mut tool_names_called: Vec<String> = vec![];
 
-        let stream = client
+        // An admission rejection (a spent quota, a refused credential)
+        // surfaces here, before any event exists.
+        let response = client
             .messages()
             .create_stream(request.clone())
             .await
+            .map_err(StreamError::from)?;
+
+        // The response's quota headers report the subscription's state even
+        // when the request succeeded.
+        for notice in watch.observe(&response.limits, Utc::now()) {
+            yield Event::Notice(notice);
+        }
+
+        let stream = response
+            .stream
             .map_err(StreamError::from)
             .map_ok(|v| stream::iter(map_event(v, is_structured)))
             .try_flatten()
@@ -363,6 +716,7 @@ fn call(
                         chain_events,
                         is_structured,
                         chains_remaining - 1,
+                        watch.clone(),
                     ) {
                         yield event?;
                     }
@@ -385,6 +739,7 @@ fn call(
                         chain_events,
                         fallback,
                         is_structured,
+                        watch.clone(),
                     ) {
                         yield event?;
                     }
@@ -438,6 +793,7 @@ fn call(
                 }
                 patch @ Event::Patch(_) => yield patch,
                 keep_alive @ Event::KeepAlive => yield keep_alive,
+                notice @ Event::Notice(_) => yield notice,
             }
         }
     }))
@@ -458,6 +814,7 @@ fn chain(
     events: Vec<ConversationEvent>,
     is_structured: bool,
     chains_remaining: u8,
+    watch: resolve::QuotaWatch,
 ) -> EventStream {
     debug_assert!(!events.iter().any(ConversationEvent::is_tool_call_request));
 
@@ -499,7 +856,14 @@ fn chain(
     });
 
     Box::pin(try_stream!({
-        for await event in call(client, request, chains_remaining, is_structured, None) {
+        for await event in call(
+            client,
+            request,
+            chains_remaining,
+            is_structured,
+            None,
+            watch,
+        ) {
             let mut event = event?;
 
             // When chaining new events, the reasoning content is irrelevant, as
@@ -545,6 +909,7 @@ fn dispatch_force_retry(
     events: Vec<ConversationEvent>,
     fallback: &ForcedToolFallback,
     is_structured: bool,
+    watch: resolve::QuotaWatch,
 ) -> EventStream {
     match fallback.strategy {
         ForceStrategy::DisableThinking => {
@@ -552,14 +917,22 @@ fn dispatch_force_retry(
                 "Model did not call the required tool. Retrying with thinking disabled and forced \
                  tool_choice."
             );
-            force_tool_retry(client, request, events, fallback, is_structured)
+            force_tool_retry(client, request, events, fallback, is_structured, watch)
         }
         ForceStrategy::EscalatingNudge { remaining } => {
             info!(
                 remaining,
                 "Model did not call the required tool. Retrying with a firmer nudge."
             );
-            soft_force_retry(client, request, events, fallback, is_structured, remaining)
+            soft_force_retry(
+                client,
+                request,
+                events,
+                fallback,
+                is_structured,
+                remaining,
+                watch,
+            )
         }
     }
 }
@@ -577,6 +950,7 @@ fn force_tool_retry(
     events: Vec<ConversationEvent>,
     fallback: &ForcedToolFallback,
     is_structured: bool,
+    watch: resolve::QuotaWatch,
 ) -> EventStream {
     // Append the assistant's response from the first request.
     let message = events
@@ -627,7 +1001,7 @@ fn force_tool_retry(
 
     Box::pin(try_stream!({
         // Pass `None` for forced_tool_fallback to prevent infinite retries.
-        for await event in call(client, request, 0, is_structured, None) {
+        for await event in call(client, request, 0, is_structured, None, watch) {
             let event = event?;
 
             // Skip reasoning (shouldn't appear with thinking disabled, but
@@ -659,6 +1033,7 @@ fn soft_force_retry(
     fallback: &ForcedToolFallback,
     is_structured: bool,
     remaining: u8,
+    watch: resolve::QuotaWatch,
 ) -> EventStream {
     // Append the assistant's (non-compliant) response from the previous attempt.
     let message = events
@@ -709,7 +1084,7 @@ fn soft_force_retry(
     });
 
     Box::pin(try_stream!({
-        for await event in call(client, request, 0, is_structured, next_fallback) {
+        for await event in call(client, request, 0, is_structured, next_fallback, watch) {
             yield event?;
         }
 
@@ -1193,7 +1568,8 @@ impl Anthropic {
         model: &ModelDetails,
         query: ChatQuery,
     ) -> Result<serde_json::Value> {
-        let (request, ..) = create_request(model, query, true, &self.beta)?;
+        let bearer = matches!(self.fixed_credential, Some(Credential::Bearer(_)));
+        let (request, ..) = create_request(model, query, true, &self.beta, bearer)?;
         Ok(serde_json::to_value(request)?)
     }
 }
@@ -1204,6 +1580,7 @@ fn create_request(
     query: ChatQuery,
     stream: bool,
     beta: &BetaFeatures,
+    bearer: bool,
 ) -> Result<(
     types::CreateMessagesRequest,
     bool,
@@ -1497,6 +1874,26 @@ fn create_request(
 
     if !tools.is_empty() {
         builder.tools(tools).tool_choice(tool_choice);
+    }
+
+    // Bearer requests must open with the Claude Code identity line;
+    // Anthropic rejects them otherwise. The override immediately after it
+    // keeps the foreign identity from standing as an instruction.
+    // Both are inserted after cache breakpoints are assigned, so the cached
+    // block keeps its annotation and neither of these is a breakpoint itself.
+    if bearer {
+        for (i, text) in [CLAUDE_CODE_IDENTITY_LINE, IDENTITY_LINE_OVERRIDE]
+            .into_iter()
+            .enumerate()
+        {
+            system_content.insert(
+                i,
+                types::SystemContent::Text(types::Text {
+                    text: text.to_owned(),
+                    cache_control: None,
+                }),
+            );
+        }
     }
 
     if !system_content.is_empty() {
@@ -1968,31 +2365,14 @@ fn map_event(
     }
 }
 
-impl TryFrom<&AnthropicConfig> for Anthropic {
-    type Error = Error;
-
-    fn try_from(config: &AnthropicConfig) -> Result<Self> {
-        let api_key = env::var(&config.api_key_env)
-            .map_err(|_| Error::MissingEnv(config.api_key_env.clone()))?;
-
-        let mut builder = Client::builder();
-        builder
-            .api_key(api_key)
-            .base_url(config.base_url.clone())
-            .version("2023-06-01");
-
-        if !config.beta_headers.is_empty() {
-            builder.beta(config.beta_headers.join(","));
-        }
-
-        Ok(Anthropic {
-            beta: BetaFeatures(config.beta_headers.clone()),
-            chain_on_max_tokens: config.chain_on_max_tokens,
-            client: builder
-                .build()
-                .map_err(|e| Error::Anthropic(AnthropicError::Unknown(e.to_string())))?,
-        })
-    }
+/// Convert a quota reset reported as Unix seconds into a timestamp.
+///
+/// A value that cannot be represented is dropped rather than clamped: the
+/// caller's fallback cooldown is a better answer than a fabricated instant.
+fn quota_reset_at(seconds: u64) -> Option<chrono::DateTime<chrono::Utc>> {
+    i64::try_from(seconds)
+        .ok()
+        .and_then(|secs| chrono::DateTime::from_timestamp(secs, 0))
 }
 
 /// Transform a JSON schema to conform to Anthropic's structured output
@@ -2510,9 +2890,49 @@ impl From<AnthropicError> for StreamError {
         match error {
             E::Network(error) => Self::from(error),
             E::StreamTransport(_) => StreamError::transient(error.to_string()).with_source(error),
-            E::RateLimit { retry_after } => {
-                Self::rate_limit(retry_after.map(Duration::from_secs)).with_source(error)
+            // A subscription window, ordinary throttling, and a rejected
+            // request fingerprint all arrive as `429 rate_limit_error`.
+            // Only the unified quota headers tell them apart: a rejection
+            // that names the exhausted window (or reports on paid
+            // spillover) is a spent allowance; one that carries neither is
+            // not a quota limit at all and is retried in place.
+            E::RateLimit { ref limits, .. } if limits.is_quota_rejection() => {
+                let scope = limits.representative_claim.clone();
+                let reset = limits.reset.and_then(quota_reset_at);
+                let window = scope.as_deref().unwrap_or("account");
+
+                // When paid extra usage could not cover the request either,
+                // the provider says why. Naming the reason distinguishes an
+                // empty wallet from an organization spending cap, which the
+                // user resolves in different places.
+                let refusal = limits
+                    .overage_disabled_reason
+                    .as_deref()
+                    .map(|reason| format!(" Extra usage unavailable: {reason}."))
+                    .unwrap_or_default();
+
+                StreamError::subscription_exhausted(
+                    format!("Subscription limit reached ({window}).{refusal} ({error})"),
+                    reset,
+                    scope,
+                )
+                .with_source(error)
             }
+
+            // The credential itself was refused. Retrying cannot help, and
+            // the shell marks the profile as needing re-login.
+            E::Auth { .. } => StreamError::auth_rejected(error.to_string()).with_source(error),
+
+            // A zero-second hint carries no timing information, and taking
+            // it literally makes the retry layer sleep zero and hammer the
+            // endpoint. Drop it so backoff applies, matching how retry
+            // headers are read elsewhere (see `extract_retry_after`).
+            E::RateLimit { retry_after, .. } => Self::rate_limit(
+                retry_after
+                    .filter(|secs| *secs > 0)
+                    .map(Duration::from_secs),
+            )
+            .with_source(error),
 
             // Anthropic's API is notoriously unreliable, so we special-case a
             // few common errors that most of the times resolve themselves when

--- a/crates/jp_llm/src/provider/anthropic/auth.rs
+++ b/crates/jp_llm/src/provider/anthropic/auth.rs
@@ -1,0 +1,114 @@
+//! Anthropic credential mechanics.
+//!
+//! Account identity recovery via the Claude CLI bootstrap endpoint: given a
+//! fresh access or setup token, the endpoint reports the account UUID and email
+//! the token belongs to.
+//! Login uses it when the token response carries no identity; a profile whose
+//! recovery fails is stored unverified.
+
+use std::time::Duration;
+
+use async_anthropic::bearer;
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::credential::{AccountIdentity, ProviderAuth};
+
+/// The Claude CLI bootstrap endpoint.
+///
+/// Whether it accepts long-lived setup tokens (not just OAuth access tokens) is
+/// an open measurement (RFD 090, Phase 1); a rejection lands on the
+/// unverified-profile path either way.
+const BOOTSTRAP_URL: &str = "https://api.anthropic.com/api/claude_cli/bootstrap";
+
+/// Query parameters the reference implementation pins on the bootstrap call.
+const BOOTSTRAP_QUERY: &[(&str, &str)] = &[("entrypoint", "cli"), ("model", "claude-opus-4-8")];
+
+const BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Anthropic's [`ProviderAuth`] implementation.
+#[derive(Debug, Clone, Copy)]
+pub struct AnthropicAuth;
+
+#[async_trait]
+impl ProviderAuth for AnthropicAuth {
+    fn setup_token_hint(&self) -> &'static str {
+        "Run `claude setup-token` on its own, complete the sign-in, then paste the \
+         `sk-ant-oat01-…` value it prints. That command is an interactive session, so it cannot be \
+         the source of a pipe: every stage of a pipeline starts at once, so JP would read the \
+         stream before a token exists. A non-interactive source pipes fine, e.g. `pbpaste | jp \
+         provider auth login llm.anthropic --setup-token`."
+    }
+
+    async fn recover_identity(
+        &self,
+        token: &str,
+    ) -> Result<AccountIdentity, Box<dyn std::error::Error + Send + Sync>> {
+        let client = bootstrap_client()?;
+
+        let response = client
+            .get(BOOTSTRAP_URL)
+            .query(BOOTSTRAP_QUERY)
+            .header("accept", "application/json")
+            .header("authorization", format!("Bearer {token}"))
+            .header("anthropic-beta", bearer::OAUTH_BETA)
+            .header(
+                "user-agent",
+                format!("claude-code/{}", bearer::CLAUDE_CODE_VERSION),
+            )
+            .send()
+            .await?;
+
+        let status = response.status();
+        let body = response.text().await?;
+
+        if !status.is_success() {
+            return Err(format!("bootstrap endpoint answered HTTP {status}: {body}").into());
+        }
+
+        Ok(parse_bootstrap_response(&body))
+    }
+}
+
+/// Build the HTTP client used for the bootstrap call.
+fn bootstrap_client() -> Result<reqwest::Client, reqwest::Error> {
+    reqwest::Client::builder()
+        .timeout(BOOTSTRAP_TIMEOUT)
+        .build()
+}
+
+#[derive(Deserialize)]
+struct BootstrapResponse {
+    #[serde(default)]
+    oauth_account: Option<BootstrapAccount>,
+}
+
+#[derive(Deserialize)]
+struct BootstrapAccount {
+    #[serde(default)]
+    account_uuid: Option<String>,
+    #[serde(default)]
+    account_email: Option<String>,
+}
+
+/// Extract the account identity from a bootstrap response body.
+///
+/// Missing or empty fields become `None`; an unparseable body is an empty
+/// identity rather than an error, since the response carries best-effort
+/// metadata only.
+fn parse_bootstrap_response(body: &str) -> AccountIdentity {
+    let account = serde_json::from_str::<BootstrapResponse>(body)
+        .ok()
+        .and_then(|response| response.oauth_account);
+
+    let non_empty = |v: Option<String>| v.filter(|s| !s.is_empty());
+
+    account.map_or_else(AccountIdentity::default, |account| AccountIdentity {
+        account_id: non_empty(account.account_uuid),
+        email: non_empty(account.account_email),
+    })
+}
+
+#[cfg(test)]
+#[path = "auth_tests.rs"]
+mod tests;

--- a/crates/jp_llm/src/provider/anthropic/auth_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic/auth_tests.rs
@@ -1,0 +1,45 @@
+use test_log::test;
+
+use super::*;
+
+/// The bootstrap call talks HTTPS, which requires a TLS backend compiled into
+/// `reqwest`.
+/// A missing backend surfaces at client construction as an opaque `builder
+/// error`, so pin it here rather than discovering it at login time.
+#[test]
+fn test_bootstrap_client_builds() {
+    let result = bootstrap_client();
+    assert!(result.is_ok(), "{:?}", result.err());
+}
+
+#[test]
+fn test_parse_bootstrap_response() {
+    let identity = parse_bootstrap_response(
+        r#"{"oauth_account": {"account_uuid": "uuid-1", "account_email": "a@b.c"}}"#,
+    );
+    assert_eq!(identity, AccountIdentity {
+        account_id: Some("uuid-1".to_owned()),
+        email: Some("a@b.c".to_owned()),
+    });
+}
+
+#[test]
+fn test_parse_bootstrap_response_tolerates_gaps() {
+    // Empty strings, missing fields, and unparseable bodies all degrade to
+    // a (partially) empty identity.
+    let cases = [
+        r#"{"oauth_account": {"account_uuid": "", "account_email": "a@b.c"}}"#,
+        r#"{"oauth_account": {"account_email": "a@b.c"}}"#,
+    ];
+    for body in cases {
+        let identity = parse_bootstrap_response(body);
+        assert_eq!(identity.account_id, None, "body: {body}");
+        assert_eq!(identity.email.as_deref(), Some("a@b.c"), "body: {body}");
+    }
+
+    assert_eq!(parse_bootstrap_response("{}"), AccountIdentity::default());
+    assert_eq!(
+        parse_bootstrap_response("not json"),
+        AccountIdentity::default()
+    );
+}

--- a/crates/jp_llm/src/provider/anthropic/oauth.rs
+++ b/crates/jp_llm/src/provider/anthropic/oauth.rs
@@ -1,0 +1,314 @@
+//! Anthropic's OAuth flow: PKCE, token exchange, and refresh.
+//!
+//! The endpoints, client id, and request shapes are Claude Code's, not
+//! published API (RFD 090).
+//! They are named here as constants so a drift shows up in one place.
+//!
+//! Request building and response parsing are pure; [`exchange_code`] and
+//! [`refresh`] are the thin network shell around them.
+//! The browser, the localhost callback, and the store writes live outside this
+//! module.
+
+use std::time::Duration;
+
+use chrono::{DateTime, TimeDelta, Utc};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use sha2::{Digest as _, Sha256};
+
+use crate::credential::AccountIdentity;
+
+/// Claude Code's OAuth client id.
+///
+/// JP borrows it: Anthropic issues `user:inference` only to this client, and
+/// there is no way to register another (RFD 090, Policy risk).
+const CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+
+/// Where the user approves the grant.
+///
+/// Anthropic routes this through `claude.com/cai/*`, which redirects to
+/// `claude.ai/oauth/authorize`.
+const AUTHORIZE_URL: &str = "https://claude.com/cai/oauth/authorize";
+
+/// Where an authorization code and a refresh token are exchanged for tokens.
+const TOKEN_URL: &str = "https://platform.claude.com/v1/oauth/token";
+
+/// The redirect used when no localhost callback can be reached.
+///
+/// The page shows the code for the user to paste back.
+pub const MANUAL_REDIRECT_URL: &str = "https://platform.claude.com/oauth/code/callback";
+
+/// The scopes JP asks for.
+///
+/// Deliberately smaller than Claude Code's own grant, which also requests
+/// API-key creation, session, MCP-server, and file-upload capabilities that JP
+/// has no use for.
+/// `user:profile` is not optional within this set: account attribution needs it
+/// (RFD 090, Phase 1).
+const SCOPES: &[&str] = &["user:profile", "user:inference"];
+
+const TOKEN_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How long before expiry an access token is treated as stale.
+///
+/// Refreshing early keeps a token from expiring between resolution and the
+/// request it was resolved for.
+pub const EXPIRY_BUFFER: TimeDelta = TimeDelta::minutes(5);
+
+/// Errors from the OAuth endpoints.
+#[derive(Debug, thiserror::Error)]
+pub enum OauthError {
+    #[error("could not reach the Anthropic OAuth endpoint")]
+    Transport(#[from] reqwest::Error),
+
+    /// The endpoint refused the grant.
+    ///
+    /// A refused refresh token cannot be recovered by retrying; the profile
+    /// needs a fresh login.
+    #[error("OAuth request rejected (HTTP {status}): {body}")]
+    Rejected { status: u16, body: String },
+
+    #[error("could not parse the OAuth token response: {0}")]
+    Malformed(#[from] serde_json::Error),
+}
+
+impl OauthError {
+    /// Whether the grant itself was refused, as opposed to the request not
+    /// getting through.
+    ///
+    /// Only a refusal means the stored credential is dead; a transport failure
+    /// is worth another attempt later.
+    #[must_use]
+    pub fn is_rejection(&self) -> bool {
+        matches!(self, Self::Rejected { .. })
+    }
+}
+
+/// A PKCE verifier and the challenge derived from it.
+#[derive(Debug, Clone)]
+pub struct Pkce {
+    /// The secret held by the client until the code is exchanged.
+    pub verifier: String,
+
+    /// The `S256` hash of the verifier, sent with the authorize request.
+    pub challenge: String,
+}
+
+impl Pkce {
+    /// Generate a fresh verifier and its challenge.
+    #[must_use]
+    pub fn generate() -> Self {
+        let verifier = random_token();
+        let digest = Sha256::digest(verifier.as_bytes());
+
+        Self {
+            challenge: base64_url(&digest),
+            verifier,
+        }
+    }
+}
+
+/// The tokens an exchange or refresh produced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Tokens {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub expires_at: DateTime<Utc>,
+
+    /// The account the tokens belong to, when the response named it.
+    pub identity: AccountIdentity,
+}
+
+/// 256 bits of URL-safe randomness, for a PKCE verifier or an OAuth `state`.
+///
+/// Sourced from v4 UUIDs, which are drawn from the platform's cryptographic
+/// random number generator.
+#[must_use]
+pub fn random_token() -> String {
+    let mut bytes = [0u8; 32];
+    bytes[..16].copy_from_slice(uuid::Uuid::new_v4().as_bytes());
+    bytes[16..].copy_from_slice(uuid::Uuid::new_v4().as_bytes());
+
+    base64_url(&bytes)
+}
+
+/// Base64 encode without padding, using the URL-safe alphabet.
+fn base64_url(bytes: &[u8]) -> String {
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// The URL the user opens to approve the grant.
+///
+/// `redirect_uri` is the localhost callback, or [`MANUAL_REDIRECT_URL`] when no
+/// callback can be reached.
+#[must_use]
+pub fn authorize_url(challenge: &str, state: &str, redirect_uri: &str) -> String {
+    let query = [
+        // Tells the consent page this is a CLI code flow.
+        ("code", "true"),
+        ("client_id", CLIENT_ID),
+        ("response_type", "code"),
+        ("redirect_uri", redirect_uri),
+        ("scope", &SCOPES.join(" ")),
+        ("code_challenge", challenge),
+        ("code_challenge_method", "S256"),
+        ("state", state),
+    ]
+    .into_iter()
+    .map(|(key, value)| format!("{key}={}", urlencode(value)))
+    .collect::<Vec<_>>()
+    .join("&");
+
+    format!("{AUTHORIZE_URL}?{query}")
+}
+
+/// Percent-encode a query parameter value.
+fn urlencode(value: &str) -> String {
+    value
+        .bytes()
+        .map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                (byte as char).to_string()
+            }
+            _ => format!("%{byte:02X}"),
+        })
+        .collect()
+}
+
+/// The body of an authorization-code exchange.
+#[must_use]
+pub fn exchange_body(code: &str, state: &str, verifier: &str, redirect_uri: &str) -> Value {
+    json!({
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": CLIENT_ID,
+        "code_verifier": verifier,
+        "state": state,
+    })
+}
+
+/// The body of a refresh-token exchange.
+#[must_use]
+pub fn refresh_body(refresh_token: &str) -> Value {
+    json!({
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": CLIENT_ID,
+        "scope": SCOPES.join(" "),
+    })
+}
+
+/// Exchange an authorization code for tokens.
+///
+/// # Errors
+///
+/// Returns an error when the endpoint cannot be reached, refuses the code, or
+/// answers with a body this build cannot read.
+pub async fn exchange_code(
+    code: &str,
+    state: &str,
+    verifier: &str,
+    redirect_uri: &str,
+) -> Result<Tokens, OauthError> {
+    post_token(
+        exchange_body(code, state, verifier, redirect_uri),
+        Utc::now(),
+    )
+    .await
+}
+
+/// Trade a refresh token for a fresh access token.
+///
+/// The refresh token rotates: the response usually carries a new one, and the
+/// old one stops working.
+/// Persisting the result is the caller's job, and must happen under the store
+/// lock.
+///
+/// # Errors
+///
+/// Returns an error when the endpoint cannot be reached, refuses the token, or
+/// answers with a body this build cannot read.
+pub async fn refresh(refresh_token: &str) -> Result<Tokens, OauthError> {
+    let mut tokens = post_token(refresh_body(refresh_token), Utc::now()).await?;
+
+    // A response that omits `refresh_token` leaves the current one in force.
+    if tokens.refresh_token.is_empty() {
+        tokens.refresh_token = refresh_token.to_owned();
+    }
+
+    Ok(tokens)
+}
+
+/// Send a token request and read the response.
+async fn post_token(body: Value, now: DateTime<Utc>) -> Result<Tokens, OauthError> {
+    let response = reqwest::Client::builder()
+        .timeout(TOKEN_TIMEOUT)
+        .build()?
+        .post(TOKEN_URL)
+        .json(&body)
+        .send()
+        .await?;
+
+    let status = response.status();
+    let text = response.text().await?;
+
+    if !status.is_success() {
+        return Err(OauthError::Rejected {
+            status: status.as_u16(),
+            body: text,
+        });
+    }
+
+    parse_tokens(&text, now)
+}
+
+/// The token endpoint's response.
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+
+    #[serde(default)]
+    refresh_token: String,
+
+    /// Lifetime of the access token, in seconds.
+    expires_in: i64,
+
+    #[serde(default)]
+    account: Option<TokenAccount>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenAccount {
+    #[serde(default)]
+    uuid: Option<String>,
+
+    #[serde(default)]
+    email_address: Option<String>,
+}
+
+/// Parse a token response, resolving its relative expiry against `now`.
+fn parse_tokens(body: &str, now: DateTime<Utc>) -> Result<Tokens, OauthError> {
+    let response: TokenResponse = serde_json::from_str(body)?;
+
+    let non_empty = |value: Option<String>| value.filter(|v| !v.is_empty());
+    let identity = response
+        .account
+        .map_or_else(AccountIdentity::default, |account| AccountIdentity {
+            account_id: non_empty(account.uuid),
+            email: non_empty(account.email_address),
+        });
+
+    Ok(Tokens {
+        access_token: response.access_token,
+        refresh_token: response.refresh_token,
+        expires_at: now + TimeDelta::seconds(response.expires_in),
+        identity,
+    })
+}
+
+#[cfg(test)]
+#[path = "oauth_tests.rs"]
+mod tests;

--- a/crates/jp_llm/src/provider/anthropic/oauth_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic/oauth_tests.rs
@@ -1,0 +1,186 @@
+use datetime_literal::datetime;
+use test_log::test;
+
+use super::*;
+
+const NOW: fn() -> DateTime<Utc> = || datetime!(2026-07-03 12:00:00 Z);
+
+/// The verifier must survive a URL round-trip unencoded and carry enough
+/// entropy to be unguessable; RFC 7636 puts the floor at 43 characters.
+#[test]
+fn test_pkce_verifier_is_url_safe_and_long_enough() {
+    let pkce = Pkce::generate();
+
+    assert!(pkce.verifier.len() >= 43, "{}", pkce.verifier);
+    assert!(
+        pkce.verifier
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+        "{}",
+        pkce.verifier
+    );
+}
+
+#[test]
+fn test_pkce_pairs_are_distinct() {
+    let first = Pkce::generate();
+    let second = Pkce::generate();
+
+    assert_ne!(first.verifier, second.verifier);
+    assert_ne!(first.challenge, second.challenge);
+}
+
+/// The challenge is the `S256` hash of the verifier: the server recomputes it
+/// from the verifier at exchange time, so an incorrect derivation fails the
+/// whole flow.
+///
+/// The vector is RFC 7636's appendix B example.
+#[test]
+fn test_challenge_is_the_s256_hash_of_the_verifier() {
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let digest = Sha256::digest(verifier.as_bytes());
+
+    assert_eq!(
+        base64_url(&digest),
+        "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+    );
+}
+
+#[test]
+fn test_authorize_url_carries_the_pkce_and_scope_parameters() {
+    let url = authorize_url(
+        "challenge-value",
+        "state-value",
+        "http://localhost:7654/callback",
+    );
+
+    assert!(
+        url.starts_with("https://claude.com/cai/oauth/authorize?"),
+        "{url}"
+    );
+    assert!(
+        url.contains("client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e"),
+        "{url}"
+    );
+    assert!(url.contains("response_type=code"), "{url}");
+    assert!(url.contains("code_challenge=challenge-value"), "{url}");
+    assert!(url.contains("code_challenge_method=S256"), "{url}");
+    assert!(url.contains("state=state-value"), "{url}");
+
+    // The redirect and the space-separated scope list must be encoded, or the
+    // consent page reads them as extra parameters.
+    assert!(
+        url.contains("redirect_uri=http%3A%2F%2Flocalhost%3A7654%2Fcallback"),
+        "{url}"
+    );
+    assert!(
+        url.contains("scope=user%3Aprofile%20user%3Ainference"),
+        "{url}"
+    );
+}
+
+/// JP asks for less than Claude Code's own grant: no API-key creation, no
+/// session, MCP-server, or file-upload capabilities.
+#[test]
+fn test_authorize_url_requests_only_the_reduced_scope_set() {
+    let url = authorize_url("c", "s", MANUAL_REDIRECT_URL);
+
+    assert!(!url.contains("org%3Acreate_api_key"), "{url}");
+    assert!(!url.contains("user%3Asessions"), "{url}");
+    assert!(!url.contains("user%3Amcp_servers"), "{url}");
+    assert!(!url.contains("user%3Afile_upload"), "{url}");
+}
+
+#[test]
+fn test_exchange_body_shape() {
+    let body = exchange_body(
+        "the-code",
+        "the-state",
+        "the-verifier",
+        "http://localhost:1/callback",
+    );
+
+    assert_eq!(body["grant_type"], "authorization_code");
+    assert_eq!(body["code"], "the-code");
+    assert_eq!(body["state"], "the-state");
+    assert_eq!(body["code_verifier"], "the-verifier");
+    assert_eq!(body["redirect_uri"], "http://localhost:1/callback");
+    assert_eq!(body["client_id"], "9d1c250a-e61b-44d9-88ed-5944d1962f5e");
+}
+
+#[test]
+fn test_refresh_body_shape() {
+    let body = refresh_body("the-refresh-token");
+
+    assert_eq!(body["grant_type"], "refresh_token");
+    assert_eq!(body["refresh_token"], "the-refresh-token");
+    assert_eq!(body["client_id"], "9d1c250a-e61b-44d9-88ed-5944d1962f5e");
+    assert_eq!(body["scope"], "user:profile user:inference");
+}
+
+/// The endpoint reports a *relative* lifetime, so the absolute expiry depends
+/// on when the response arrived.
+#[test]
+fn test_expiry_is_resolved_against_the_response_time() {
+    let tokens = parse_tokens(
+        r#"{"access_token":"at","refresh_token":"rt","expires_in":3600}"#,
+        NOW(),
+    )
+    .unwrap();
+
+    assert_eq!(tokens.access_token, "at");
+    assert_eq!(tokens.refresh_token, "rt");
+    assert_eq!(tokens.expires_at, datetime!(2026-07-03 13:00:00 Z));
+    assert_eq!(tokens.identity, AccountIdentity::default());
+}
+
+#[test]
+fn test_account_identity_is_read_when_present() {
+    let tokens = parse_tokens(
+        r#"{
+            "access_token": "at",
+            "refresh_token": "rt",
+            "expires_in": 60,
+            "account": { "uuid": "acct-1", "email_address": "jean@example.com" }
+        }"#,
+        NOW(),
+    )
+    .unwrap();
+
+    assert_eq!(tokens.identity, AccountIdentity {
+        account_id: Some("acct-1".to_owned()),
+        email: Some("jean@example.com".to_owned()),
+    });
+}
+
+/// An account block with empty strings carries no identity, and must not be
+/// mistaken for a verified profile.
+#[test]
+fn test_empty_account_fields_are_not_an_identity() {
+    let tokens = parse_tokens(
+        r#"{
+            "access_token": "at",
+            "refresh_token": "rt",
+            "expires_in": 60,
+            "account": { "uuid": "", "email_address": "" }
+        }"#,
+        NOW(),
+    )
+    .unwrap();
+
+    assert_eq!(tokens.identity, AccountIdentity::default());
+}
+
+/// A refusal is terminal for the credential, while a transport failure is worth
+/// another attempt; the caller marks a profile for re-login on the former only.
+#[test]
+fn test_only_a_refusal_is_a_rejection() {
+    let rejected = OauthError::Rejected {
+        status: 400,
+        body: "invalid_grant".to_owned(),
+    };
+    assert!(rejected.is_rejection());
+
+    let malformed = OauthError::Malformed(serde_json::from_str::<Value>("{").unwrap_err());
+    assert!(!malformed.is_rejection());
+}

--- a/crates/jp_llm/src/provider/anthropic/resolve.rs
+++ b/crates/jp_llm/src/provider/anthropic/resolve.rs
@@ -1,0 +1,706 @@
+//! Anthropic credential-chain resolution.
+//!
+//! Walks the `providers.llm.anthropic.auth` chain in order and produces the
+//! first usable credential.
+//! Config-shaped problems (an entry naming no stored profile, a malformed
+//! store, a chain with no possibly-resolvable entry) are hard errors; per-entry
+//! state (a profile needing re-login, an active cooldown, a missing environment
+//! variable in a multi-entry chain) is a skip that falls through to the next
+//! entry.
+//!
+//! Outcomes are recorded through the core-owned credential store
+//! (`jp_credentials`): a spent profile gets a scoped cooldown, a refused one a
+//! re-login marker, and the recorded state is what routes the next resolution
+//! past it — a mid-turn switch and a fresh invocation share one code path.
+
+use std::env;
+
+use async_anthropic::errors::{UnifiedRateLimit, WindowUtilization};
+use chrono::{DateTime, Utc};
+use jp_config::providers::llm::anthropic::{AnthropicConfig, AuthEntry};
+use jp_credentials::{
+    CATEGORY_LLM, CredentialSecret, CredentialStore, PROVIDER_ANTHROPIC, SCOPE_ACCOUNT,
+    StoreDocument, StoreError, StoredCredential, cooldown_until,
+};
+use tracing::{debug, warn};
+
+use crate::{credential::Credential, error::StreamError, provider::anthropic::oauth};
+
+/// Errors from walking the credential chain.
+#[derive(Debug, thiserror::Error)]
+pub enum ResolveError {
+    #[error(transparent)]
+    Store(#[from] StoreError),
+
+    /// A `profile:<name>` entry names a profile that is not stored.
+    #[error(
+        "providers.llm.anthropic.auth entry `profile:{name}` matches no stored profile; run `jp \
+         provider auth login llm.anthropic --profile {name}` to create it"
+    )]
+    UnknownProfile {
+        /// The profile name the chain entry refers to.
+        name: String,
+    },
+
+    /// A bare `profile` entry with zero stored profiles.
+    #[error(
+        "providers.llm.anthropic.auth entry `profile` matches no stored profile; run `jp provider \
+         auth login llm.anthropic` to create one"
+    )]
+    NoProfiles,
+
+    /// A bare `profile` entry with multiple stored profiles.
+    #[error(
+        "providers.llm.anthropic.auth entry `profile` is ambiguous: multiple profiles are \
+         stored ({}); name one with `profile:<name>`",
+        names.join(", ")
+    )]
+    AmbiguousProfile {
+        /// Every stored profile name the bare entry could refer to.
+        names: Vec<String>,
+    },
+
+    /// The single-entry `["api_key"]` chain with its environment variable
+    /// unset.
+    #[error("Missing environment variable: {0}")]
+    MissingEnv(String),
+
+    /// Every chain entry was skipped.
+    #[error(
+        "no usable credential in the providers.llm.anthropic.auth chain: {}",
+        reasons.join("; ")
+    )]
+    ChainExhausted {
+        /// Why each chain entry was skipped, in chain order.
+        reasons: Vec<String>,
+    },
+
+    /// An expired access token could not be refreshed.
+    ///
+    /// Distinct from a refused refresh, which retires the profile: this is the
+    /// token endpoint being unreachable, which the retry layer above may
+    /// outlast.
+    #[error("could not refresh the access token for profile `{profile}`")]
+    Refresh {
+        profile: String,
+        #[source]
+        source: oauth::OauthError,
+    },
+}
+
+/// What a walk of the chain landed on.
+#[derive(Debug)]
+enum Landing {
+    /// A credential that can be sent as-is.
+    Ready(Credential),
+
+    /// An OAuth profile whose access token is spent or nearly so.
+    ///
+    /// Resolution refreshes it before use; preflight treats it as usable, since
+    /// it has no business making a network call.
+    Stale {
+        profile: String,
+        refresh_token: String,
+    },
+}
+
+/// A resolved chain attempt: the credential to send with, the entry that
+/// produced it, and notices for entries skipped on the way there.
+#[derive(Debug)]
+pub(super) struct Attempt {
+    /// The credential the request authenticates with.
+    pub credential: Credential,
+
+    /// Which chain entry produced the credential, with a bare `profile`
+    /// normalized to the profile it resolved to.
+    ///
+    /// `None` when the credential was injected directly instead of resolved
+    /// from the chain, in which case there is no chain to advance.
+    pub selected: Option<AuthEntry>,
+
+    /// User-facing notices for skipped entries, surfaced as chrome.
+    pub notices: Vec<String>,
+}
+
+/// Check that some entry of the chain could resolve, without any network use.
+///
+/// An access token that has expired counts as usable: [`resolve`] refreshes it
+/// before the request, and refreshing is a network call preflight must not
+/// make.
+///
+/// # Errors
+///
+/// Returns an error when the chain, the store, or one of their entries is
+/// config-shaped-broken, or when no chain entry can resolve.
+pub(super) fn preflight(
+    config: &AnthropicConfig,
+    store: Option<&CredentialStore>,
+    model: &str,
+    now: DateTime<Utc>,
+) -> Result<(), ResolveError> {
+    let snapshot = store.map(CredentialStore::load).transpose()?;
+    walk_chain(config, snapshot.as_ref(), model, now).map(drop)
+}
+
+/// Resolve the first usable credential in the chain.
+///
+/// An expired or nearly-expired OAuth access token is refreshed in place and
+/// the rotated tokens persisted, so a long-lived profile keeps working without
+/// the user logging in again.
+///
+/// The store is only read for profile entries, so the default `["api_key"]`
+/// chain works without touching the store at all.
+pub(super) async fn resolve(
+    config: &AnthropicConfig,
+    store: Option<&CredentialStore>,
+    model: &str,
+    now: DateTime<Utc>,
+) -> Result<Attempt, ResolveError> {
+    // Each pass either resolves or retires one chain entry, so the walk
+    // cannot cycle; the bound is belt against a profile that refuses to
+    // settle.
+    for _ in 0..=config.auth.len() {
+        let snapshot = store.map(CredentialStore::load).transpose()?;
+        let (landing, selected, mut notices) = walk_chain(config, snapshot.as_ref(), model, now)?;
+
+        let stale = match landing {
+            Landing::Ready(credential) => {
+                debug!(
+                    entry = %selected,
+                    mechanism = credential.kind(),
+                    model,
+                    skipped = notices.len(),
+                    "Resolved provider credential."
+                );
+
+                return Ok(Attempt {
+                    credential,
+                    selected: Some(selected),
+                    notices,
+                });
+            }
+            Landing::Stale {
+                profile,
+                refresh_token,
+            } => (profile, refresh_token),
+        };
+
+        let (profile, refresh_token) = stale;
+        debug!(profile, "Access token expired; refreshing.");
+
+        match oauth::refresh(&refresh_token).await {
+            Ok(tokens) => {
+                persist_rotation(store, &profile, &refresh_token, &tokens);
+            }
+
+            // The grant was refused: this profile cannot serve requests again
+            // until the user logs in. Retire it and walk on.
+            Err(error) if error.is_rejection() => {
+                warn!(%error, profile, "Refresh rejected; profile needs a fresh login.");
+                retire(store, &profile, &refresh_token);
+
+                notices.push(format!(
+                    "skipping profile:{profile}: session expired; run `jp provider auth login \
+                     llm.anthropic --profile {profile}`"
+                ));
+            }
+
+            // The endpoint could not be reached. The credential is probably
+            // fine, and so is the next attempt; falling to another chain entry
+            // would not help, since the request itself needs the same network.
+            Err(source) => return Err(ResolveError::Refresh { profile, source }),
+        }
+    }
+
+    Err(ResolveError::ChainExhausted {
+        reasons: vec!["every profile needs a fresh login".to_owned()],
+    })
+}
+
+/// Store the tokens a refresh produced.
+///
+/// Refresh tokens rotate, so the write rechecks its precondition under the
+/// lock: if the stored token is no longer the one this refresh consumed,
+/// another process rotated first and its tokens are the live ones.
+/// Overwriting them would invalidate a credential that works.
+fn persist_rotation(
+    store: Option<&CredentialStore>,
+    profile: &str,
+    consumed: &str,
+    tokens: &oauth::Tokens,
+) {
+    let Some(store) = store else {
+        return;
+    };
+
+    let result = store.mutate(|document| {
+        let Some(credential) = document.profile_mut(CATEGORY_LLM, PROVIDER_ANTHROPIC, profile)
+        else {
+            return Ok(false);
+        };
+
+        if !holds_refresh_token(credential, consumed) {
+            return Ok(false);
+        }
+
+        credential.secret = CredentialSecret::Oauth {
+            access_token: tokens.access_token.clone(),
+            refresh_token: tokens.refresh_token.clone(),
+            expires_at: tokens.expires_at,
+        };
+        credential.needs_relogin = false;
+
+        // A refresh that reports identity verifies a profile stored without
+        // one.
+        if credential.account_id.is_none() {
+            credential
+                .account_id
+                .clone_from(&tokens.identity.account_id);
+            credential.email.clone_from(&tokens.identity.email);
+        }
+
+        Ok(true)
+    });
+
+    match result {
+        Ok(true) => debug!(profile, "Rotated stored OAuth tokens."),
+        Ok(false) => debug!(
+            profile,
+            "Another process rotated this profile first; keeping its tokens."
+        ),
+        Err(error) => warn!(%error, profile, "Could not persist refreshed tokens."),
+    }
+}
+
+/// Mark a profile as needing a fresh login after its refresh was refused.
+///
+/// Rechecks the same precondition as [`persist_rotation`]: a profile another
+/// process has since rotated is healthy, and must not be retired because this
+/// process presented a token that had already been replaced.
+fn retire(store: Option<&CredentialStore>, profile: &str, consumed: &str) {
+    let Some(store) = store else {
+        return;
+    };
+
+    let result = store.mutate(|document| {
+        let Some(credential) = document.profile_mut(CATEGORY_LLM, PROVIDER_ANTHROPIC, profile)
+        else {
+            return Ok(false);
+        };
+
+        if !holds_refresh_token(credential, consumed) {
+            return Ok(false);
+        }
+
+        credential.needs_relogin = true;
+        Ok(true)
+    });
+
+    match result {
+        Ok(true) => {}
+        Ok(false) => debug!(
+            profile,
+            "Profile was rotated while refreshing; leaving it usable."
+        ),
+        Err(error) => warn!(%error, profile, "Could not record credential state."),
+    }
+}
+
+/// Whether a stored credential still holds the refresh token a refresh used.
+fn holds_refresh_token(credential: &StoredCredential, token: &str) -> bool {
+    matches!(
+        &credential.secret,
+        CredentialSecret::Oauth { refresh_token, .. } if refresh_token == token
+    )
+}
+
+/// Move to the next usable credential after `error`.
+///
+/// Records why `spent` is out (a scoped cooldown, or a re-login marker) and
+/// re-resolves the chain; the recorded state is what makes resolution skip the
+/// spent entry.
+/// The returned attempt carries the switch notice, appended after any skip
+/// notices resolution produced.
+///
+/// Returns `None` when the chain has nothing further to offer, which the caller
+/// surfaces as the original, now-terminal error.
+pub(super) async fn advance(
+    config: &AnthropicConfig,
+    store: Option<&CredentialStore>,
+    spent: &AuthEntry,
+    error: &StreamError,
+    model: &str,
+    now: DateTime<Utc>,
+) -> Option<Attempt> {
+    record_outcome(store, spent, error, now);
+
+    // Re-resolution reads the state just recorded against the same instant,
+    // so a cooldown that starts now is already in effect for this walk.
+    // An exhausted chain is not a new failure to report: the caller surfaces
+    // the error that prompted the switch.
+    let mut attempt = match resolve(config, store, model, now).await {
+        Ok(attempt) => attempt,
+        Err(error) => {
+            debug!(%error, "Credential chain exhausted after a failed request.");
+            return None;
+        }
+    };
+
+    // Resolution landing on the same entry means nothing was recorded that
+    // could move it: `api_key` has no store entry, so an exhausted key falls
+    // through instead of being retried forever.
+    if attempt.selected.as_ref() == Some(spent) {
+        debug!("Credential chain did not advance; treating the failure as terminal.");
+        return None;
+    }
+
+    attempt
+        .notices
+        .push(switch_notice(error, spent, attempt.selected.as_ref()));
+
+    Some(attempt)
+}
+
+/// Persist why the spent credential cannot serve the request.
+///
+/// Best-effort: a store that cannot be written costs this switch its
+/// cross-invocation memory, not the request itself.
+fn record_outcome(
+    store: Option<&CredentialStore>,
+    spent: &AuthEntry,
+    error: &StreamError,
+    now: DateTime<Utc>,
+) {
+    // Only a stored profile has state to record against.
+    let AuthEntry::Profile(Some(profile)) = spent else {
+        return;
+    };
+    let Some(store) = store else {
+        return;
+    };
+
+    let result = if error.is_auth_rejected() {
+        store.mark_needs_relogin(CATEGORY_LLM, PROVIDER_ANTHROPIC, profile)
+    } else {
+        let scope = error.quota_scope.as_deref().unwrap_or(SCOPE_ACCOUNT);
+        let until = cooldown_until(error.quota_reset, now);
+        debug!(profile, scope, %until, "Recording quota cooldown.");
+        store.record_cooldown(CATEGORY_LLM, PROVIDER_ANTHROPIC, profile, scope, until)
+    };
+
+    match result {
+        Ok(true) => {}
+        Ok(false) => warn!(
+            profile,
+            "Credential profile vanished before its state was recorded."
+        ),
+        Err(error) => warn!(%error, profile, "Could not record credential state."),
+    }
+}
+
+/// Reads the subscription state a response reported.
+///
+/// The unified quota headers ride on every response, not only on a rejection,
+/// so a spent allowance is visible without waiting for a request to fail.
+/// That matters because an account with paid extra usage enabled keeps serving
+/// requests past its window and bills them: without reading a successful
+/// response, JP would never learn the allowance was gone.
+#[derive(Debug, Clone, Default)]
+pub(super) struct QuotaWatch {
+    /// Where to record what a response reported.
+    ///
+    /// `None` for a request with no stored profile behind it (`api_key`), which
+    /// has nothing to record against.
+    store: Option<CredentialStore>,
+
+    /// The stored profile the request authenticated as.
+    profile: Option<String>,
+}
+
+impl QuotaWatch {
+    /// A watch over the profile `selected` names, if it names one.
+    pub(super) fn new(store: Option<&CredentialStore>, selected: Option<&AuthEntry>) -> Self {
+        let profile = match selected {
+            Some(AuthEntry::Profile(Some(name))) => Some(name.clone()),
+            _ => None,
+        };
+
+        Self {
+            store: profile.is_some().then(|| store.cloned()).flatten(),
+            profile,
+        }
+    }
+
+    /// Act on what a response's quota headers reported.
+    ///
+    /// Returns the notices to surface as chrome.
+    /// A spent allowance is recorded as a cooldown, so the next resolution
+    /// moves off this profile instead of billing another request against paid
+    /// extra usage.
+    pub(super) fn observe(&self, limits: &UnifiedRateLimit, now: DateTime<Utc>) -> Vec<String> {
+        if limits.is_empty() {
+            return vec![];
+        }
+
+        // The window is spent even though the request went through, which
+        // means paid extra usage served it.
+        if limits.is_rejected() {
+            let scope = limits
+                .representative_claim
+                .as_deref()
+                .unwrap_or(SCOPE_ACCOUNT);
+
+            self.record(scope, limits.reset.and_then(reset_at), now);
+
+            return vec![format!(
+                "{} spent; this request was billed as extra usage",
+                window_name(scope)
+            )];
+        }
+
+        limits
+            .warning()
+            .map(|window| vec![warning_notice(window)])
+            .unwrap_or_default()
+    }
+
+    /// Record a cooldown against the watched profile, best-effort.
+    fn record(&self, scope: &str, reset: Option<DateTime<Utc>>, now: DateTime<Utc>) {
+        let (Some(store), Some(profile)) = (&self.store, &self.profile) else {
+            return;
+        };
+
+        let until = cooldown_until(reset, now);
+        debug!(
+            profile,
+            scope,
+            %until,
+            "Recording quota cooldown reported by a successful response."
+        );
+
+        if let Err(error) =
+            store.record_cooldown(CATEGORY_LLM, PROVIDER_ANTHROPIC, profile, scope, until)
+        {
+            warn!(%error, profile, "Could not record credential state.");
+        }
+    }
+}
+
+/// Convert a reset reported as Unix seconds into a timestamp.
+fn reset_at(seconds: u64) -> Option<DateTime<Utc>> {
+    i64::try_from(seconds)
+        .ok()
+        .and_then(|secs| DateTime::from_timestamp(secs, 0))
+}
+
+/// How a usage window is named in user-facing output.
+///
+/// Matches the vocabulary Anthropic's own subscription UI uses, so the notice
+/// names the same limit the user sees on their account.
+fn window_name(claim: &str) -> &str {
+    match claim {
+        "five_hour" => "session limit",
+        "seven_day" => "weekly limit",
+        "seven_day_opus" => "Opus weekly limit",
+        "seven_day_sonnet" => "Sonnet weekly limit",
+        other => other,
+    }
+}
+
+/// The notice for a window that has crossed a warning threshold.
+fn warning_notice(window: &WindowUtilization) -> String {
+    let name = window_name(&window.claim);
+
+    let used = window.utilization.map_or_else(
+        || "nearly spent".to_owned(),
+        |fraction| format!("{:.0}% used", fraction * 100.0),
+    );
+
+    match window.reset.and_then(reset_at) {
+        Some(reset) => format!(
+            "{name} {used}, resets {}",
+            reset.format("%Y-%m-%d %H:%M UTC")
+        ),
+        None => format!("{name} {used}"),
+    }
+}
+
+/// The one-line notice announcing a credential switch.
+fn switch_notice(error: &StreamError, from: &AuthEntry, to: Option<&AuthEntry>) -> String {
+    let reason = if error.is_auth_rejected() {
+        "credential rejected"
+    } else if error.kind == crate::StreamErrorKind::SubscriptionExhausted {
+        "subscription limit reached"
+    } else {
+        "quota exhausted"
+    };
+
+    match to {
+        Some(to) => format!("{reason} ({}) — continuing with {}", label(from), label(to)),
+        None => format!("{reason} ({})", label(from)),
+    }
+}
+
+/// How a chain entry is named in user-facing output.
+fn label(entry: &AuthEntry) -> String {
+    match entry {
+        AuthEntry::ApiKey => "api_key".to_owned(),
+        AuthEntry::Profile(Some(name)) => name.clone(),
+        AuthEntry::Profile(None) => "profile".to_owned(),
+    }
+}
+
+/// Walk the chain and return the first usable credential, the entry that
+/// produced it, and the notices for entries skipped along the way.
+fn walk_chain(
+    config: &AnthropicConfig,
+    store: Option<&StoreDocument>,
+    model: &str,
+    now: DateTime<Utc>,
+) -> Result<(Landing, AuthEntry, Vec<String>), ResolveError> {
+    let mut notices = vec![];
+    let mut reasons = vec![];
+
+    for entry in &config.auth {
+        match entry {
+            AuthEntry::ApiKey => {
+                if let Ok(key) = env::var(&config.api_key_env) {
+                    return Ok((
+                        Landing::Ready(Credential::ApiKey(key)),
+                        AuthEntry::ApiKey,
+                        notices,
+                    ));
+                }
+
+                // Under the single-entry default chain, a missing key is
+                // the same failure it was before chains existed.
+                if config.auth.len() == 1 {
+                    return Err(ResolveError::MissingEnv(config.api_key_env.clone()));
+                }
+
+                skip(
+                    &mut notices,
+                    &mut reasons,
+                    format!(
+                        "api_key: environment variable {} is not set",
+                        config.api_key_env
+                    ),
+                );
+            }
+
+            AuthEntry::Profile(name) => {
+                let (profile, stored) = lookup_profile(store, name.as_deref())?;
+
+                if stored.needs_relogin {
+                    skip(
+                        &mut notices,
+                        &mut reasons,
+                        format!(
+                            "profile:{profile} needs re-login; run `jp provider auth login \
+                             llm.anthropic --profile {profile}`"
+                        ),
+                    );
+                    continue;
+                }
+
+                if let Some((scope, until)) = stored.active_cooldown(model, now) {
+                    skip(
+                        &mut notices,
+                        &mut reasons,
+                        format!("profile:{profile} cooling down until {until} ({scope})"),
+                    );
+                    continue;
+                }
+
+                // A bare `profile` entry is reported as the profile it
+                // resolved to, so callers and logs name a concrete
+                // credential.
+                let selected = AuthEntry::Profile(Some(profile.to_owned()));
+
+                match &stored.secret {
+                    CredentialSecret::Token { token } => {
+                        return Ok((
+                            Landing::Ready(Credential::Bearer(token.clone())),
+                            selected,
+                            notices,
+                        ));
+                    }
+                    CredentialSecret::Oauth {
+                        access_token,
+                        refresh_token,
+                        expires_at,
+                    } => {
+                        // Refreshed slightly before the deadline, so a token
+                        // cannot expire between being resolved and being used.
+                        if *expires_at <= now + oauth::EXPIRY_BUFFER {
+                            return Ok((
+                                Landing::Stale {
+                                    profile: profile.to_owned(),
+                                    refresh_token: refresh_token.clone(),
+                                },
+                                selected,
+                                notices,
+                            ));
+                        }
+
+                        return Ok((
+                            Landing::Ready(Credential::Bearer(access_token.clone())),
+                            selected,
+                            notices,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    Err(ResolveError::ChainExhausted { reasons })
+}
+
+/// Record a skipped entry as both a chrome notice and an exhaustion reason.
+fn skip(notices: &mut Vec<String>, reasons: &mut Vec<String>, reason: String) {
+    debug!("Skipping credential chain entry: {reason}");
+    notices.push(format!("skipping {reason}"));
+    reasons.push(reason);
+}
+
+/// Look up the profile a chain entry refers to.
+///
+/// A named entry must exist; a bare `profile` entry refers to the sole stored
+/// profile and errors on zero or multiple candidates.
+fn lookup_profile<'a>(
+    store: Option<&'a StoreDocument>,
+    name: Option<&str>,
+) -> Result<(&'a str, &'a StoredCredential), ResolveError> {
+    let profiles = store
+        .expect("store is loaded when the chain contains profile entries")
+        .profiles(CATEGORY_LLM, PROVIDER_ANTHROPIC);
+
+    if let Some(name) = name {
+        return profiles
+            .and_then(|p| p.get_key_value(name))
+            .map(|(profile, stored)| (profile.as_str(), stored))
+            .ok_or_else(|| ResolveError::UnknownProfile {
+                name: name.to_owned(),
+            });
+    }
+
+    let mut iter = profiles.into_iter().flatten();
+    let first = iter.next().ok_or(ResolveError::NoProfiles)?;
+
+    if iter.next().is_some() {
+        return Err(ResolveError::AmbiguousProfile {
+            names: profiles
+                .into_iter()
+                .flatten()
+                .map(|(name, _)| name.clone())
+                .collect(),
+        });
+    }
+
+    Ok((first.0.as_str(), first.1))
+}
+
+#[cfg(test)]
+#[path = "resolve_tests.rs"]
+mod tests;

--- a/crates/jp_llm/src/provider/anthropic/resolve_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic/resolve_tests.rs
@@ -1,0 +1,555 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use assert_matches::assert_matches;
+use datetime_literal::datetime;
+use jp_credentials::InMemoryCredentialBackend;
+use jp_storage::resource_lock::InMemoryResourceLocker;
+use test_log::test;
+
+use super::*;
+use crate::StreamErrorKind;
+
+const NOW: fn() -> DateTime<Utc> = || datetime!(2026-07-03 12:00:00 Z);
+
+/// An environment variable that is always set, so `api_key` entries can resolve
+/// without mutating the test process environment.
+const SET_ENV_VAR: &str = if cfg!(windows) { "USERNAME" } else { "USER" };
+
+/// An environment variable that is never set.
+const UNSET_ENV_VAR: &str = "JP_TEST_RESOLVE_UNSET_VAR";
+
+const MODEL: &str = "claude-opus-4-6";
+
+fn anthropic_config(auth: &[&str], api_key_env: &str) -> AnthropicConfig {
+    let mut config = jp_config::AppConfig::new_test().providers.llm.anthropic;
+    config.auth = auth.iter().map(|s| s.parse().unwrap()).collect();
+    config.api_key_env = api_key_env.to_owned();
+    config
+}
+
+fn store_with(profiles: &[(&str, StoredCredential)]) -> StoreDocument {
+    let mut document = StoreDocument::default();
+    for (name, credential) in profiles {
+        document.insert_profile(CATEGORY_LLM, PROVIDER_ANTHROPIC, name, credential.clone());
+    }
+    document
+}
+
+fn token_profile(token: &str) -> StoredCredential {
+    StoredCredential {
+        secret: CredentialSecret::Token {
+            token: token.to_owned(),
+        },
+        account_id: Some("uuid-1".to_owned()),
+        email: None,
+        cooldowns: BTreeMap::new(),
+        needs_relogin: false,
+    }
+}
+
+fn oauth_profile(access_token: &str, expires_at: DateTime<Utc>) -> StoredCredential {
+    StoredCredential {
+        secret: CredentialSecret::Oauth {
+            access_token: access_token.to_owned(),
+            refresh_token: "rt".to_owned(),
+            expires_at,
+        },
+        account_id: Some("uuid-2".to_owned()),
+        email: None,
+        cooldowns: BTreeMap::new(),
+        needs_relogin: false,
+    }
+}
+
+fn profile(name: &str) -> AuthEntry {
+    AuthEntry::Profile(Some(name.to_owned()))
+}
+
+/// The credential a walk landed on, failing the test if it needs a refresh.
+fn ready(landing: Landing) -> Credential {
+    match landing {
+        Landing::Ready(credential) => credential,
+        Landing::Stale { profile, .. } => {
+            panic!("profile:{profile} unexpectedly needs a refresh")
+        }
+    }
+}
+
+#[test]
+fn test_named_profile_resolves_to_bearer() {
+    let config = anthropic_config(&["profile:personal"], UNSET_ENV_VAR);
+    let store = store_with(&[("personal", token_profile("sk-ant-token"))]);
+
+    let (landing, _selected, notices) = walk_chain(&config, Some(&store), MODEL, NOW()).unwrap();
+
+    assert_eq!(
+        ready(landing),
+        Credential::Bearer("sk-ant-token".to_owned())
+    );
+    assert!(notices.is_empty());
+}
+
+#[test]
+fn test_bare_profile_resolves_sole_profile() {
+    let config = anthropic_config(&["profile"], UNSET_ENV_VAR);
+    let store = store_with(&[("personal", token_profile("sk-ant-token"))]);
+
+    let (landing, ..) = walk_chain(&config, Some(&store), MODEL, NOW()).unwrap();
+    assert_eq!(
+        ready(landing),
+        Credential::Bearer("sk-ant-token".to_owned())
+    );
+}
+
+#[test]
+fn test_bare_profile_with_zero_profiles_is_error() {
+    let config = anthropic_config(&["profile"], UNSET_ENV_VAR);
+    let store = store_with(&[]);
+
+    let error = walk_chain(&config, Some(&store), MODEL, NOW()).unwrap_err();
+    assert_matches!(error, ResolveError::NoProfiles);
+}
+
+#[test]
+fn test_bare_profile_with_multiple_profiles_is_error() {
+    let config = anthropic_config(&["profile"], UNSET_ENV_VAR);
+    let store = store_with(&[
+        ("personal", token_profile("sk-a")),
+        ("work", token_profile("sk-b")),
+    ]);
+
+    let error = walk_chain(&config, Some(&store), MODEL, NOW()).unwrap_err();
+    assert_matches!(
+        error,
+        ResolveError::AmbiguousProfile { names } if names == vec!["personal", "work"]
+    );
+}
+
+#[test]
+fn test_unknown_profile_is_error_even_with_later_entries() {
+    // A chain entry naming a nonexistent profile is a config-shaped
+    // mistake, not a skippable state: it fails even though `api_key`
+    // could resolve.
+    let config = anthropic_config(&["profile:missing", "api_key"], SET_ENV_VAR);
+    let store = store_with(&[("personal", token_profile("sk-a"))]);
+
+    let error = walk_chain(&config, Some(&store), MODEL, NOW()).unwrap_err();
+    assert_matches!(error, ResolveError::UnknownProfile { name } if name == "missing");
+}
+
+#[test]
+fn test_needs_relogin_profile_falls_through_with_notice() {
+    let config = anthropic_config(&["profile:personal", "api_key"], SET_ENV_VAR);
+    let mut profile = token_profile("sk-a");
+    profile.needs_relogin = true;
+    let store = store_with(&[("personal", profile)]);
+
+    let (landing, _selected, notices) = walk_chain(&config, Some(&store), MODEL, NOW()).unwrap();
+
+    assert_matches!(ready(landing), Credential::ApiKey(_));
+    assert_eq!(notices.len(), 1);
+    assert!(notices[0].contains("needs re-login"), "{notices:?}");
+}
+
+#[test]
+fn test_cooldown_scoped_to_model_family() {
+    let config = anthropic_config(&["profile:personal", "api_key"], SET_ENV_VAR);
+    let mut profile = token_profile("sk-a");
+    profile
+        .cooldowns
+        .insert("opus".to_owned(), datetime!(2026-07-03 13:00:00 Z));
+    let store = store_with(&[("personal", profile)]);
+
+    // An Opus request skips the cooling-down profile.
+    let (landing, _selected, notices) = walk_chain(&config, Some(&store), MODEL, NOW()).unwrap();
+    assert_matches!(ready(landing), Credential::ApiKey(_));
+    assert!(notices[0].contains("cooling down"), "{notices:?}");
+
+    // A Haiku request on the same account resolves the profile.
+    let (landing, _selected, notices) =
+        walk_chain(&config, Some(&store), "claude-haiku-4-5", NOW()).unwrap();
+    assert_eq!(ready(landing), Credential::Bearer("sk-a".to_owned()));
+    assert!(notices.is_empty());
+}
+
+/// An expired access token is not a dead credential: resolution refreshes it in
+/// place, so the walk reports it as stale rather than falling past it.
+#[test]
+fn test_expired_oauth_token_is_stale_rather_than_skipped() {
+    let config = anthropic_config(&["profile:personal", "api_key"], SET_ENV_VAR);
+    let store = store_with(&[(
+        "personal",
+        oauth_profile("at", datetime!(2026-07-03 11:00:00 Z)),
+    )]);
+
+    let (landing, selected, notices) = walk_chain(&config, Some(&store), MODEL, NOW()).unwrap();
+
+    assert_matches!(landing, Landing::Stale { profile, refresh_token }
+        if profile == "personal" && refresh_token == "rt");
+    assert_eq!(selected, profile("personal"));
+    assert!(notices.is_empty(), "{notices:?}");
+}
+
+/// A token inside the refresh window is refreshed early, so it cannot expire
+/// between being resolved and being used.
+#[test]
+fn test_token_expiring_within_the_buffer_is_stale() {
+    let config = anthropic_config(&["profile:personal"], UNSET_ENV_VAR);
+    let store = store_with(&[(
+        "personal",
+        // Two minutes out, inside the five-minute buffer.
+        oauth_profile("at", datetime!(2026-07-03 12:02:00 Z)),
+    )]);
+
+    let (landing, ..) = walk_chain(&config, Some(&store), MODEL, NOW()).unwrap();
+    assert_matches!(landing, Landing::Stale { .. });
+}
+
+#[test]
+fn test_live_oauth_token_resolves() {
+    let config = anthropic_config(&["profile:personal"], UNSET_ENV_VAR);
+    let store = store_with(&[(
+        "personal",
+        oauth_profile("at", datetime!(2026-07-03 13:00:00 Z)),
+    )]);
+
+    let (landing, ..) = walk_chain(&config, Some(&store), MODEL, NOW()).unwrap();
+    assert_eq!(ready(landing), Credential::Bearer("at".to_owned()));
+}
+
+#[test]
+fn test_default_chain_missing_env_reports_missing_env() {
+    // Same failure shape as before credential chains existed.
+    let config = anthropic_config(&["api_key"], UNSET_ENV_VAR);
+
+    let error = walk_chain(&config, None, MODEL, NOW()).unwrap_err();
+    assert_matches!(error, ResolveError::MissingEnv(var) if var == UNSET_ENV_VAR);
+}
+
+#[test]
+fn test_multi_entry_chain_exhaustion_lists_reasons() {
+    let config = anthropic_config(&["profile:personal", "api_key"], UNSET_ENV_VAR);
+    let mut profile = token_profile("sk-a");
+    profile.needs_relogin = true;
+    let store = store_with(&[("personal", profile)]);
+
+    let error = walk_chain(&config, Some(&store), MODEL, NOW()).unwrap_err();
+    assert_matches!(error, ResolveError::ChainExhausted { reasons } if reasons.len() == 2);
+}
+
+#[test]
+fn test_selected_entry_names_the_resolved_profile() {
+    // A bare `profile` entry reports the profile it resolved to, so a log
+    // line or a switch notice names a concrete credential rather than the
+    // ambiguous chain entry the user wrote.
+    let config = anthropic_config(&["profile"], UNSET_ENV_VAR);
+    let store = store_with(&[("personal", token_profile("sk-a"))]);
+
+    let (_, selected, _) = walk_chain(&config, Some(&store), MODEL, NOW()).unwrap();
+    assert_eq!(selected, AuthEntry::Profile(Some("personal".to_owned())));
+
+    // An `api_key` entry reports itself.
+    let config = anthropic_config(&["api_key"], SET_ENV_VAR);
+    let (_, selected, _) = walk_chain(&config, None, MODEL, NOW()).unwrap();
+    assert_eq!(selected, AuthEntry::ApiKey);
+}
+
+#[test]
+fn test_switch_notice_names_both_credentials_and_the_reason() {
+    let exhausted = StreamError::subscription_exhausted("spent", None, None);
+    assert_eq!(
+        switch_notice(&exhausted, &profile("personal"), Some(&profile("work"))),
+        "subscription limit reached (personal) — continuing with work"
+    );
+
+    // Falling through to the API key names it as written in the chain, so the
+    // notice doubles as the audit trail for entering paid billing.
+    assert_eq!(
+        switch_notice(&exhausted, &profile("personal"), Some(&AuthEntry::ApiKey)),
+        "subscription limit reached (personal) — continuing with api_key"
+    );
+
+    // A refused credential is a different reason: nothing was spent.
+    let rejected = StreamError::auth_rejected("revoked");
+    assert_eq!(
+        switch_notice(&rejected, &profile("personal"), Some(&AuthEntry::ApiKey)),
+        "credential rejected (personal) — continuing with api_key"
+    );
+
+    // Billing exhaustion on a per-token account is neither of the above.
+    let billing = StreamError::new(StreamErrorKind::InsufficientQuota, "no credit");
+    assert_eq!(
+        switch_notice(&billing, &AuthEntry::ApiKey, None),
+        "quota exhausted (api_key)"
+    );
+}
+
+/// Advancing away from `api_key` is impossible: it has no store entry to record
+/// against, so re-resolution lands on the same entry and the failure is
+/// terminal.
+#[test(tokio::test)]
+async fn test_advance_from_api_key_is_terminal() {
+    let config = anthropic_config(&["api_key"], SET_ENV_VAR);
+    let error = StreamError::new(StreamErrorKind::InsufficientQuota, "no credit");
+
+    assert!(
+        advance(&config, None, &AuthEntry::ApiKey, &error, MODEL, NOW())
+            .await
+            .is_none()
+    );
+}
+
+/// A store backed by memory, so a test can observe what resolution persisted
+/// without touching the user's real credentials.
+fn memory_store(profiles: &[(&str, StoredCredential)]) -> CredentialStore {
+    let store = CredentialStore::new(
+        Arc::new(InMemoryCredentialBackend::new()),
+        Arc::new(InMemoryResourceLocker::new()),
+    );
+
+    store
+        .mutate(|document| {
+            for (name, credential) in profiles {
+                document.insert_profile(CATEGORY_LLM, PROVIDER_ANTHROPIC, name, credential.clone());
+            }
+            Ok(())
+        })
+        .unwrap();
+
+    store
+}
+
+/// Read a stored profile back out of the store.
+fn stored(store: &CredentialStore, name: &str) -> StoredCredential {
+    store
+        .load()
+        .unwrap()
+        .profiles(CATEGORY_LLM, PROVIDER_ANTHROPIC)
+        .and_then(|profiles| profiles.get(name))
+        .cloned()
+        .expect("profile is stored")
+}
+
+/// Exhausting the active profile records a cooldown scoped to what the provider
+/// reported, and lands on the next chain entry.
+///
+/// The recorded cooldown is the mechanism rather than a side effect: it is what
+/// makes the *next* resolution skip the spent profile, so a mid-turn switch and
+/// a fresh invocation share one code path.
+#[test(tokio::test)]
+async fn test_advance_records_scoped_cooldown_and_moves_to_next_profile() {
+    let config = anthropic_config(&["profile:personal", "profile:work"], UNSET_ENV_VAR);
+    let store = memory_store(&[
+        ("personal", token_profile("sk-personal")),
+        ("work", token_profile("sk-work")),
+    ]);
+
+    // Four hours ahead of `NOW`: inside the seven-day cap, so the reported
+    // reset is recorded verbatim rather than being capped or defaulted.
+    let reset = datetime!(2026-07-03 16:00:00 Z);
+    let error = StreamError::subscription_exhausted(
+        "spent",
+        Some(reset),
+        Some("seven_day_opus".to_owned()),
+    );
+
+    let next = advance(
+        &config,
+        Some(&store),
+        &profile("personal"),
+        &error,
+        MODEL,
+        NOW(),
+    )
+    .await
+    .expect("the chain has a second profile to fall to");
+
+    assert_eq!(next.selected, Some(profile("work")));
+    assert_eq!(next.credential, Credential::Bearer("sk-work".to_owned()));
+    assert_eq!(
+        next.notices.last().unwrap(),
+        "subscription limit reached (personal) \u{2014} continuing with work"
+    );
+
+    // The cooldown is persisted against the spent profile, at the scope and
+    // expiry the provider reported.
+    let spent = stored(&store, "personal");
+    assert_eq!(spent.cooldowns.get("seven_day_opus"), Some(&reset));
+    assert!(!spent.needs_relogin);
+
+    // A resolution after the switch skips the spent profile on its own,
+    // without being told which entry was spent.
+    let after = resolve(&config, Some(&store), MODEL, NOW()).await.unwrap();
+    assert_eq!(after.selected, Some(profile("work")));
+
+    // The cooldown is scoped to the Opus family, so a Haiku request on the
+    // same account still resolves the profile that was spent for Opus.
+    let haiku = resolve(&config, Some(&store), "claude-haiku-4-5", NOW())
+        .await
+        .unwrap();
+    assert_eq!(haiku.selected, Some(profile("personal")));
+}
+
+/// A refused credential is marked for re-login rather than cooled down: no
+/// allowance was spent, and waiting cannot help.
+#[test(tokio::test)]
+async fn test_advance_marks_refused_credential_for_relogin() {
+    let config = anthropic_config(&["profile:personal", "profile:work"], UNSET_ENV_VAR);
+    let store = memory_store(&[
+        ("personal", token_profile("sk-personal")),
+        ("work", token_profile("sk-work")),
+    ]);
+
+    let next = advance(
+        &config,
+        Some(&store),
+        &profile("personal"),
+        &StreamError::auth_rejected("OAuth token has been revoked"),
+        MODEL,
+        NOW(),
+    )
+    .await
+    .expect("the chain has a second profile to fall to");
+
+    assert_eq!(next.selected, Some(profile("work")));
+    assert_eq!(
+        next.notices.last().unwrap(),
+        "credential rejected (personal) \u{2014} continuing with work"
+    );
+
+    let spent = stored(&store, "personal");
+    assert!(spent.needs_relogin);
+    assert!(spent.cooldowns.is_empty());
+}
+
+/// The last entry in the chain has nothing to fall to, so the failure stays
+/// terminal.
+/// The cooldown is still recorded, so the next invocation starts from an
+/// accurate picture instead of rediscovering the exhaustion.
+#[test(tokio::test)]
+async fn test_advance_past_the_last_entry_is_terminal_but_still_records() {
+    let config = anthropic_config(&["profile:personal"], UNSET_ENV_VAR);
+    let store = memory_store(&[("personal", token_profile("sk-personal"))]);
+
+    let error = StreamError::subscription_exhausted("spent", None, None);
+    assert!(
+        advance(
+            &config,
+            Some(&store),
+            &profile("personal"),
+            &error,
+            MODEL,
+            NOW()
+        )
+        .await
+        .is_none()
+    );
+
+    let spent = stored(&store, "personal");
+    assert!(
+        spent.cooldowns.contains_key(SCOPE_ACCOUNT),
+        "a rejection without a reported scope cools down the whole account"
+    );
+}
+
+/// Quota headers as they arrive on a response that *succeeded* while the
+/// subscription window was already spent: paid extra usage served it.
+fn spent_window_limits() -> UnifiedRateLimit {
+    UnifiedRateLimit {
+        status: Some("rejected".to_owned()),
+        representative_claim: Some("seven_day".to_owned()),
+        // 4 hours after `NOW`.
+        reset: Some(1_783_094_400),
+        overage_status: Some("allowed".to_owned()),
+        ..UnifiedRateLimit::default()
+    }
+}
+
+/// A successful response can report a spent allowance, which is the only
+/// warning JP gets before extra usage starts billing.
+///
+/// Recording the cooldown is what makes the *next* request move off the profile
+/// rather than silently spending money on it again.
+#[test(tokio::test)]
+async fn test_spent_window_on_a_successful_response_records_a_cooldown() {
+    let store = memory_store(&[("personal", token_profile("sk-personal"))]);
+    let watch = QuotaWatch::new(Some(&store), Some(&profile("personal")));
+
+    let notices = watch.observe(&spent_window_limits(), NOW());
+
+    assert_eq!(notices, vec![
+        "weekly limit spent; this request was billed as extra usage".to_owned()
+    ]);
+
+    let spent = stored(&store, "personal");
+    assert_eq!(
+        spent.cooldowns.get("seven_day"),
+        Some(&datetime!(2026-07-03 16:00:00 Z)),
+        "the reported reset is recorded verbatim"
+    );
+
+    // The next resolution moves off the profile on its own.
+    let config = anthropic_config(&["profile:personal", "api_key"], SET_ENV_VAR);
+    let after = resolve(&config, Some(&store), MODEL, NOW()).await.unwrap();
+    assert_eq!(after.selected, Some(AuthEntry::ApiKey));
+}
+
+/// An `api_key` request has no stored profile, so there is nothing to record
+/// against; the notice still tells the user what happened.
+#[test]
+fn test_spent_window_without_a_profile_records_nothing() {
+    let store = memory_store(&[("personal", token_profile("sk-personal"))]);
+    let watch = QuotaWatch::new(Some(&store), Some(&AuthEntry::ApiKey));
+
+    let notices = watch.observe(&spent_window_limits(), NOW());
+    assert_eq!(notices.len(), 1);
+
+    assert!(
+        stored(&store, "personal").cooldowns.is_empty(),
+        "an api_key request must not record against an unrelated profile"
+    );
+}
+
+/// A window that crossed a warning threshold is surfaced, and nothing is
+/// recorded: the allowance is not spent yet.
+#[test]
+fn test_warning_threshold_is_surfaced_without_recording() {
+    let store = memory_store(&[("personal", token_profile("sk-personal"))]);
+    let watch = QuotaWatch::new(Some(&store), Some(&profile("personal")));
+
+    let limits = UnifiedRateLimit {
+        status: Some("allowed_warning".to_owned()),
+        windows: vec![WindowUtilization {
+            claim: "seven_day".to_owned(),
+            utilization: Some(0.82),
+            reset: Some(1_783_094_400),
+            surpassed_threshold: Some(0.75),
+        }],
+        ..UnifiedRateLimit::default()
+    };
+
+    let notices = watch.observe(&limits, NOW());
+    assert_eq!(notices, vec![
+        "weekly limit 82% used, resets 2026-07-03 16:00 UTC".to_owned()
+    ]);
+
+    assert!(
+        stored(&store, "personal").cooldowns.is_empty(),
+        "a warning is not an exhausted window"
+    );
+}
+
+/// A response with no quota headers at all (an API key account, or a provider
+/// that stopped sending them) says nothing and changes nothing.
+#[test]
+fn test_response_without_quota_headers_is_silent() {
+    let store = memory_store(&[("personal", token_profile("sk-personal"))]);
+    let watch = QuotaWatch::new(Some(&store), Some(&profile("personal")));
+
+    assert!(
+        watch
+            .observe(&UnifiedRateLimit::default(), NOW())
+            .is_empty()
+    );
+    assert!(stored(&store, "personal").cooldowns.is_empty());
+}

--- a/crates/jp_llm/src/provider/anthropic_tests.rs
+++ b/crates/jp_llm/src/provider/anthropic_tests.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use assert_matches::assert_matches;
+use async_anthropic::errors::UnifiedRateLimit;
 use indexmap::IndexMap;
 use jp_config::model::{
     id::ModelIdConfig,
@@ -96,9 +97,16 @@ async fn chaining_is_bounded_by_the_continuation_budget() {
         .build()
         .expect("a valid request");
 
-    let events: Vec<_> = call(client, request, MAX_CHAIN_DEPTH, false, None)
-        .collect()
-        .await;
+    let events: Vec<_> = call(
+        client,
+        request,
+        MAX_CHAIN_DEPTH,
+        false,
+        None,
+        resolve::QuotaWatch::new(None, None),
+    )
+    .collect()
+    .await;
 
     assert!(
         events.iter().all(std::result::Result::is_ok),
@@ -253,6 +261,194 @@ async fn test_opus_4_6_max_effort() -> Result {
     run_test(PROVIDER, function_name!(), Some(request)).await
 }
 
+/// A rate limit whose `Retry-After` is zero (or absent) must not pin the
+/// backoff to zero: the retry layer honors `retry_after` verbatim, so a literal
+/// zero turns the bounded retry budget into five back-to-back requests.
+#[test]
+fn test_zero_retry_after_falls_back_to_backoff() {
+    let error = StreamError::from(rate_limit(Some(0), UnifiedRateLimit::default()));
+    assert_eq!(error.kind, StreamErrorKind::RateLimit);
+    assert_eq!(error.retry_after, None, "a zero hint must be dropped");
+    assert!(error.is_retryable());
+
+    // A real hint is preserved.
+    let error = StreamError::from(rate_limit(Some(30), UnifiedRateLimit::default()));
+    assert_eq!(error.retry_after, Some(Duration::from_secs(30)));
+
+    // An absent hint stays absent.
+    let error = StreamError::from(rate_limit(None, UnifiedRateLimit::default()));
+    assert_eq!(error.retry_after, None);
+}
+
+/// A `429` carrying Anthropic's unified quota headers.
+fn rate_limit(retry_after: Option<u64>, limits: UnifiedRateLimit) -> AnthropicError {
+    AnthropicError::RateLimit {
+        retry_after,
+        limits,
+    }
+}
+
+/// An API error envelope, as returned in a rejection body.
+fn api_error(error_type: &str, message: &str) -> async_anthropic::errors::ApiError {
+    async_anthropic::errors::ApiError {
+        error_type: error_type.to_owned(),
+        message: Some(message.to_owned()),
+    }
+}
+
+/// A spent usage window, ordinary throttling, and a rejected request
+/// fingerprint (Phase 1, measured: body `"Error"`) all arrive as `429
+/// rate_limit_error`.
+///
+/// Only the unified quota headers tell them apart.
+/// Getting this wrong is expensive in one direction: treating an unexplained
+/// 429 as exhaustion would cool the profile down and move the conversation onto
+/// per-token billing over what may be our own bug.
+#[test]
+fn test_only_quota_headers_make_a_rate_limit_exhaustion() {
+    // The measured fingerprint-rejection shape carries no quota headers, so
+    // it stays a plain rate limit: retried in place, no cooldown, no
+    // credential switch.
+    let opaque = StreamError::from(rate_limit(None, UnifiedRateLimit::default()));
+    assert_eq!(opaque.kind, StreamErrorKind::RateLimit);
+    assert!(!opaque.needs_credential_switch());
+    assert!(opaque.is_retryable());
+
+    // A rejection naming the exhausted window is exhaustion: not retryable
+    // in place, and it carries the scope and reset the cooldown needs.
+    let exhausted = StreamError::from(rate_limit(Some(3600), UnifiedRateLimit {
+        status: Some("rejected".to_owned()),
+        representative_claim: Some("seven_day_opus".to_owned()),
+        reset: Some(1_781_000_000),
+        ..UnifiedRateLimit::default()
+    }));
+    assert_eq!(exhausted.kind, StreamErrorKind::SubscriptionExhausted);
+    assert_eq!(exhausted.quota_scope.as_deref(), Some("seven_day_opus"));
+    assert_eq!(
+        exhausted.quota_reset,
+        chrono::DateTime::from_timestamp(1_781_000_000, 0)
+    );
+    assert!(
+        !exhausted.is_retryable(),
+        "retrying the same credential cannot clear a usage window"
+    );
+
+    // Paid spillover being reported at all also marks a quota rejection,
+    // even without a named window.
+    let overage = StreamError::from(rate_limit(None, UnifiedRateLimit {
+        overage_status: Some("rejected".to_owned()),
+        ..UnifiedRateLimit::default()
+    }));
+    assert_eq!(overage.kind, StreamErrorKind::SubscriptionExhausted);
+    assert_eq!(overage.quota_scope, None, "no window was named");
+}
+
+/// A refused credential cannot be fixed by retrying, and the shell needs to
+/// know so it can mark the profile for re-login and move down the chain.
+#[test]
+fn test_auth_rejections_require_a_credential_switch() {
+    for (status, error_type, message) in [
+        (403, "permission_error", "OAuth token has been revoked"),
+        (
+            401,
+            "authentication_error",
+            "OAuth authentication is currently not allowed for this organization",
+        ),
+        (401, "authentication_error", "invalid bearer token"),
+    ] {
+        let error = StreamError::from(AnthropicError::Auth {
+            status,
+            error: api_error(error_type, message),
+        });
+
+        assert_eq!(error.kind, StreamErrorKind::AuthRejected, "{message}");
+        assert!(error.is_auth_rejected(), "{message}");
+        assert!(error.needs_credential_switch(), "{message}");
+        assert!(!error.is_retryable(), "{message}");
+        assert!(
+            error.message().contains(message),
+            "the provider's reason must survive: {}",
+            error.message()
+        );
+    }
+}
+
+/// A subscription (bearer) request opens its system content with the Claude
+/// Code identity line followed by the override that neutralizes it, ahead of
+/// JP's own prompt; an API key request carries neither.
+///
+/// Anthropic enforces the line: without it, a bearer request is answered `429
+/// rate_limit_error` with an opaque body, so this is the one place where auth
+/// mode changes the request body rather than only its headers.
+#[test]
+fn test_bearer_mode_prepends_identity_line_and_override() {
+    let model = ModelDetails {
+        id: (PROVIDER, "claude-sonnet-5").try_into().unwrap(),
+        display_name: Some("Claude Sonnet 5".to_string()),
+        context_window: Some(200_000),
+        max_output_tokens: Some(64_000),
+        reasoning: Some(ReasoningDetails::adaptive(false, true)),
+        knowledge_cutoff: None,
+        deprecated: None,
+        structured_output: None,
+        prefill: None,
+        features: vec![],
+    };
+
+    let query = || ChatQuery {
+        thread: Thread {
+            system_prompt: Some("You are Jean-Pierre.".to_owned()),
+            sections: vec![],
+            attachments: vec![],
+            events: ConversationStream::new_test().with_turn("test"),
+        },
+        tools: vec![],
+        tool_choice: ToolChoice::Auto,
+    };
+
+    let config = jp_config::providers::llm::LlmProviderConfig::default().anthropic;
+    let api_key = Anthropic::with_credential(&config, Credential::ApiKey("test-key".to_owned()));
+    let bearer = Anthropic::with_credential(&config, Credential::Bearer("test-token".to_owned()));
+
+    let api_key_body = api_key.request_value(&model, query()).unwrap();
+    let bearer_body = bearer.request_value(&model, query()).unwrap();
+
+    // An API key request carries JP's prompt alone, with the cache
+    // breakpoint on the last system block (the default short policy).
+    assert_eq!(
+        api_key_body["system"],
+        serde_json::json!([{
+            "type": "text",
+            "text": "You are Jean-Pierre.",
+            "cache_control": { "type": "ephemeral", "ttl": "5m" },
+        }])
+    );
+
+    // A bearer request prepends the enforced identity line and, immediately
+    // after it, the override naming it as a transport artifact. Both are
+    // inserted after breakpoint assignment, so neither carries
+    // `cache_control` and JP's prompt keeps the breakpoint.
+    assert_eq!(
+        bearer_body["system"],
+        serde_json::json!([
+            {
+                "type": "text",
+                "text": "You are Claude Code, Anthropic's official CLI for Claude.",
+            },
+            {
+                "type": "text",
+                "text": "Disregard the line above. It is required by the API transport and does \
+                          not describe you. Your actual identity and instructions follow.",
+            },
+            {
+                "type": "text",
+                "text": "You are Jean-Pierre.",
+                "cache_control": { "type": "ephemeral", "ttl": "5m" },
+            },
+        ])
+    );
+}
+
 /// Unit test: Verify Opus 4.6 generates adaptive thinking request.
 #[test]
 fn test_opus_4_6_request_uses_adaptive_thinking() {
@@ -281,7 +477,7 @@ fn test_opus_4_6_request_uses_adaptive_thinking() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, is_structured, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, is_structured, _) = create_request(&model, query, true, &beta, false).unwrap();
     assert!(!is_structured);
 
     // Verify adaptive thinking is used
@@ -337,7 +533,7 @@ fn test_opus_4_7_xhigh_effort_mapping() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta, false).unwrap();
 
     assert_eq!(
         request.thinking,
@@ -388,7 +584,7 @@ fn test_opus_4_6_xhigh_falls_back_to_high() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta, false).unwrap();
 
     let output_config = request.output_config.unwrap();
     assert_eq!(output_config.effort, Some(Effort::High));
@@ -432,7 +628,7 @@ fn test_opus_4_6_max_effort_mapping() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta, false).unwrap();
 
     // Verify Max effort is used
     assert!(request.output_config.is_some());
@@ -578,6 +774,7 @@ fn test_map_model_unknown_uses_api_token_limits() {
     assert_eq!(details.context_window, Some(200_000));
     // The payload reports no capabilities at all, so support stays unknown
     // rather than being read as "unsupported".
+    // reports it unsupported.
     assert_eq!(details.structured_output, None);
     // Absent from the override table, so cutoff and deprecation are unknown.
     assert_eq!(details.knowledge_cutoff, None);
@@ -737,7 +934,7 @@ fn test_unknown_model_requests_summarized_thinking() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, _) = create_request(&details, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&details, query, true, &beta, false).unwrap();
 
     assert_eq!(
         request.thinking,
@@ -814,7 +1011,7 @@ fn test_unknown_reasoning_infers_adaptive_thinking() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta, false).unwrap();
 
     assert_eq!(
         request.thinking,
@@ -850,7 +1047,7 @@ fn tier_request(
         tool_choice: ToolChoice::Auto,
     };
 
-    create_request(&model, query, true, &BetaFeatures(vec![])).map(|(request, ..)| request)
+    create_request(&model, query, true, &BetaFeatures(vec![]), false).map(|(request, ..)| request)
 }
 
 /// The two fields Anthropic splits the concept across.
@@ -956,7 +1153,7 @@ fn test_off_on_unknown_model_attempts_disable() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta, false).unwrap();
 
     assert_eq!(
         request.thinking,
@@ -1073,7 +1270,7 @@ fn test_fable_5_reasoning_off_omits_disabled_thinking() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta, false).unwrap();
 
     // Thinking-always-on model: the disabled-thinking branch is skipped, so no
     // `thinking` field is sent and the model thinks adaptively.
@@ -1108,7 +1305,7 @@ fn test_opus_4_5_uses_budgetted_thinking() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta, false).unwrap();
 
     // Verify budget-based thinking is used (not adaptive)
     assert!(matches!(
@@ -1160,7 +1357,7 @@ fn test_structured_output_sets_format() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, is_structured, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, is_structured, _) = create_request(&model, query, true, &beta, false).unwrap();
 
     assert!(is_structured);
     assert!(request.output_config.is_some());
@@ -1234,7 +1431,7 @@ fn test_schema_ignored_when_last_event_is_not_chat_request() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (_, is_structured, _) = create_request(&model, query, true, &beta).unwrap();
+    let (_, is_structured, _) = create_request(&model, query, true, &beta, false).unwrap();
     assert!(!is_structured);
 }
 
@@ -1274,7 +1471,7 @@ fn test_adaptive_thinking_with_structured_output() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, is_structured, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, is_structured, _) = create_request(&model, query, true, &beta, false).unwrap();
 
     assert!(is_structured);
     assert_eq!(
@@ -1336,7 +1533,7 @@ fn test_forced_tool_with_reasoning_returns_fallback() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, fallback) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, fallback) = create_request(&model, query, true, &beta, false).unwrap();
 
     // tool_choice should have been downgraded to auto.
     assert!(
@@ -1408,7 +1605,7 @@ fn test_forced_tool_thinking_always_on_uses_escalating_nudge() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, fallback) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, fallback) = create_request(&model, query, true, &beta, false).unwrap();
 
     // Thinking-always-on model uses the escalating-nudge strategy, not the
     // disable-thinking hard retry.
@@ -1492,7 +1689,7 @@ fn test_forced_tool_thinking_always_on_reasoning_off_still_soft_forces() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, fallback) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, fallback) = create_request(&model, query, true, &beta, false).unwrap();
 
     // The forced choice must be downgraded to auto; sending it while thinking is
     // active is the 400 this guards against.
@@ -1557,7 +1754,7 @@ fn test_forced_tool_function_multi_tool_preserves_name() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, fallback) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, fallback) = create_request(&model, query, true, &beta, false).unwrap();
 
     assert!(
         matches!(request.tool_choice, Some(types::ToolChoice::Auto { .. })),
@@ -1624,7 +1821,7 @@ fn test_forced_tool_without_reasoning_no_fallback() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, fallback) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, fallback) = create_request(&model, query, true, &beta, false).unwrap();
 
     // No fallback needed - tool_choice should stay as forced (any).
     assert!(fallback.is_none(), "Expected no fallback without reasoning");
@@ -1663,7 +1860,7 @@ fn test_auto_tool_choice_with_reasoning_no_fallback() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (_, _, fallback) = create_request(&model, query, true, &beta).unwrap();
+    let (_, _, fallback) = create_request(&model, query, true, &beta, false).unwrap();
 
     assert!(
         fallback.is_none(),
@@ -1805,7 +2002,7 @@ fn test_continue_injected_when_prefill_unsupported() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta, false).unwrap();
 
     // Last message should be the synthetic continue message.
     let last = request.messages.last().unwrap();
@@ -1854,7 +2051,7 @@ fn test_prefill_preserved_for_supported_models() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta, false).unwrap();
 
     // Last message should be the assistant message (prefill), not a synthetic user message.
     let last = request.messages.last().unwrap();
@@ -1893,7 +2090,7 @@ fn test_no_injection_when_last_message_is_user() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta, false).unwrap();
 
     let last = request.messages.last().unwrap();
     assert_eq!(last.role, types::MessageRole::User);
@@ -1936,7 +2133,7 @@ fn test_create_request_resends_signed_thinking_as_native_block() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta, false).unwrap();
 
     assert_eq!(request.messages.len(), 3);
     let assistant = &request.messages[1];
@@ -1992,7 +2189,7 @@ fn test_create_request_resends_redacted_thinking_as_native_block() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta, false).unwrap();
 
     assert_eq!(request.messages.len(), 3);
     let assistant = &request.messages[1];
@@ -2044,7 +2241,7 @@ fn test_create_request_falls_back_to_think_tags_without_signature() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta, false).unwrap();
 
     assert_eq!(request.messages.len(), 3);
     let assistant = &request.messages[1];
@@ -2102,7 +2299,7 @@ fn test_create_request_drops_empty_reasoning_instead_of_empty_think_tags() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta, false).unwrap();
 
     let assistant = &request.messages[1];
     assert_eq!(assistant.role, types::MessageRole::Assistant);
@@ -2158,7 +2355,7 @@ fn test_create_request_downgrades_trailing_assistant_thinking() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta, false).unwrap();
 
     // user, assistant (downgraded), synthetic continue user.
     assert_eq!(request.messages.len(), 3);
@@ -2223,7 +2420,7 @@ fn test_create_request_drops_trailing_redacted_thinking() {
     };
 
     let beta = BetaFeatures(vec![]);
-    let (request, _, _) = create_request(&model, query, true, &beta).unwrap();
+    let (request, _, _) = create_request(&model, query, true, &beta, false).unwrap();
 
     let assistant = request.messages.last().unwrap();
     assert_eq!(assistant.role, types::MessageRole::Assistant);

--- a/crates/jp_llm/src/provider/openrouter.rs
+++ b/crates/jp_llm/src/provider/openrouter.rs
@@ -226,6 +226,7 @@ fn call(
                 }
                 patch @ Event::Patch(_) => yield patch,
                 keep_alive @ Event::KeepAlive => yield keep_alive,
+                notice @ Event::Notice(_) => yield notice,
             }
         }
     })

--- a/crates/jp_llm/src/stream/chain.rs
+++ b/crates/jp_llm/src/stream/chain.rs
@@ -118,7 +118,7 @@ impl EventChain {
             }
 
             // Pass through immediately — not part of the content stream.
-            Event::Patch(_) | Event::KeepAlive => vec![event],
+            Event::Patch(_) | Event::KeepAlive | Event::Notice(_) => vec![event],
         }
     }
 
@@ -165,7 +165,7 @@ impl EventChain {
             }
 
             // Pass through immediately — not part of the content stream.
-            Event::Patch(_) | Event::KeepAlive => vec![event],
+            Event::Patch(_) | Event::KeepAlive | Event::Notice(_) => vec![event],
         }
     }
 

--- a/crates/jp_llm/src/test.rs
+++ b/crates/jp_llm/src/test.rs
@@ -675,7 +675,7 @@ pub async fn run_chat_completion(
                                         stream.extend(std::iter::once(event));
                                     }
                                 }
-                                Event::Patch(_) | Event::KeepAlive => {}
+                                Event::Patch(_) | Event::KeepAlive | Event::Notice(_) => {}
                                 Event::Finished(reason) => {
                                     for mut event in builder.drain() {
                                         event.timestamp =

--- a/crates/jp_task/src/task/title_generator.rs
+++ b/crates/jp_task/src/task/title_generator.rs
@@ -39,10 +39,10 @@ impl TitleGeneratorTask {
     ) -> Result<Self, Box<dyn Error + Send + Sync>> {
         let model = title::resolve_model(config, None);
 
-        // Fail fast on a misconfigured title provider (e.g. a missing API
-        // key environment variable). Without this, the failure only surfaces
-        // inside the spawned task, after the query has already committed to
-        // waiting for it at teardown.
+        // Fail fast on a misconfigured title provider (e.g. a missing API key
+        // environment variable, or a credential chain with no usable entry).
+        // Without this, the failure only surfaces inside the spawned task,
+        // after the query has already committed to waiting for it at teardown.
         provider::preflight(model.id.resolved().provider, &config.providers.llm)?;
 
         Ok(Self {

--- a/deny.toml
+++ b/deny.toml
@@ -28,7 +28,6 @@ unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
-    "https://github.com/JeanMertz/async-anthropic",
     "https://github.com/JeanMertz/backon",
     "https://github.com/JeanMertz/gemini-client",
     "https://github.com/JeanMertz/httpmock?branch=tweaks",

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -356,7 +356,7 @@
     "summary": "Stream paragraphs incrementally while guaranteeing byte-identical output to non-streaming, with four guards managing block-start ambiguity, setext reinterpretation, inline spans, and wrap-in-progress stability."
   },
   "090-anthropic-subscription-auth-with-credential-fallback.md": {
-    "hash": "2294333a757d087fe5efa3d5f579e6980dba20892c52a6dd81d431eee6bfed10",
+    "hash": "90d6da76cfd31c03bc1282a12899dd43b75d3da93f0dd8694f579072643fd467",
     "summary": "OAuth subscription auth for Anthropic with automatic fallback chain, credential store, and scoped cooldown tracking across profiles."
   },
   "091-printer-owned-status-region.md": {

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -356,8 +356,8 @@
     "summary": "Stream paragraphs incrementally while guaranteeing byte-identical output to non-streaming, with four guards managing block-start ambiguity, setext reinterpretation, inline spans, and wrap-in-progress stability."
   },
   "090-anthropic-subscription-auth-with-credential-fallback.md": {
-    "hash": "2f2a3694924055b6abf1a6e5a40af4759861017e172e1c94798dda2c3f7557e2",
-    "summary": "JP gains Anthropic subscription auth with automatic fallback to API key billing when quotas exhaust."
+    "hash": "2294333a757d087fe5efa3d5f579e6980dba20892c52a6dd81d431eee6bfed10",
+    "summary": "OAuth subscription auth for Anthropic with automatic fallback chain, credential store, and scoped cooldown tracking across profiles."
   },
   "091-printer-owned-status-region.md": {
     "hash": "9f50bec24fd8434ab87f60ece312c4ec6492f67fcb8014e2d8afc33e9d31e286",

--- a/docs/rfd/090-anthropic-subscription-auth-with-credential-fallback.md
+++ b/docs/rfd/090-anthropic-subscription-auth-with-credential-fallback.md
@@ -132,12 +132,12 @@ allowance.
 The notice is chrome on stderr per [RFD 048]; under `--format json` it renders
 as NDJSON on stderr like all chrome.
 
-The auth commands are provider-owned UX: they migrate with the provider into
-its command plugin (as `jp anthropic login`, `list`, `logout`) once the
+The auth commands are provider-owned UX: they migrate with the provider into its
+command plugin (as `jp anthropic login`, `list`, `logout`) once the
 command-plugin protocol supports running without a workspace and prompting for
 input.
-Until then they live in `jp_cli`; their behavior is the contract, their
-location is not.
+Until then they live in `jp_cli`; their behavior is the contract, their location
+is not.
 
 ### Credential store
 
@@ -204,14 +204,13 @@ crash mid-refresh cannot lose a rotated refresh token.
 The lock-mutate-persist cycle lives in the `jp_credentials` crate:
 `CredentialStore` owns the semantics every backend shares — the document
 encoding, the schema-version check, and the mutation cycle — while storage
-backends implement the `keyring-core` store interface, holding the document as
-a single entry.
+backends implement the `keyring-core` store interface, holding the document as a
+single entry.
 A file-based store is the baseline backend, and the macOS keyring (Phase 4)
 swaps in behind the same interface.
-A file-based backend must replace its file atomically (temp file and rename)
-and create it with `0600` permissions; if `keyring-core`'s bundled file store
-does not provide both, JP's file persistence implements the store interface
-itself.
+A file-based backend must replace its file atomically (temp file and rename) and
+create it with `0600` permissions; if `keyring-core`'s bundled file store does
+not provide both, JP's file persistence implements the store interface itself.
 The mutation lock is a `ResourceLocker` (`jp_storage`), the same file-based
 locking primitive conversation locks are built on, and stays file-based for
 every store backend, since keyring stores provide no locking.
@@ -241,9 +240,9 @@ Resolution is a provider concern.
 The Anthropic provider owns its credential policy: it reads the `auth` chain
 from its config, walks it per request, refreshes expired access tokens, and
 decides when an entry is skipped, retried, or abandoned.
-Core owns none of that vocabulary — every provider is constructed the same
-way, from its config alone, and the turn loop, tasks, and every other call
-site are credential-unaware.
+Core owns none of that vocabulary — every provider is constructed the same way,
+from its config alone, and the turn loop, tasks, and every other call site are
+credential-unaware.
 What core owns is the credential store (see Credential store): the provider
 loads profiles and records outcomes — cooldowns, re-login markers, recovered
 identity — through the `jp_credentials` API.
@@ -264,8 +263,8 @@ Resolution runs in two stages, both inside the provider:
    Walks the chain, skips entries per the table below, refreshes an expired
    access token, and sends the request with the credential it lands on: an API
    key or a bearer token.
-   The construction snapshot serves preflight only; a refresh re-reads the
-   store under the lock before acting (see Credential store).
+   The construction snapshot serves preflight only; a refresh re-reads the store
+   under the lock before acting (see Credential store).
 
 Every credential condition has exactly one outcome:
 
@@ -312,11 +311,10 @@ When recovery fails, the profile is non-resolvable: skipped with a notice naming
 the exact `jp provider auth login` command while another entry remains, terminal
 when the chain exhausts.
 
-Because the provider resolves per request, every request a turn issues —
-across tool-execution cycles, and equally for title generation, summarization,
-or any other purpose — lands on a usable credential, and an access token
-expiring between requests is absorbed by a refresh rather than surfacing as an
-error.
+Because the provider resolves per request, every request a turn issues — across
+tool-execution cycles, and equally for title generation, summarization, or any
+other purpose — lands on a usable credential, and an access token expiring
+between requests is absorbed by a refresh rather than surfacing as an error.
 An expiry surfacing mid-stream is a refresh-and-retry on the same credential,
 not a chain advance.
 A task whose provider fails preflight skips its work softly, exactly as title
@@ -329,8 +327,7 @@ authentication), the resolved profile's account UUID is request data the
 provider embeds in `metadata.user_id`.
 Resolution outcomes a user must see — a skipped profile, a credential switch —
 are emitted as notice events on the provider's event stream, generic stream
-vocabulary any provider can use, and rendered as chrome on stderr per
-[RFD 048].
+vocabulary any provider can use, and rendered as chrome on stderr per [RFD 048].
 
 Credential policy travels with the provider: when a provider moves out of core
 into a plugin, its resolution logic, wire mechanics, and login UX move with it,
@@ -362,17 +359,17 @@ the same status and an opaque body.
 
 The headers also carry what the cooldown needs:
 
-| Header                                             | Use                                                          |
-| -------------------------------------------------- | ------------------------------------------------------------ |
-| `anthropic-ratelimit-unified-status`               | `allowed`, `allowed_warning`, `rejected`                     |
+| Header                                             | Use                                                                                  |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `anthropic-ratelimit-unified-status`               | `allowed`, `allowed_warning`, `rejected`                                             |
 | `anthropic-ratelimit-unified-representative-claim` | the exhausted window: `five_hour`, `seven_day`, `seven_day_opus`, `seven_day_sonnet` |
-| `anthropic-ratelimit-unified-reset`                | when that window resets, as Unix seconds                     |
-| `anthropic-ratelimit-unified-overage-status`       | whether paid spillover can serve the request                 |
-| `retry-after`                                      | present only when rejected with no overage available         |
+| `anthropic-ratelimit-unified-reset`                | when that window resets, as Unix seconds                                             |
+| `anthropic-ratelimit-unified-overage-status`       | whether paid spillover can serve the request                                         |
+| `retry-after`                                      | present only when rejected with no overage available                                 |
 
 JP never chooses paid spillover.
-A quota rejection is treated the same whether `overage-status` says spillover
-is available or exhausted: the cooldown is recorded and the chain advances.
+A quota rejection is treated the same whether `overage-status` says spillover is
+available or exhausted: the cooldown is recorded and the chain advances.
 Paid usage happens only because the user listed `api_key` in the chain, which
 keeps one consent model rather than two.
 The limit of that guarantee: extra usage is an account-level setting, so an
@@ -380,8 +377,8 @@ account with it enabled may have requests served past the window and billed as
 overage without any rejection for JP to react to.
 JP cannot prevent that; it only refuses to select it.
 
-A `401` or `403` is the other credential-scoped failure: the credential
-itself was refused, so no amount of retrying helps.
+A `401` or `403` is the other credential-scoped failure: the credential itself
+was refused, so no amount of retrying helps.
 Anthropic distinguishes two cases worth naming, both of which mark the profile
 as needing re-login: `OAuth token has been revoked`, and `OAuth authentication
 is currently not allowed for this organization`.
@@ -410,8 +407,8 @@ Exhaustion becomes conditionally retryable via credential switch:
    notice as an event.
    The recorded cooldown is what routes the next resolution past the spent
    profile, so a mid-turn switch and a fresh invocation share one code path.
-3. The provider re-resolves the chain and re-sends the request immediately —
-   no backoff sleep; this is not a transient error, and the new credential is
+3. The provider re-resolves the chain and re-sends the request immediately — no
+   backoff sleep; this is not a transient error, and the new credential is
    usable now.
    Model metadata (context sizes, structural details) is retained across the
    switch; access is not guaranteed, and a model authorization or unknown-model
@@ -430,8 +427,8 @@ doomed request whenever a model name is simply wrong.
 The switch is invisible to the turn loop: it receives a provider and a stream,
 and the notice event is the only trace a switch leaves in the event flow.
 
-Fallback applies to every request the provider sends: the query streaming
-loop, conversation edit and summarize, inquiry collection, title generation.
+Fallback applies to every request the provider sends: the query streaming loop,
+conversation edit and summarize, inquiry collection, title generation.
 Persisted cooldowns route any invocation past exhausted profiles, and an
 admission-time rejection advances the chain wherever it occurs — there is no
 separate in-flight machinery to scope.
@@ -467,9 +464,9 @@ pinned oh-my-pi revision, the provider module sends for OAuth tokens:
   line, plus a billing block whose `cch` attestation is a hash computed over the
   serialized request body.
   The identity line is enforced (Phase 1), so JP sends it and immediately
-  follows it with a block naming it as a transport artifact and pointing at
-  JP's own prompt, which keeps a foreign identity from standing as an
-  instruction; the attestation is not sent at all.
+  follows it with a block naming it as a transport artifact and pointing at JP's
+  own prompt, which keeps a foreign identity from standing as an instruction;
+  the attestation is not sent at all.
 - **Behavioral constraints**: an output-token clamp (64k) applied to OAuth
   requests even when the model's ceiling is higher.
 
@@ -548,8 +545,8 @@ server, browser opening, and store I/O form the thin imperative shell around it.
   `0600` limits exposure on Unix; Windows relies on default user-profile ACLs,
   matching what Claude Code does there.
   On macOS the file is a regression against Claude Code, which uses the
-  Keychain; the Phase 4 keyring backend closes that gap, gating other
-  processes' access behind Keychain ACLs.
+  Keychain; the Phase 4 keyring backend closes that gap, gating other processes'
+  access behind Keychain ACLs.
 - **Maintenance of an undocumented flow.** The OAuth endpoints, client ID, and
   headers are Claude Code implementation details, not published API.
   Anthropic can change them without notice, and JP owns the breakage.
@@ -585,18 +582,20 @@ server, browser opening, and store I/O form the thin imperative shell around it.
 
   The store API is provider-agnostic — categories, providers, and profiles are
   just keys — while credential policy is provider-owned by construction: each
-  provider's chain semantics, refresh flow, and error vocabulary live in its
-  own module and move with it into a plugin.
+  provider's chain semantics, refresh flow, and error vocabulary live in its own
+  module and move with it into a plugin.
   The second provider adds its own policy without touching shared code; the
   store API is the only shared surface, and it is the same one plugins consume.
+
 - **Multi-account routing UX.** Ordering in the `auth` chain is the only routing
   mechanism.
   Per-conversation account pinning, usage-based routing, and similar are out of
   scope.
+
 - **Keyring backends beyond macOS.** Phase 4 adds the macOS keyring backend.
   Linux secret-service and Windows Credential Manager stores exist behind the
-  same `keyring-core` interface and can follow, but are not part of this
-  design.
+  same `keyring-core` interface and can follow, but are not part of this design.
+
 - **Sharing tokens with Claude Code.** JP's login is independent.
   Users who log the same account into both tools may see one tool's session
   invalidated by the other's refresh; that is inherent to Anthropic's token
@@ -617,8 +616,8 @@ server, browser opening, and store I/O form the thin imperative shell around it.
   follows.
   Measured: the enforcement check tolerates that insertion, and the model then
   identifies as JP without remarking on the contradiction.
-  The residual risk is that this is a prompt-level mitigation, not a guarantee —
-  a future model may weigh the identity line differently — and that API key
+  The residual risk is that this is a prompt-level mitigation, not a guarantee
+  — a future model may weigh the identity line differently — and that API key
   requests carry neither block, so the same conversation can behave differently
   across a credential switch.
 - **Thinking signatures across accounts.** Signatures minted under one account
@@ -639,13 +638,12 @@ server, browser opening, and store I/O form the thin imperative shell around it.
 ### Phase 1: bearer auth, store, and setup-token login
 
 Bearer mode in the `async-anthropic` fork; the credential store with file
-locking, versioned schema, and tagged credential variants; chain preflight
-and resolution in the `jp_credentials` crate;
-`jp provider auth login llm.anthropic --setup-token` reading a long-lived
-token from `claude setup-token` on stdin, stored as a static `token`
-credential, with identity recovery attempted at login and the profile stored
-unverified when it fails; `jp provider auth list` and `jp provider auth
-logout`, so the store is never manageable only by hand-editing.
+locking, versioned schema, and tagged credential variants; chain preflight and
+resolution in the `jp_credentials` crate; `jp provider auth login llm.anthropic
+--setup-token` reading a long-lived token from `claude setup-token` on stdin,
+stored as a static `token` credential, with identity recovery attempted at login
+and the profile stored unverified when it fails; `jp provider auth list` and `jp
+provider auth logout`, so the store is never manageable only by hand-editing.
 Phase 1 carries three measurement deliverables the rest of the design is fixed
 against: the minimum request fingerprint Anthropic accepts, measured top-down
 from the complete inventory in Request authentication (headers, identity
@@ -669,9 +667,9 @@ a block that names it as a transport artifact (see Request authentication).
 The check tolerates that insertion, and the model identifies as JP rather than
 as Claude Code.
 
-The rejection does not identify itself: Anthropic answers `429
-rate_limit_error` with an opaque `"message": "Error"` body, not a `401` and not
-a message naming the check.
+The rejection does not identify itself: Anthropic answers `429 rate_limit_error`
+with an opaque `"message": "Error"` body, not a `401` and not a message naming
+the check.
 The remaining trims are read against that signature, because a rejected
 fingerprint is otherwise indistinguishable from ordinary throttling, and a
 subscription window that expires mid-campaign would read as a trim result.
@@ -702,14 +700,14 @@ the first real limit JP sees.
 
 A `429` is a quota rejection only when it carries
 `anthropic-ratelimit-unified-representative-claim` or
-`anthropic-ratelimit-unified-overage-status`; Claude Code treats a `429`
-without them as "not a quota limit" and surfaces whatever the API said.
+`anthropic-ratelimit-unified-overage-status`; Claude Code treats a `429` without
+them as "not a quota limit" and surfaces whatever the API said.
 That predicate is what separates exhaustion from capacity throttling and from
 the fingerprint rejection measured above, all three of which are `429`
 `rate_limit_error`.
-The `representative-claim` values are the cooldown scopes the store records,
-and `anthropic-ratelimit-unified-reset` carries the reset instant as Unix
-seconds, so reset timing needs no separate usage endpoint.
+The `representative-claim` values are the cooldown scopes the store records, and
+`anthropic-ratelimit-unified-reset` carries the reset instant as Unix seconds,
+so reset timing needs no separate usage endpoint.
 `seven_day` is the longest window, which is where the seven-day cooldown cap
 comes from.
 
@@ -732,8 +730,8 @@ the core-owned API described in Credential store.
 Chain preflight and resolution move from `jp_credentials` into the provider;
 in-flight switching moves from the CLI's stream-retry path into the provider's
 request admission; the switch notice becomes a provider-emitted notice event;
-provider construction returns to config-only, uniform across providers; and
-the shell's per-call-site credential resolution is deleted.
+provider construction returns to config-only, uniform across providers; and the
+shell's per-call-site credential resolution is deleted.
 The store adopts the `keyring-core` store interface behind the existing
 lock-mutate-persist cycle.
 User-visible behavior is unchanged, except that fallback now applies to every
@@ -746,13 +744,13 @@ build on it.
 ### Phase 2b: subscription-state awareness
 
 Phase 2 reacts to a spent allowance after a request fails.
-The same headers Anthropic sends on *every* response carry enough to act
-before that, and Claude Code's client shows which of them are load-bearing:
+The same headers Anthropic sends on *every* response carry enough to act before
+that, and Claude Code's client shows which of them are load-bearing:
 
 - **Warning states.** `anthropic-ratelimit-unified-status` reports
   `allowed_warning` alongside the window that is filling up, and separate
-  `-5h-utilization` / `-7d-utilization` headers carry the fraction consumed
-  with a `-surpassed-threshold` marker.
+  `-5h-utilization` / `-7d-utilization` headers carry the fraction consumed with
+  a `-surpassed-threshold` marker.
   Surfacing that as chrome tells the user their allowance is nearly gone while
   they can still choose what to spend it on — far better than discovering it
   mid-turn.
@@ -764,8 +762,8 @@ before that, and Claude Code's client shows which of them are load-bearing:
   This reports on spillover; it does not select it (see Quota fallback).
 - **Recording state from successful responses.** Cooldowns are written today
   only when a request fails.
-  Reading the same headers off a `200` lets JP record a window's utilization
-  and reset without burning a rejected request to discover it.
+  Reading the same headers off a `200` lets JP record a window's utilization and
+  reset without burning a rejected request to discover it.
 
 This phase is optional in the sense that Phase 2 is correct without it, and
 valuable because it converts the subscription from something JP reacts to into
@@ -776,10 +774,10 @@ Depends on Phases 2 and 2c.
 
 **Measured: the header names, from Claude Code's own client.** The per-window
 headers are abbreviated where the window names elsewhere are spelled out:
-`anthropic-ratelimit-unified-{5h,7d}-utilization` carries the fraction
-consumed, `-{5h,7d}-reset` the per-window reset (distinct from the top-level
-`-reset`), and `-{5h,7d,overage}-surpassed-threshold` marks a crossed warning
-threshold — its presence is the signal, its value the threshold.
+`anthropic-ratelimit-unified-{5h,7d}-utilization` carries the fraction consumed,
+`-{5h,7d}-reset` the per-window reset (distinct from the top-level `-reset`),
+and `-{5h,7d,overage}-surpassed-threshold` marks a crossed warning threshold —
+its presence is the signal, its value the threshold.
 `-overage-disabled-reason` reports one of thirteen enumerated reasons
 (`out_of_credits`, `org_level_disabled`, `seat_tier_zero_credit_limit`, …).
 JP normalizes the abbreviations to the spelled-out window names so one
@@ -787,35 +785,37 @@ vocabulary reaches the user.
 
 The client also computes a *time-relative* early warning of its own when the
 server sends no threshold (warn at 90% utilization within 72% of the 5-hour
-window, and three tiers for the weekly one). JP does not: that is client-side
-policy layered on the provider's own signal, and surfacing only what the
-provider flags keeps the notice trustworthy.
+window, and three tiers for the weekly one).
+JP does not: that is client-side policy layered on the provider's own signal,
+and surfacing only what the provider flags keeps the notice trustworthy.
 
 **A spent window is readable from a response that succeeded.** `status:
 rejected` accompanies a `200` whenever paid extra usage covered the request, so
 the drawback this design records as unpreventable — usage billed past the
 window with no rejection to react to — is detectable one request after it
-starts. JP records the scoped cooldown at that point, so the next resolution
-moves off the profile instead of billing against it again, and surfaces a
-notice naming the window. The request that revealed it is still billed; that
-part is unavoidable.
+starts.
+JP records the scoped cooldown at that point, so the next resolution moves off
+the profile instead of billing against it again, and surfaces a notice naming
+the window.
+The request that revealed it is still billed; that part is unavoidable.
 
 ### Transport: reading a successful response's headers
 
-The quota headers ride on every response, but JP's Anthropic client reached
-them only on failures: `reqwest-eventsource` yields a unit `Open` event and
-exposes the `Response` only in its error variants. Phase 2b therefore rests on
-a transport change, made as its own step: the streaming path issues the request
-directly and parses the body with `eventsource-stream` (the SSE parser
-`reqwest-eventsource` itself wraps), which makes the response — and its headers
-— available on success.
+The quota headers ride on every response, but JP's Anthropic client reached them
+only on failures: `reqwest-eventsource` yields a unit `Open` event and exposes
+the `Response` only in its error variants.
+Phase 2b therefore rests on a transport change, made as its own step: the
+streaming path issues the request directly and parses the body with
+`eventsource-stream` (the SSE parser `reqwest-eventsource` itself wraps), which
+makes the response — and its headers — available on success.
 
-The change drops SSE-level reconnection, deliberately. Anthropic's message
-endpoint sends no SSE event ids, so a reconnect cannot resume: it issues a
-fresh completion whose content restarts from the beginning, which is the wrong
-operation at that layer. Nothing consumed it in practice — every error was
-yielded to the caller, which abandoned the stream — while the orphaned
-reconnect still fired 15 seconds later and paid for a completion nobody read.
+The change drops SSE-level reconnection, deliberately.
+Anthropic's message endpoint sends no SSE event ids, so a reconnect cannot
+resume: it issues a fresh completion whose content restarts from the beginning,
+which is the wrong operation at that layer.
+Nothing consumed it in practice — every error was yielded to the caller, which
+abandoned the stream — while the orphaned reconnect still fired 15 seconds
+later and paid for a completion nobody read.
 Recovery stays where it belongs: the turn loop flushes partial content, rebuilds
 the thread with it as assistant prefill, and continues on a fresh stream.
 The `cerebras` and `llamacpp` providers had already reached the same conclusion
@@ -823,20 +823,20 @@ and configure `retry::Never`.
 
 One related fix: the buffered `get`/`post` paths retried *every* `429` with a
 15-second floor, including quota rejections, so a spent subscription stalled for
-the better part of a minute before the credential switch could act. They now
-retry only capacity throttling.
+the better part of a minute before the credential switch could act.
+They now retry only capacity throttling.
 
 ### Phase 3: PKCE browser login
 
-The full browser login flow: PKCE, browser, localhost callback, paste
-fallback, refresh-on-expiry.
+The full browser login flow: PKCE, browser, localhost callback, paste fallback,
+refresh-on-expiry.
 The phase lands in two halves.
-The token exchange and refresh logic is pure library code in the provider's
-auth module and lands first: refresh-on-expiry is what per-request resolution
-needs for `oauth` profiles, however the tokens were obtained.
-The login command ships in the provider's command plugin (`jp anthropic
-login`), which waits on two command-plugin protocol capabilities specified
-separately: running without a workspace, and prompting for input.
+The token exchange and refresh logic is pure library code in the provider's auth
+module and lands first: refresh-on-expiry is what per-request resolution needs
+for `oauth` profiles, however the tokens were obtained.
+The login command ships in the provider's command plugin (`jp anthropic login`),
+which waits on two command-plugin protocol capabilities specified separately:
+running without a workspace, and prompting for input.
 Until the plugin ships, setup-token login through the in-core CLI remains the
 login path.
 Phase 3 measures whether the authorize endpoint grants the reduced
@@ -860,19 +860,18 @@ keeps one from lapsing between being resolved and being used; JP uses the same
 buffer.
 
 **Still unmeasured: whether the reduced scope set is granted.** That needs a
-live authorize round-trip, which arrives with the browser flow. Until then the
-reduced set is what JP requests and the full-set fallback remains the
-documented contingency.
+live authorize round-trip, which arrives with the browser flow.
+Until then the reduced set is what JP requests and the full-set fallback remains
+the documented contingency.
 
 ### Phase 4: macOS keyring store backend
 
 The macOS Keychain behind the `keyring-core` store interface
-(`apple-native-keyring-store`), replacing the file store on macOS and
-restoring parity for users migrating from Claude Code there.
+(`apple-native-keyring-store`), replacing the file store on macOS and restoring
+parity for users migrating from Claude Code there.
 The backend stores the same versioned JSON document as a single entry, so
-cooldowns and re-login state move with the secrets; the store's
-`ResourceLocker` lock file keeps serializing mutations, since the Keychain
-provides no locking.
+cooldowns and re-login state move with the secrets; the store's `ResourceLocker`
+lock file keeps serializing mutations, since the Keychain provides no locking.
 
 Existing stores migrate once, under the file lock: read the file store, write
 the Keychain item, read it back and verify, switch the backend marker, then

--- a/docs/rfd/090-anthropic-subscription-auth-with-credential-fallback.md
+++ b/docs/rfd/090-anthropic-subscription-auth-with-credential-fallback.md
@@ -4,6 +4,7 @@
 - **Category**: Design
 - **Authors**: Jean Mertz <git@jeanmertz.com>
 - **Date**: 2026-07-03
+- **Tracking Issue**: [\#875]
 
 ## Summary
 
@@ -39,8 +40,8 @@ cannot use through JP, and again per token.
 Log in once per subscription account:
 
 ```sh
-jp auth login anthropic                    # default profile
-jp auth login anthropic --profile work     # named profile
+jp provider auth login llm.anthropic                   # default profile
+jp provider auth login llm.anthropic --profile work    # named profile
 ```
 
 The command opens the browser for Anthropic's OAuth consent, captures the
@@ -54,135 +55,386 @@ account under two profiles, keyed on the account UUID — never email alone.
 A profile without a resolved account UUID — even when an email was recovered —
 is stored as unverified with a warning, and duplicate detection is skipped for
 it.
+If the missing identity is recovered later (see Credential resolution), the
+duplicate check runs at that point.
 
 Inspect and remove stored credentials without touching the store by hand:
 
 ```sh
-jp auth list                               # profiles, accounts, expiry, cooldowns
-jp auth logout anthropic --profile work    # remove a profile
+jp provider auth list                                  # profiles, accounts, expiry, cooldowns
+jp provider auth logout llm.anthropic --profile work   # remove a profile
 ```
 
-`jp auth list` shows each profile's state: valid, expired, needing re-login,
-cooling down, or unverified.
+`jp provider auth list` shows each profile's credential type and state: valid,
+expired, needing re-login, cooling down (with the scope, account or model
+family, and the cooldown's expiry), or unverified.
+An unverified profile is additionally marked usable or needing re-login,
+depending on whether account attribution is enforced (see Request
+authentication) and whether identity recovery has failed.
 There is no manual cooldown-reset command, deliberately: a cooldown clears on
 its own, or via logout and re-login.
+
+Credentials are user-global, so auth commands work anywhere: `jp provider auth`
+bypasses workspace discovery entirely, the same startup exception `jp init`
+uses.
+`list` and `logout` require no TTY and are safe to script.
+Browser login needs a reachable localhost callback or an interactive paste; when
+neither is possible, it fails with a diagnostic naming both options.
+Setup tokens are read from stdin, never from process arguments, which leak into
+shell history and `ps` output.
+Normal LLM commands never start a login implicitly; a missing or expired profile
+is an error naming the exact `jp provider auth login` command that fixes it.
 
 Configure the credential chain, in fallback order:
 
 ```toml
 [providers.llm.anthropic]
-auth = ["oauth:personal", "oauth:work", "api_key"]
+auth = ["profile:personal", "profile:work", "api_key"]
 ```
 
 - `api_key` resolves via `api_key_env`, exactly as today.
-- `oauth` (bare) resolves the sole configured profile; `oauth:<name>` names one.
+- `profile` (bare) resolves the sole configured profile; `profile:<name>` names
+  one.
   Profile names are case-sensitive.
-- Bare `oauth` with zero or with multiple configured profiles, and
-  `oauth:<name>` naming a profile not in the store, are resolution errors naming
-  the fix; an empty `auth` list, duplicate entries, and unrecognized items are
-  config validation errors.
+- A chain entry selects a stored profile; it does not assert the credential's
+  mechanism.
+  The same entry keeps working when a profile migrates from a static setup token
+  to browser OAuth.
+- Bare `profile` with zero or with multiple configured profiles, and
+  `profile:<name>` naming a profile not in the store, are preflight errors
+  naming the fix; an empty `auth` list, duplicate entries, and unrecognized
+  items are config validation errors.
 - The default is `["api_key"]`: existing setups behave identically.
 - Across config layers, `auth` replaces as a whole — it never appends.
-  An appending merge would let a workspace config silently add paid fallback
-  beneath a user's subscription-only global config.
+  Merging two chains element-wise produces an order nobody wrote; replacement
+  keeps every effective chain one that some layer spelled out in full.
   `JP_CFG_PROVIDERS_LLM_ANTHROPIC_AUTH` overrides it like any other key.
 
-Chain order is the consent model: listing `api_key` after an OAuth profile is
-explicit authorization to continue on per-token billing when subscriptions are
-exhausted.
-There is no additional prompt or setting.
+Chain contents are governed by the ordinary config trust model: a workspace
+config can rewrite the chain, exactly as it can rewrite `api_key_env` or the
+model selection today.
+A user who wants their chain to be authoritative pins it in a layer that
+outranks workspace files: the user-workspace config or the environment variable.
+Listing `api_key` in the effective chain is the authorization to continue on API
+billing when earlier entries are exhausted; there is no additional prompt or
+setting.
 
 When the active subscription account runs out of tokens, JP prints a one-line
 notice — `subscription limit reached (personal) — continuing with work` — and
 retries the request with the next credential in the chain.
-The fallback is automatic but never silent: switching from fixed-cost to
-per-token billing is a money decision, and the notice is the audit trail.
+The fallback is automatic but never silent: a credential switch can change what
+the request costs, and the notice is the audit trail.
+The notice reports the switch; it does not certify how either side is billed.
+A subscription account with paid usage credits enabled can incur paid usage even
+under a `profile` entry — Anthropic tracks that as an overage status alongside
+the usage window — so JP never promises that OAuth traffic is covered by the
+allowance.
 The notice is chrome on stderr per [RFD 048]; under `--format json` it renders
 as NDJSON on stderr like all chrome.
 
+The auth commands are provider-owned UX: they migrate with the provider into
+its command plugin (as `jp anthropic login`, `list`, `logout`) once the
+command-plugin protocol supports running without a workspace and prompting for
+input.
+Until then they live in `jp_cli`; their behavior is the contract, their
+location is not.
+
 ### Credential store
 
-A user-global JSON file (`credentials.json` in JP's user data directory, created
-with `0600` permissions), keyed by provider and profile:
+A user-global store holding one versioned JSON document, keyed by category,
+provider, and profile:
 
 ```json
 {
-  "anthropic": {
-    "personal": {
-      "type": "oauth",
-      "access_token": "…",
-      "refresh_token": "…",
-      "expires_at": "2026-07-03T12:00:00Z",
-      "account_id": "…",
-      "email": "jean@example.com",
-      "exhausted_until": null
+  "version": 1,
+  "credentials": {
+    "llm": {
+      "anthropic": {
+        "personal": {
+          "type": "oauth",
+          "access_token": "…",
+          "refresh_token": "…",
+          "expires_at": "2026-07-03T12:00:00Z",
+          "account_id": "…",
+          "email": "jean@example.com",
+          "cooldowns": {}
+        },
+        "ci": {
+          "type": "token",
+          "token": "…",
+          "account_id": null,
+          "email": null,
+          "cooldowns": {}
+        }
+      }
     }
   }
 }
 ```
 
-The store is provider-agnostic in shape but Anthropic-only in implementation.
-All mutations (refresh, exhaustion marking) happen under a file lock, because
+A credential is a tagged variant.
+`oauth` carries a refreshable token pair and expiry; `token` is a static bearer
+token (the Phase 1 `claude setup-token` output) with no refresh flow and no
+expiry JP can inspect.
+`jp provider auth list` reports the variant, so a static token is never
+misdescribed as expired or refreshable.
+
+`version` is the migration discriminator: a store written by a newer schema is
+rejected with a clear error rather than partially read, and a migration rewrites
+the file atomically under the same lock as any other mutation.
+Credentials nest under a category (`llm`) and a provider (`anthropic`) rather
+than a flat dotted key, so listing one category (every LLM credential, say) is a
+direct lookup instead of key-prefix parsing, and future non-LLM categories slot
+in without a schema break.
+Only the `anthropic` provider under `llm` is implemented.
+As a paper check against a second provider: OpenAI Codex OAuth issues the same
+material (access/refresh/expiry plus account identity), so the `oauth` variant
+and the `llm` category fit it unchanged; any misfit a real implementation
+surfaces is absorbed by a version bump in the RFD that extends this one.
+
+All mutations (refresh, cooldown marking) happen under a file lock, because
 refresh tokens rotate: two processes racing a refresh can invalidate each
 other's tokens.
-Writes are atomic: mutate under the lock, write a temp file, and rename it over
-the store, so a crash mid-refresh cannot lose a rotated refresh token.
+The lock alone is not enough: a mutation reloads the store and rechecks its
+precondition after acquiring it, so a process holding a pre-rotation snapshot
+cannot submit an already-rotated refresh token and falsely mark a healthy
+profile as needing re-login.
+Writes are atomic — the document is replaced whole, never partially — so a
+crash mid-refresh cannot lose a rotated refresh token.
+The lock-mutate-persist cycle lives in the `jp_credentials` crate:
+`CredentialStore` owns the semantics every backend shares — the document
+encoding, the schema-version check, and the mutation cycle — while storage
+backends implement the `keyring-core` store interface, holding the document as
+a single entry.
+A file-based store is the baseline backend, and the macOS keyring (Phase 4)
+swaps in behind the same interface.
+A file-based backend must replace its file atomically (temp file and rename)
+and create it with `0600` permissions; if `keyring-core`'s bundled file store
+does not provide both, JP's file persistence implements the store interface
+itself.
+The mutation lock is a `ResourceLocker` (`jp_storage`), the same file-based
+locking primitive conversation locks are built on, and stays file-based for
+every store backend, since keyring stores provide no locking.
 A refresh rejected by the token endpoint marks the profile as needing re-login;
 resolution skips it with a notice and continues down the chain.
 
-`exhausted_until` persists quota cooldowns across invocations.
-Subscription limits reset on rolling windows and the quota error carries reset
-timing; recording it means a fresh `jp` invocation resolves straight past the
-exhausted profile instead of burning a failed request rediscovering it.
+`cooldowns` persists quota cooldowns across invocations, keyed by the window
+Anthropic reports as exhausted: `five_hour` and `seven_day` cover the whole
+account, while `seven_day_opus` and `seven_day_sonnet` cover one model family.
+A single profile-wide timestamp would let an exhausted Opus window block the
+same account's Haiku title generation.
+Resolution skips a profile only when a cooldown scope matching the requested
+model is in the future.
+Persisting reset timing means a fresh `jp` invocation resolves straight past the
+exhausted scope instead of burning a failed request rediscovering it.
+
+The store is core-owned and reached only through its API.
+Providers in core call `jp_credentials` directly; command plugins — and
+provider plugins, once those exist — reach the same operations through host
+protocol messages, so the on-disk format is never a cross-binary contract.
+The API is the versioning contract between JP and its plugins; the schema
+`version` above guards the document itself.
 
 ### Credential resolution
 
-Resolution is a shell concern.
-A resolver in `jp_cli` walks the configured chain before provider construction:
-skip profiles whose `exhausted_until` is in the future, refresh the access token
-if expired (under the file lock), and hand the provider a resolved credential —
-either an API key or a bearer token.
-`jp_llm` providers stay free of storage and refresh I/O.
-Provider construction takes the config plus the resolved credential:
-`TryFrom<&AnthropicConfig>`, which reads the env var today, is replaced by a
-constructor like `Anthropic::new(config, credential)`; env lookup leaves
-`jp_llm` entirely.
-The shell retains the identity of the credential it resolved (profile name and
-kind) and pairs it with any stream error at retry time; credential identity
-never crosses the provider boundary.
+Resolution is a provider concern.
+The Anthropic provider owns its credential policy: it reads the `auth` chain
+from its config, walks it per request, refreshes expired access tokens, and
+decides when an entry is skipped, retried, or abandoned.
+Core owns none of that vocabulary — every provider is constructed the same
+way, from its config alone, and the turn loop, tasks, and every other call
+site are credential-unaware.
+What core owns is the credential store (see Credential store): the provider
+loads profiles and records outcomes — cooldowns, re-login markers, recovered
+identity — through the `jp_credentials` API.
 
-This sits upstream of the provider SDKs, so it survives a later migration of the
-streaming layer unchanged: whatever builds the request receives auth material as
-data.
+Resolution runs in two stages, both inside the provider:
+
+1. **Preflight**, synchronous and local, at provider construction, against a
+   store snapshot.
+   Hard failures are config-shaped: an unparseable chain, an entry that maps to
+   no stored profile, or a malformed stored record.
+   Everything else is per-entry state, and preflight fails only when no entry in
+   the chain could possibly resolve: one broken profile does not block a chain
+   whose purpose is to fall past it.
+   This is the existing `provider::preflight` seam, uniform across providers: a
+   provider that cannot possibly authenticate fails before commands start
+   side-effectful work, exactly as one with an unset `api_key_env` does.
+2. **Resolution**, asynchronous, before each request the provider sends.
+   Walks the chain, skips entries per the table below, refreshes an expired
+   access token, and sends the request with the credential it lands on: an API
+   key or a bearer token.
+   The construction snapshot serves preflight only; a refresh re-reads the
+   store under the lock before acting (see Credential store).
+
+Every credential condition has exactly one outcome:
+
+| Condition                                    | Detected at       | Outcome                                       |
+| -------------------------------------------- | ----------------- | --------------------------------------------- |
+| Empty chain, duplicate or unrecognized entry | config validation | error                                         |
+| Entry maps to no stored profile              | preflight         | error                                         |
+| Stored record malformed                      | preflight         | error                                         |
+| No chain entry can possibly resolve          | preflight         | error                                         |
+| Profile marked needs-re-login                | resolution        | skip, notice                                  |
+| Profile unverified, attribution optional     | resolution        | resolve normally                              |
+| Profile unverified, attribution required     | resolution        | recover identity; on failure skip, notice     |
+| Cooldown scope matches requested model       | resolution        | skip                                          |
+| `api_key` environment variable unset         | resolution        | skip, notice                                  |
+| Refresh rejected by the token endpoint       | resolution        | mark needs-re-login; skip, notice             |
+| Credential refused mid-request (`401`/`403`) | streaming         | mark needs-re-login; advance chain, notice    |
+| Subscription-window exhaustion               | streaming         | record scoped cooldown; advance chain, notice |
+| API billing exhaustion                       | streaming         | advance chain, notice                         |
+| Access token expired                         | streaming         | refresh, retry same credential                |
+| Transient rate limit (plain 429)             | streaming         | retry same credential with backoff            |
+| Chain exhausted                              | any stage         | terminal error                                |
+
+Two rows pin down behavior worth naming.
+A missing `api_key` environment variable is a skip in a multi-entry chain, so a
+missing key cannot block subscription use; under the default `["api_key"]` chain
+the skip exhausts the chain and preflight fails exactly as today.
+Cooldown recording applies only to stored profiles: `api_key` has no store
+entry, so an exhausted key is retried once per invocation and falls through,
+with the retry rejected at admission before any tokens are billed.
+
+Unverified profiles resolve according to the attribution requirement Phase 1
+fixes (see Request authentication).
+If `account_uuid` proves optional, an unverified profile resolves normally:
+`device_id` and `session_id` are JP-derived and need no account identity, and
+`account_uuid` is omitted; the reference implementation's metadata shape already
+tolerates its absence.
+If attribution proves required, resolution attempts one identity recovery via
+the Claude CLI bootstrap endpoint, the same call login uses.
+That endpoint rejects setup tokens (measured; see Phase 1), so a setup-token
+profile can never be attributed and stays unverified for its lifetime.
+A recovered UUID is persisted under the store lock, and the duplicate-account
+check that login skipped runs at that point.
+When recovery fails, the profile is non-resolvable: skipped with a notice naming
+the exact `jp provider auth login` command while another entry remains, terminal
+when the chain exhausts.
+
+Because the provider resolves per request, every request a turn issues —
+across tool-execution cycles, and equally for title generation, summarization,
+or any other purpose — lands on a usable credential, and an access token
+expiring between requests is absorbed by a refresh rather than surfacing as an
+error.
+An expiry surfacing mid-stream is a refresh-and-retry on the same credential,
+not a chain advance.
+A task whose provider fails preflight skips its work softly, exactly as title
+generation does today.
+Profile names, chain position, and account identity never leave the provider:
+the store API speaks in categories, providers, and profiles, but no other core
+component consumes them.
+When request enforcement requires account attribution (see Request
+authentication), the resolved profile's account UUID is request data the
+provider embeds in `metadata.user_id`.
+Resolution outcomes a user must see — a skipped profile, a credential switch —
+are emitted as notice events on the provider's event stream, generic stream
+vocabulary any provider can use, and rendered as chrome on stderr per
+[RFD 048].
+
+Credential policy travels with the provider: when a provider moves out of core
+into a plugin, its resolution logic, wire mechanics, and login UX move with it,
+and the credentials API — reachable in-process today, over the plugin protocol
+then — is the only seam left behind.
 
 ### Quota fallback
 
-`StreamErrorKind::InsufficientQuota` exists and `looks_like_quota_error` already
-matches Anthropic's quota error text.
-Today the kind is terminal.
-It becomes conditionally retryable:
+Three failure semantics matter here; the current classifier represents two:
 
-1. A request fails with `InsufficientQuota` while an OAuth profile is active.
-   The provider's error classifier populates an optional quota-reset timestamp
-   on the `StreamError` — distinct from `retry_after`, whose backoff semantics
-   don't fit a subscription cooldown.
-2. The stream retry module in `jp_cli` marks the profile exhausted in the store
-   (using the reset timestamp), prints the notice, and returns a
-   credential-switch outcome, distinct from a plain retry.
-3. The turn loop re-resolves the chain, rebuilds the provider from the new
-   credential, and re-enters the streaming phase immediately — no backoff
-   sleep; this is not a transient error, and the new credential is usable now.
-   Model details are retained across the switch; they are account-independent.
-4. If the chain is exhausted, the error is terminal, exactly as today.
+- **Transient rate limit.** A plain HTTP 429, today's `RateLimit`; retried in
+  place with backoff.
+  Unchanged by this design.
+- **API billing exhaustion.** Credit-balance and billing errors on per-token
+  accounts, today's `InsufficientQuota`; currently terminal.
+- **Subscription-window exhaustion.** A subscription account hitting a rolling
+  usage window.
+  Nothing represents this today: `looks_like_quota_error` matches billing
+  phrases, and the Anthropic classifier maps ordinary 429s to `RateLimit`.
 
-The turn loop therefore receives a provider source — the resolver plus the
-provider config — rather than a pre-built provider.
+Subscription limits are reported in response headers, not in the error body
+(measured; see Phase 1).
+A `429` carrying `anthropic-ratelimit-unified-representative-claim` or
+`anthropic-ratelimit-unified-overage-status` is a quota rejection; a `429`
+without them is not, and Claude Code's own client says so in as many words.
+That distinction is the classifier: it separates exhaustion from ordinary
+capacity throttling and from a rejected request fingerprint, which arrive with
+the same status and an opaque body.
 
-In-flight fallback is scoped to the query streaming loop.
-Other LLM call sites (conversation edit, summarize, inquiry collection, title
-generation) resolve the chain at provider construction, so a persisted cooldown
-routes them past exhausted profiles; a quota error mid-request there remains
-terminal, exactly as today.
+The headers also carry what the cooldown needs:
+
+| Header                                             | Use                                                          |
+| -------------------------------------------------- | ------------------------------------------------------------ |
+| `anthropic-ratelimit-unified-status`               | `allowed`, `allowed_warning`, `rejected`                     |
+| `anthropic-ratelimit-unified-representative-claim` | the exhausted window: `five_hour`, `seven_day`, `seven_day_opus`, `seven_day_sonnet` |
+| `anthropic-ratelimit-unified-reset`                | when that window resets, as Unix seconds                     |
+| `anthropic-ratelimit-unified-overage-status`       | whether paid spillover can serve the request                 |
+| `retry-after`                                      | present only when rejected with no overage available         |
+
+JP never chooses paid spillover.
+A quota rejection is treated the same whether `overage-status` says spillover
+is available or exhausted: the cooldown is recorded and the chain advances.
+Paid usage happens only because the user listed `api_key` in the chain, which
+keeps one consent model rather than two.
+The limit of that guarantee: extra usage is an account-level setting, so an
+account with it enabled may have requests served past the window and billed as
+overage without any rejection for JP to react to.
+JP cannot prevent that; it only refuses to select it.
+
+A `401` or `403` is the other credential-scoped failure: the credential
+itself was refused, so no amount of retrying helps.
+Anthropic distinguishes two cases worth naming, both of which mark the profile
+as needing re-login: `OAuth token has been revoked`, and `OAuth authentication
+is currently not allowed for this organization`.
+Any other `401`/`403` is treated the same way, since a credential the provider
+won't accept cannot serve the request whatever the reason.
+
+Exhaustion becomes conditionally retryable via credential switch:
+
+1. A request fails at admission with an exhaustion kind: subscription-window
+   exhaustion under a stored profile, or billing exhaustion under any chain
+   entry.
+   The provider classifies the rejection from the headers above, reading the
+   exhausted scope and its reset instant — distinct from `retry-after`, whose
+   backoff semantics don't fit a subscription cooldown.
+   When a rejection arrives without reset timing, a fixed 30-minute cooldown
+   applies, scoped to the whole account.
+   The costs are asymmetric, so the fixed value biases short: a too-short
+   cooldown wastes one admission-rejected request per expiry (no tokens are
+   billed), a too-long one silently spends per-token money while a recovered
+   allowance sits idle.
+   Observed reset timing dominates whenever available, capped at the longest
+   known window (seven days) so a misparsed timestamp cannot brick a profile; a
+   cooldown clears on its own or via logout and re-login.
+2. The provider records the scoped cooldown through the store API (for stored
+   profiles; `api_key` has no entry to record against) and emits the switch
+   notice as an event.
+   The recorded cooldown is what routes the next resolution past the spent
+   profile, so a mid-turn switch and a fresh invocation share one code path.
+3. The provider re-resolves the chain and re-sends the request immediately —
+   no backoff sleep; this is not a transient error, and the new credential is
+   usable now.
+   Model metadata (context sizes, structural details) is retained across the
+   switch; access is not guaranteed, and a model authorization or unknown-model
+   error under the fresh credential is terminal, with an error naming the
+   credential and the model.
+4. If the chain is exhausted, the original error is terminal, exactly as today.
+
+Every credential in the chain is expected to have access to the models the
+conversation uses.
+JP does not switch models on a credential's behalf, and it does not probe the
+chain for a credential that can serve the model: "this account lacks the model"
+and "this model does not exist" are indistinguishable on the wire (both answer
+404), and walking the chain on that ambiguity would burn every credential on a
+doomed request whenever a model name is simply wrong.
+
+The switch is invisible to the turn loop: it receives a provider and a stream,
+and the notice event is the only trace a switch leaves in the event flow.
+
+Fallback applies to every request the provider sends: the query streaming
+loop, conversation edit and summarize, inquiry collection, title generation.
+Persisted cooldowns route any invocation past exhausted profiles, and an
+admission-time rejection advances the chain wherever it occurs — there is no
+separate in-flight machinery to scope.
 
 Anthropic enforces quota at request admission and lets an in-flight stream
 finish (it goes "into debt" rather than cutting mid-stream), so fallback
@@ -195,13 +447,61 @@ No new recovery machinery is needed.
 
 ### Request authentication
 
-OAuth requests differ from API key requests in two headers: `Authorization:
-Bearer <token>` instead of `x-api-key`, plus `anthropic-beta: oauth-2025-04-20`.
+OAuth requests differ from API key requests by far more than the auth header.
+The reference implementations send a Claude Code request fingerprint; at the
+pinned oh-my-pi revision, the provider module sends for OAuth tokens:
+
+- **Headers**, built by [`buildAnthropicHeaders`][oh-my-pi-headers]:
+  `Authorization: Bearer <token>` instead of `x-api-key`; an `anthropic-beta`
+  set including `oauth-2025-04-20` plus Claude Code betas
+  (`claude-code-20250219`, `interleaved-thinking-2025-05-14`,
+  `context-management-2025-06-27`, and more); client identity, a Claude Code
+  user agent plus `x-app: cli`; client platform and version headers
+  (`X-Stainless-*`, `anthropic-client-platform`, `anthropic-client-version`);
+  and per-request identifiers (`x-client-request-id`, plus an optional Claude
+  Code session-id header).
+- **Request metadata**: `metadata.user_id` carrying `{device_id, session_id,
+  account_uuid}`: the active credential's account UUID, a stable device
+  identifier, and a per-session UUID.
+- **System content**: a system prompt beginning with Claude Code's identity
+  line, plus a billing block whose `cch` attestation is a hash computed over the
+  serialized request body.
+  The identity line is enforced (Phase 1), so JP sends it and immediately
+  follows it with a block naming it as a transport artifact and pointing at
+  JP's own prompt, which keeps a foreign identity from standing as an
+  instruction; the attestation is not sent at all.
+- **Behavioral constraints**: an output-token clamp (64k) applied to OAuth
+  requests even when the model's ceiling is higher.
+
+How much of this fingerprint Anthropic enforces is unknown; measuring it is a
+Phase 1 deliverable, run top-down: start from the complete fingerprint above and
+remove elements until the minimum accepted request remains, rather than starting
+minimal and reading the absence of immediate errors as proof.
+The policy decision, recorded here: JP sends the fingerprint that established
+harnesses have verified Anthropic accepts, including the system-prompt identity
+line if enforcement requires it, and prefers the smallest fingerprint that works
+reliably, dropping impersonation elements Phase 1 shows to be unnecessary.
+Identifying as JP is preferred wherever Anthropic accepts it; matching Claude
+Code where it does not is an accepted trade-off, made explicitly in this RFD
+rather than inside the `async-anthropic` fork.
+
+Two groups carry their own rules.
+If identity metadata proves required, JP sends pseudonymous identifiers of its
+own in the required shape (a device identifier derived from a JP-local install
+ID, never Claude Code's), and the resolved credential carries the account UUID
+as a narrowly typed attribution field (see Credential resolution); Phase 1
+records exactly which identity metadata is transmitted.
+Profiles without a stored account UUID follow the unverified-profile rules in
+Credential resolution.
+The output clamp is behavior, not authentication: JP adopts it only if Phase 1
+shows enforcement, and then as a documented cap on OAuth `max_tokens`, never as
+a hidden side effect of bearer mode.
+
 The `async-anthropic` fork the project already maintains grows a bearer-auth
-mode.
-The bearer-auth mode emits the OAuth beta header itself; user-configured
-`beta_headers` merge separately and can neither remove nor duplicate it, and the
-header is never sent with API key auth.
+mode implementing the fingerprint as named, documented constants.
+The bearer-auth mode emits the OAuth headers itself; user-configured
+`beta_headers` merge separately and can neither remove nor duplicate them, and
+none of this is sent with API key auth.
 
 ### OAuth flow mechanics
 
@@ -209,12 +509,27 @@ The login flow is the one Claude Code uses, well-documented by multiple
 open-source implementations:
 
 1. Generate a PKCE verifier/challenge and random state.
-2. Open `https://claude.ai/oauth/authorize` with Claude Code's client ID and the
-   inference scopes (`user:inference` is only granted via this endpoint; the
-   platform console endpoint issues API-key-management tokens only).
+2. Open `https://claude.ai/oauth/authorize` with Claude Code's client ID,
+   requesting `user:inference` plus `user:profile` for account identification
+   (`user:inference` is only granted via this endpoint; the platform console
+   endpoint issues API-key-management tokens only).
 3. Capture the callback on a localhost port, or accept a pasted redirect URL.
 4. Exchange the code at `https://api.anthropic.com/v1/oauth/token`.
 5. Store `{access, refresh, expires, account_id, email}`.
+
+The requested scope set is deliberately smaller than Claude Code's own grant,
+which also asks for `org:create_api_key`, `user:sessions:claude_code`,
+`user:mcp_servers`, and `user:file_upload`: capabilities JP has no use for, each
+widening what a leaked refresh token can do and what the browser consent screen
+asks the user to approve.
+JP borrows a client ID it does not own, so the authorize endpoint may refuse the
+reduced set; whether the reduction holds is a Phase 3 measurement, not a
+promise.
+`user:profile` is not optional within that set: the bootstrap identity call
+requires it (see Phase 1), so dropping it would leave every profile unverified.
+If Anthropic requires the full Claude Code scope set for this client ID, JP
+requests it, and this RFD gains a one-line justification per extra capability,
+recorded as an accepted risk before Phase 3 ships.
 
 Refresh uses the same token endpoint with `grant_type: refresh_token`.
 The exchange and refresh logic is pure (types in, types out); the callback
@@ -232,9 +547,17 @@ server, browser opening, and store I/O form the thin imperative shell around it.
   approved tools — can read it.
   `0600` limits exposure on Unix; Windows relies on default user-profile ACLs,
   matching what Claude Code does there.
+  On macOS the file is a regression against Claude Code, which uses the
+  Keychain; the Phase 4 keyring backend closes that gap, gating other
+  processes' access behind Keychain ACLs.
 - **Maintenance of an undocumented flow.** The OAuth endpoints, client ID, and
   headers are Claude Code implementation details, not published API.
   Anthropic can change them without notice, and JP owns the breakage.
+  The request fingerprint deepens this: every impersonated element is one more
+  surface that can silently change or become an enforcement check.
+  If identity metadata proves required, JP sends a stable pseudonymous device
+  identifier with every OAuth request; that is a privacy-relevant behavior this
+  RFD makes explicit rather than inherits silently.
 
 ## Alternatives
 
@@ -254,16 +577,26 @@ server, browser opening, and store I/O form the thin imperative shell around it.
 
 ## Non-Goals
 
-- **OAuth for other providers.** The store schema and chain are
-  provider-agnostic by construction, but only Anthropic is implemented.
-  OpenAI Codex OAuth has the same shape and can follow as its own RFD.
+- **OAuth for other providers.** Only Anthropic is implemented.
+  The store schema is versioned and namespaced so a later RFD can extend it;
+  OpenAI Codex OAuth follows as its own RFD that `Extends` this one.
+  Genericism is argued on paper (see Credential store), not claimed proven from
+  a single implementation.
+
+  The store API is provider-agnostic — categories, providers, and profiles are
+  just keys — while credential policy is provider-owned by construction: each
+  provider's chain semantics, refresh flow, and error vocabulary live in its
+  own module and move with it into a plugin.
+  The second provider adds its own policy without touching shared code; the
+  store API is the only shared surface, and it is the same one plugins consume.
 - **Multi-account routing UX.** Ordering in the `auth` chain is the only routing
   mechanism.
   Per-conversation account pinning, usage-based routing, and similar are out of
   scope.
-- **OS keychain storage.** The file-based store matches JP's threat model (the
-  user's own machine) and what Claude Code itself does on Linux.
-  A keyring backend can be added behind the same store interface later.
+- **Keyring backends beyond macOS.** Phase 4 adds the macOS keyring backend.
+  Linux secret-service and Windows Credential Manager stores exist behind the
+  same `keyring-core` interface and can follow, but are not part of this
+  design.
 - **Sharing tokens with Claude Code.** JP's login is independent.
   Users who log the same account into both tools may see one tool's session
   invalidated by the other's refresh; that is inherent to Anthropic's token
@@ -276,55 +609,295 @@ server, browser opening, and store I/O form the thin imperative shell around it.
   published policy.
   Anthropic has previously cut off third-party tools using this flow.
   The feature can break by fiat; API key auth remains the supported path.
-- **System prompt enforcement.** Historically, inference with OAuth tokens
-  required the system prompt to begin with Claude Code's identity line.
-  If this is enforced, JP must decide — explicitly, in this RFD before
-  acceptance — whether prepending that line is acceptable.
-  This is a policy call, not an engineering one.
-  Phase 1 exists to answer it empirically before further investment.
+- **System prompt enforcement.** Inference with OAuth tokens requires the system
+  prompt to begin with Claude Code's identity line; Phase 1 measured the
+  enforcement, so JP prepends it.
+  The line cannot be removed, but its effect can be bounded: JP follows it with
+  a block naming it as a transport artifact and pointing at the prompt that
+  follows.
+  Measured: the enforcement check tolerates that insertion, and the model then
+  identifies as JP without remarking on the contradiction.
+  The residual risk is that this is a prompt-level mitigation, not a guarantee —
+  a future model may weigh the identity line differently — and that API key
+  requests carry neither block, so the same conversation can behave differently
+  across a credential switch.
 - **Thinking signatures across accounts.** Signatures minted under one account
   may be rejected under another after a fallback switch.
   The existing stale-signature recovery (strip and retry) should absorb this;
   confirm during manual testing.
-- **Quota error shape.** The reset-timing field on quota errors needs verifying
-  against the live API; if absent, `exhausted_until` falls back to a fixed
-  conservative cooldown.
+- **Quota error shape.** The quota headers are taken from Claude Code's client
+  source, not from a live rejection JP observed.
+  If the names or values have drifted, exhaustion degrades to an ordinary rate
+  limit: JP retries in place, records no cooldown, and never switches
+  credentials — the safe direction, since the opposite would spend money over a
+  misread header.
+  A rejection without reset timing falls back to the fixed 30-minute
+  account-scoped cooldown.
 
 ## Implementation Plan
 
 ### Phase 1: bearer auth, store, and setup-token login
 
 Bearer mode in the `async-anthropic` fork; the credential store with file
-locking and profile schema; chain resolution in `jp_cli`; `jp auth login
-anthropic --setup-token` accepting a pasted long-lived token from `claude
-setup-token`; `jp auth list` and `jp auth logout`, so the store is never
-manageable only by hand-editing.
-This exercises the full request path — including the system-prompt and
-signature questions above — before the browser flow is built.
+locking, versioned schema, and tagged credential variants; chain preflight
+and resolution in the `jp_credentials` crate;
+`jp provider auth login llm.anthropic --setup-token` reading a long-lived
+token from `claude setup-token` on stdin, stored as a static `token`
+credential, with identity recovery attempted at login and the profile stored
+unverified when it fails; `jp provider auth list` and `jp provider auth
+logout`, so the store is never manageable only by hand-editing.
+Phase 1 carries three measurement deliverables the rest of the design is fixed
+against: the minimum request fingerprint Anthropic accepts, measured top-down
+from the complete inventory in Request authentication (headers, identity
+metadata, system content and attestation) and recording which identity metadata
+is transmitted; whether the bootstrap endpoint accepts setup tokens for identity
+recovery; and the observed wire shape of a subscription-limit failure (status,
+body, headers).
 Independently reviewable and useful on its own.
+
+**Measured: the complete fingerprint is accepted.** A setup-token credential on
+a single-entry `["profile"]` chain (no fallback to mask a failure) completes a
+turn against `claude-sonnet-5`, with the headers, the OAuth beta set, and the
+Claude Code identity line as inventoried above.
+The trim runs from there, one element per request, keeping whatever Anthropic
+still accepts without it.
+
+**Measured: the system-prompt identity line is enforced.** Dropping it — the
+first trim, since it is the element with a behavioral cost rather than only a
+maintenance one — makes every request fail, so JP keeps sending it, followed by
+a block that names it as a transport artifact (see Request authentication).
+The check tolerates that insertion, and the model identifies as JP rather than
+as Claude Code.
+
+The rejection does not identify itself: Anthropic answers `429
+rate_limit_error` with an opaque `"message": "Error"` body, not a `401` and not
+a message naming the check.
+The remaining trims are read against that signature, because a rejected
+fingerprint is otherwise indistinguishable from ordinary throttling, and a
+subscription window that expires mid-campaign would read as a trim result.
+It also constrains Phase 2: status alone cannot separate a fingerprint
+rejection, a transient rate limit, and subscription-window exhaustion, so the
+classifier keys on the error body.
+
+**Measured: the bootstrap endpoint rejects setup tokens.** It answers HTTP 403
+`permission_error` with `scope requirement any_of(user:ccr_inference,
+user:profile)`, and `claude setup-token` mints a token scoped to
+`user:inference` alone.
+Identity recovery is therefore unavailable for setup-token profiles: they are
+stored unverified, which the design already treats as a usable state, and the
+duplicate-account check never runs for them.
+This also fixes a scope requirement for Phase 3: `user:profile` is what makes
+attribution possible, so the reduced scope set must keep it.
+
+The token reaches JP by paste, not by pipe: `claude setup-token` is an
+interactive session, and every stage of a shell pipeline starts at once, so a
+downstream JP would read the stream before a token exists while the command
+still needs the terminal for its own prompts.
+A non-interactive source (a clipboard tool, a file) pipes fine.
+
+**Measured: subscription limits are reported in response headers.** Read from
+Claude Code's own client source rather than captured from a live rejection, so
+the header names are authoritative but the values should be confirmed against
+the first real limit JP sees.
+
+A `429` is a quota rejection only when it carries
+`anthropic-ratelimit-unified-representative-claim` or
+`anthropic-ratelimit-unified-overage-status`; Claude Code treats a `429`
+without them as "not a quota limit" and surfaces whatever the API said.
+That predicate is what separates exhaustion from capacity throttling and from
+the fingerprint rejection measured above, all three of which are `429`
+`rate_limit_error`.
+The `representative-claim` values are the cooldown scopes the store records,
+and `anthropic-ratelimit-unified-reset` carries the reset instant as Unix
+seconds, so reset timing needs no separate usage endpoint.
+`seven_day` is the longest window, which is where the seven-day cooldown cap
+comes from.
+
+The same source confirms that `overage-status` governs paid spillover on
+Anthropic's side: a subscription account with extra usage enabled keeps serving
+requests past its window and bills them, which is why JP never claims a
+`profile` entry is free (see Drawbacks).
 
 ### Phase 2: quota fallback
 
-Reclassify `InsufficientQuota` as retryable-via-credential-switch, exhaustion
-marking with persisted cooldown, the fallback notice, and no-backoff retry.
+The subscription-window exhaustion classification, keyed on the quota headers
+Phase 1 identified; retryable-via-credential-switch handling; scoped cooldown
+persistence; the fallback notice; and no-backoff retry.
 Depends on Phase 1.
+
+### Phase 2c: provider-owned credential policy and the core store API
+
+Moves credential policy into the Anthropic provider and reshapes the store into
+the core-owned API described in Credential store.
+Chain preflight and resolution move from `jp_credentials` into the provider;
+in-flight switching moves from the CLI's stream-retry path into the provider's
+request admission; the switch notice becomes a provider-emitted notice event;
+provider construction returns to config-only, uniform across providers; and
+the shell's per-call-site credential resolution is deleted.
+The store adopts the `keyring-core` store interface behind the existing
+lock-mutate-persist cycle.
+User-visible behavior is unchanged, except that fallback now applies to every
+request the provider sends rather than only the query streaming loop.
+It is numbered `2c` although it runs before Phase 2b: 2b was already named when
+this phase was added, and existing phase references keep their meaning.
+Depends on Phases 1 and 2 (it relocates what they built); Phases 2b, 3, and 4
+build on it.
+
+### Phase 2b: subscription-state awareness
+
+Phase 2 reacts to a spent allowance after a request fails.
+The same headers Anthropic sends on *every* response carry enough to act
+before that, and Claude Code's client shows which of them are load-bearing:
+
+- **Warning states.** `anthropic-ratelimit-unified-status` reports
+  `allowed_warning` alongside the window that is filling up, and separate
+  `-5h-utilization` / `-7d-utilization` headers carry the fraction consumed
+  with a `-surpassed-threshold` marker.
+  Surfacing that as chrome tells the user their allowance is nearly gone while
+  they can still choose what to spend it on — far better than discovering it
+  mid-turn.
+- **Explaining a refusal.** `-overage-disabled-reason` names why paid spillover
+  could not serve the request (`out_of_credits`, org- or seat-level caps).
+  That belongs in the terminal error rather than being flattened into "limit
+  reached", so a user whose organization capped spending is told so instead of
+  guessing.
+  This reports on spillover; it does not select it (see Quota fallback).
+- **Recording state from successful responses.** Cooldowns are written today
+  only when a request fails.
+  Reading the same headers off a `200` lets JP record a window's utilization
+  and reset without burning a rejected request to discover it.
+
+This phase is optional in the sense that Phase 2 is correct without it, and
+valuable because it converts the subscription from something JP reacts to into
+something it can report on.
+It is numbered `2b` rather than `3` so the phase numbers already referenced
+elsewhere in this document keep their meaning.
+Depends on Phases 2 and 2c.
+
+**Measured: the header names, from Claude Code's own client.** The per-window
+headers are abbreviated where the window names elsewhere are spelled out:
+`anthropic-ratelimit-unified-{5h,7d}-utilization` carries the fraction
+consumed, `-{5h,7d}-reset` the per-window reset (distinct from the top-level
+`-reset`), and `-{5h,7d,overage}-surpassed-threshold` marks a crossed warning
+threshold — its presence is the signal, its value the threshold.
+`-overage-disabled-reason` reports one of thirteen enumerated reasons
+(`out_of_credits`, `org_level_disabled`, `seat_tier_zero_credit_limit`, …).
+JP normalizes the abbreviations to the spelled-out window names so one
+vocabulary reaches the user.
+
+The client also computes a *time-relative* early warning of its own when the
+server sends no threshold (warn at 90% utilization within 72% of the 5-hour
+window, and three tiers for the weekly one). JP does not: that is client-side
+policy layered on the provider's own signal, and surfacing only what the
+provider flags keeps the notice trustworthy.
+
+**A spent window is readable from a response that succeeded.** `status:
+rejected` accompanies a `200` whenever paid extra usage covered the request, so
+the drawback this design records as unpreventable — usage billed past the
+window with no rejection to react to — is detectable one request after it
+starts. JP records the scoped cooldown at that point, so the next resolution
+moves off the profile instead of billing against it again, and surfaces a
+notice naming the window. The request that revealed it is still billed; that
+part is unavoidable.
+
+### Transport: reading a successful response's headers
+
+The quota headers ride on every response, but JP's Anthropic client reached
+them only on failures: `reqwest-eventsource` yields a unit `Open` event and
+exposes the `Response` only in its error variants. Phase 2b therefore rests on
+a transport change, made as its own step: the streaming path issues the request
+directly and parses the body with `eventsource-stream` (the SSE parser
+`reqwest-eventsource` itself wraps), which makes the response — and its headers
+— available on success.
+
+The change drops SSE-level reconnection, deliberately. Anthropic's message
+endpoint sends no SSE event ids, so a reconnect cannot resume: it issues a
+fresh completion whose content restarts from the beginning, which is the wrong
+operation at that layer. Nothing consumed it in practice — every error was
+yielded to the caller, which abandoned the stream — while the orphaned
+reconnect still fired 15 seconds later and paid for a completion nobody read.
+Recovery stays where it belongs: the turn loop flushes partial content, rebuilds
+the thread with it as assistant prefill, and continues on a fresh stream.
+The `cerebras` and `llamacpp` providers had already reached the same conclusion
+and configure `retry::Never`.
+
+One related fix: the buffered `get`/`post` paths retried *every* `429` with a
+15-second floor, including quota rejections, so a spent subscription stalled for
+the better part of a minute before the credential switch could act. They now
+retry only capacity throttling.
 
 ### Phase 3: PKCE browser login
 
-The full `jp auth login anthropic` flow: PKCE, browser, localhost callback,
-paste fallback, refresh-on-expiry.
-Depends on Phase 1; independent of Phase 2.
+The full browser login flow: PKCE, browser, localhost callback, paste
+fallback, refresh-on-expiry.
+The phase lands in two halves.
+The token exchange and refresh logic is pure library code in the provider's
+auth module and lands first: refresh-on-expiry is what per-request resolution
+needs for `oauth` profiles, however the tokens were obtained.
+The login command ships in the provider's command plugin (`jp anthropic
+login`), which waits on two command-plugin protocol capabilities specified
+separately: running without a workspace, and prompting for input.
+Until the plugin ships, setup-token login through the in-core CLI remains the
+login path.
+Phase 3 measures whether the authorize endpoint grants the reduced
+`user:inference` plus `user:profile` scope set for Claude Code's client ID; if
+not, the full-set fallback and its per-capability justifications land in this
+RFD before the phase ships (see OAuth flow mechanics).
+Depends on Phases 1 and 2c; independent of Phase 2.
+
+**Measured: the endpoints moved.** The token endpoint is
+`https://platform.claude.com/v1/oauth/token`, not the `api.anthropic.com` path
+named above, and the authorize endpoint Anthropic's client opens is
+`https://claude.com/cai/oauth/authorize`, which redirects to the `claude.ai`
+path named above.
+JP sends what the client sends.
+Both token requests carry a JSON body, not a form encoding, and the paste
+fallback redirects to `https://platform.claude.com/oauth/code/callback`.
+
+**Measured: an access token is refreshed five minutes before it expires.**
+Anthropic's client treats a token inside that window as already expired, which
+keeps one from lapsing between being resolved and being used; JP uses the same
+buffer.
+
+**Still unmeasured: whether the reduced scope set is granted.** That needs a
+live authorize round-trip, which arrives with the browser flow. Until then the
+reduced set is what JP requests and the full-set fallback remains the
+documented contingency.
+
+### Phase 4: macOS keyring store backend
+
+The macOS Keychain behind the `keyring-core` store interface
+(`apple-native-keyring-store`), replacing the file store on macOS and
+restoring parity for users migrating from Claude Code there.
+The backend stores the same versioned JSON document as a single entry, so
+cooldowns and re-login state move with the secrets; the store's
+`ResourceLocker` lock file keeps serializing mutations, since the Keychain
+provides no locking.
+
+Existing stores migrate once, under the file lock: read the file store, write
+the Keychain item, read it back and verify, switch the backend marker, then
+remove the file best-effort and warn when removal fails.
+The single item write makes partial migration impossible; on any failure JP
+stays on the file backend and says so.
+The file remains the backend on Linux and Windows.
+Depends on Phases 1 and 2c; independent of Phases 2 and 3.
 
 ## References
 
+- [Claude Code client source (de-obfuscated)][claude-code-source] — quota
+  headers, error classification, OAuth handling
 - [Anthropic OAuth flow reference implementation (oh-my-pi)][oh-my-pi]
+- [oh-my-pi request fingerprint (`buildAnthropicHeaders`)][oh-my-pi-headers]
 - [OpenClaw OAuth concepts][openclaw] — token sink, refresh rotation, profile
   routing
 - [CLIProxyAPI][cliproxy] — proxy-based alternative
 - [Using Claude Code with your Pro or Max plan][claude-plans]
 
 [RFD 048]: 048-four-channel-output-model.md
+[\#875]: https://github.com/dcdpr/jp/issues/875
+[claude-code-source]: https://github.com/alex000kim/claude-code
 [claude-plans]: https://support.claude.com/en/articles/11145838-using-claude-code-with-your-pro-or-max-plan
 [cliproxy]: https://github.com/router-for-me/CLIProxyAPI
 [oh-my-pi]: https://github.com/can1357/oh-my-pi/blob/75bdb20212871221406e119745136edcb2197653/packages/ai/src/registry/oauth/anthropic.ts
+[oh-my-pi-headers]: https://github.com/can1357/oh-my-pi/blob/75bdb20212871221406e119745136edcb2197653/packages/ai/src/providers/anthropic.ts
 [openclaw]: https://docs.openclaw.ai/concepts/oauth


### PR DESCRIPTION
JP can now authenticate Anthropic requests with a Claude Pro/Max
subscription alongside an API key, and move between them on its own. A
spent allowance no longer ends a turn: the provider records what was
spent, switches to the next credential in the chain, and carries on.

The Anthropic provider owns its credential policy. It reads the `auth`
chain, walks it before every request, refreshes an expired OAuth token
in place, and switches at request admission when a credential is spent
or refused. Nothing above it knows what a credential is: every provider
is built from its config alone, and the turn loop, the tasks, and every
other call site are credential-unaware. What core owns is the store —
`jp_credentials` holds one versioned document, and every mutation runs
under a lock that re-reads and rechecks its precondition, because
refresh tokens rotate and two processes racing a refresh would otherwise
invalidate each other.

Bearer requests carry the Claude Code request fingerprint, which
Anthropic enforces: a bearer request whose system prompt does not begin
with their identity line is refused. JP sends it and immediately follows
it with a block naming it as a transport artifact, so a foreign identity
does not stand as an instruction ahead of JP's own prompt.

A subscription's usage state arrives in response headers rather than
error bodies, and on every response rather than only rejections. That
distinction matters twice. It is the only way to tell a spent window
from ordinary throttling — both are `429 rate_limit_error` with an
opaque body — and it is the only warning JP gets when an account with
extra usage enabled is quietly billing past its allowance. Both are read
and acted on: a scoped cooldown routes the next resolution off the
profile, and a crossed warning threshold is surfaced while the user can
still choose what to spend the rest on.

Reading those headers required the streaming transport to change. The
vendored `async-anthropic` fork now issues the request itself and parses
the body with `eventsource-stream`, which makes a successful response's
headers reachable. SSE-level reconnection goes with it, deliberately:
Anthropic sends no event ids, so a reconnect cannot resume and instead
issues a fresh completion from the beginning. Nothing consumed it, while
the orphaned attempt still fired fifteen seconds later and paid for
output nobody read. Recovery stays in the turn loop, which flushes
partial content and continues from it.

`Event::Notice` carries provider decisions the user must see — a skipped
credential, a switch, a nearly-spent window — as chrome on stderr,
without becoming part of the conversation.

`jp provider auth login|list|logout` manages stored profiles. Login
takes a `claude setup-token` value today; the PKCE, exchange, and
refresh machinery for browser login is in place and the command that
drives it follows.