### PR TITLE
chore(rfd): Add tracking tickets to RFD board

### DIFF
--- a/.jp/config/skill/rfd.toml
+++ b/.jp/config/skill/rfd.toml
@@ -58,7 +58,7 @@ status, which also moves the file up to `docs/rfd/`.
 
 `rfd_promote` handles deferred numbering: for DNN-prefixed drafts, it \
 assigns the next available permanent number and renames the file. When \
-promoting to Accepted, it creates a GitHub tracking issue.
+promoting to Accepted, it offers to file the RFD's tracking ticket.
 
 `rfd_renumber` moves an RFD (draft or published) to a new id and rewrites its \
 file name, heading, cross-references, and priority-board entry. The target id \

--- a/.jp/mcp/tools/rfd/promote.toml
+++ b/.jp/mcp/tools/rfd/promote.toml
@@ -6,8 +6,9 @@ command = "just rfd-promote {{tool.arguments.nnn}}"
 description = """Promote an RFD to the next stage (Draft -> Discussion -> Accepted -> Implemented).
 
 For drafts (DNN-prefixed), assigns a permanent number and moves the file \
-from `docs/rfd/drafts/` up to `docs/rfd/`. When promoting to Accepted, \
-creates a GitHub tracking issue via `jp`."""
+from `docs/rfd/drafts/` up to `docs/rfd/`. When promoting to Accepted, offers \
+to file the RFD's tracking ticket, with its Implementation Plan as the \
+description."""
 
 [conversation.tools.rfd_promote.style]
 inline_results = "full"

--- a/.jp/mcp/tools/ticket/create.toml
+++ b/.jp/mcp/tools/ticket/create.toml
@@ -59,9 +59,13 @@ type = "string"
 required = false
 summary = "The RFD this work comes from, e.g. `045`."
 description = """
-Set this when the ticket is a phase of an accepted RFD's implementation plan.
-An RFD counts as in development while a ticket claiming it sits in the In
-Progress column, so this is what puts it there.
+Set this when the work comes from an accepted RFD, whether the ticket covers the
+whole implementation or one phase of it.
+
+The RFD's *tracking* ticket carries this field together with the label
+`type=tracking`, and that one ticket is what the RFD priority board reports as
+in development. An RFD has at most one, filed by `just rfd-track`, so name
+`type=tracking` here only when the RFD has none.
 """
 
 [conversation.tools.ticket_create.parameters.labels]

--- a/.jp/mcp/tools/ticket/labels.toml
+++ b/.jp/mcp/tools/ticket/labels.toml
@@ -79,6 +79,7 @@ enum = [
   "type=pre-rfd",
   "type=question",
   "type=task",
+  "type=tracking",
 ]
 
 # Includes retired values: see the note above.
@@ -144,6 +145,7 @@ enum = [
   "type=pre-rfd",
   "type=question",
   "type=task",
+  "type=tracking",
 ]
 
 # Includes retired values and bare keys: see the note above.
@@ -214,4 +216,5 @@ enum = [
   "type=pre-rfd",
   "type=question",
   "type=task",
+  "type=tracking",
 ]

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -5,7 +5,7 @@ import { dirname, posix, resolve } from 'node:path'
 import { defineConfig } from 'vitepress'
 import abnfGrammar from './grammars/abnf.tmLanguage.json'
 import { joinMultilineInlineCode } from './join-inline-code.mjs'
-import { readLabels } from './loaders/ticket-shared.mjs'
+import { inDevelopmentRfds, parseTicket, readLabels } from './loaders/ticket-shared.mjs'
 import { rfdRedirectServer, writeRfdRedirects } from './rfd-redirects.mjs'
 
 // Rewrite relative links that climb above the docs root to absolute GitHub
@@ -413,6 +413,93 @@ const ticketWriter = {
     },
 }
 
+// Dev-only endpoint for an RFD's in-development state (`/rfd/priority`).
+//
+// The state lives on the RFD's tracking ticket, so a write shells out to
+// `just rfd-start` / `just rfd-stop` rather than touching a file. Marking an
+// RFD files that ticket when it has none, which reads the RFD's implementation
+// plan through a provider.
+const rfdDevelopmentWriter = {
+    name: 'rfd-development-writer',
+    configureServer(server) {
+        const dir = resolve(server.config.root, 'ticket')
+
+        server.middlewares.use('/__rfd-development', (req, res, next) => {
+            // The board reads this on mount. Writing a ticket file reloads the
+            // page, and the data loader caches for the server's lifetime, so
+            // without this the board comes back showing the state it was built
+            // with. Read through the site's own parser and rule.
+            if (req.method === 'GET') {
+                const tickets = readdirSync(dir)
+                    .filter((name) => /^[0-9a-z]{7}-.+\.md$/.test(name))
+                    .map((name) => parseTicket(readFileSync(resolve(dir, name), 'utf-8'), name))
+
+                res.setHeader('Content-Type', 'application/json')
+                res.end(JSON.stringify({ inDevelopment: inDevelopmentRfds(tickets) }))
+                return
+            }
+
+            if (req.method !== 'POST') return next()
+
+            let body = ''
+            let tooBig = false
+            req.on('data', (chunk) => {
+                body += chunk
+                if (body.length > 4 * 1024) {
+                    tooBig = true
+                    req.destroy()
+                }
+            })
+            req.on('end', () => {
+                if (tooBig) {
+                    res.statusCode = 413
+                    res.end('payload too large')
+                    return
+                }
+
+                let parsed
+                try {
+                    parsed = JSON.parse(body)
+                } catch {
+                    res.statusCode = 400
+                    res.end('invalid JSON')
+                    return
+                }
+
+                // The recipe name is chosen here rather than taken from the
+                // request, so a request can only ask for one of the two
+                // operations, on a published RFD. Whether that RFD is far
+                // enough along to carry a tracking ticket is the recipe's call.
+                if (
+                    typeof parsed.num !== 'string' ||
+                    !/^\d{3}$/.test(parsed.num) ||
+                    typeof parsed.active !== 'boolean'
+                ) {
+                    res.statusCode = 400
+                    res.end('expected { num: "NNN", active: boolean }')
+                    return
+                }
+
+                const recipe = parsed.active ? 'rfd-start' : 'rfd-stop'
+                execFile('just', [recipe, parsed.num], {
+                    cwd: resolve(server.config.root, '..'),
+                    // Reading the plan goes to a provider; the default (no
+                    // timeout) leaves a wedged run holding the request open
+                    // forever.
+                    timeout: 5 * 60 * 1000,
+                }, (error, stdout, stderr) => {
+                    res.statusCode = error ? 500 : 200
+                    res.setHeader('Content-Type', 'application/json')
+                    res.end(JSON.stringify({
+                        ok: !error,
+                        output: (stdout || stderr || String(error ?? '')).trim(),
+                    }))
+                })
+            })
+        })
+    },
+}
+
 // https://vitepress.dev/reference/site-config
 
 export default defineConfig({
@@ -495,6 +582,7 @@ export default defineConfig({
             serveMarkdownAsUtf8,
             rfdRedirectServer,
             rfdPriorityWriter,
+            rfdDevelopmentWriter,
             ticketBoardWriter,
             ticketWriter,
         ],

--- a/docs/.vitepress/loaders/rfd-board.data.js
+++ b/docs/.vitepress/loaders/rfd-board.data.js
@@ -10,8 +10,9 @@ import { assembleBoard } from './rfd-shared.mjs'
 // rows — milestone lines and the unsorted cutoff — from it, since markers are
 // also created, renamed, and removed at runtime.
 //
-// Each entry's `inDevelopment` flag comes from ticket state rather than from the
-// board file, so the board reports it without being able to set it.
+// Each entry's `inDevelopment` flag comes from the RFD's tracking ticket rather
+// than from the board file. The board's checkbox writes it by moving that
+// ticket, through the dev server's `/__rfd-development` endpoint.
 
 export default {
     load() {

--- a/docs/.vitepress/loaders/rfd-priority.mjs
+++ b/docs/.vitepress/loaders/rfd-priority.mjs
@@ -28,8 +28,9 @@ export const TERMINAL_STATUSES = new Set([
 // matching "a missing file is an empty board".
 //
 // There is no in-development field: "someone is writing code for this" is a
-// property of a work item, not of a design document, and is derived from ticket
-// state instead (see RFD 100).
+// property of a work item, not of a design document, and lives on the RFD's
+// tracking ticket instead (see RFD 100). The board's checkbox moves that
+// ticket; it stores nothing here.
 export function normalizePriority(raw) {
     const ids = v => (Array.isArray(v) ? v.map(String) : [])
 

--- a/docs/.vitepress/loaders/rfd-shared.mjs
+++ b/docs/.vitepress/loaders/rfd-shared.mjs
@@ -156,9 +156,9 @@ export function mergePriority(entries, priority) {
 
 // Mark the RFDs someone is currently implementing.
 //
-// Derived from the tickets: an RFD is in development when a ticket claiming to
-// implement it sits in the In Progress column. The board doesn't record this and
-// can't set it — closing the ticket clears the flag on its own.
+// Derived from the tickets: an RFD is in development when its tracking ticket
+// sits in the In Progress column. The board file records nothing about this, so
+// moving or closing that ticket is what changes the flag.
 export function mergeInDevelopment(entries, tickets) {
     const inDev = new Set(inDevelopmentRfds(tickets))
     for (const entry of entries) {
@@ -513,8 +513,8 @@ export function checkRequiresOnImplemented(graph) {
 
 // Assemble the full priority board: every published RFD and prioritisable
 // draft, annotated with board position (`priority`), in-development flag (from
-// ticket state), and hard dependencies (`dependsOn`). Entries not placed on the
-// board — including terminal RFDs — carry `priority: null`.
+// the RFD's tracking ticket), and hard dependencies (`dependsOn`). Entries not
+// placed on the board — including terminal RFDs — carry `priority: null`.
 //
 // Returns the entries alongside the normalized `priority` record so callers
 // can tell the prioritised `order` — and its milestone groups, `planned` —

--- a/docs/.vitepress/loaders/ticket-shared.mjs
+++ b/docs/.vitepress/loaders/ticket-shared.mjs
@@ -222,17 +222,25 @@ export function orderColumn(tickets, column, order) {
     })
 }
 
+// The label marking a ticket as its RFD's tracking ticket.
+export const TRACKING_LABEL = 'type=tracking'
+
 // The RFDs currently being implemented, derived from ticket state.
 //
-// An RFD is in development when a ticket claiming to implement it sits in the In
-// Progress column. Derived, not synced, so there is nothing to keep in step (see
-// RFD 100).
+// An RFD is in development when its tracking ticket sits in the In Progress
+// column. Phase tickets name the same RFD in `Implements` without the tracking
+// label, and never light the flag. Derived, not synced, so there is nothing to
+// keep in step (see RFD 100).
 export function inDevelopmentRfds(tickets) {
     const rfds = new Set()
     for (const ticket of tickets) {
         if (ticket.status !== 'In Progress' || !ticket.implements) continue
-        const num = ticket.implements.match(/\d{1,3}/)?.[0]
-        if (num) rfds.add(num.padStart(3, '0'))
+        if (!ticket.labels.includes(TRACKING_LABEL)) continue
+        // Anchored, so a draft id keeps its `D`: an unanchored digit match
+        // reads `D33` as RFD 033, which is a different document.
+        const id = ticket.implements.trim().replace(/^RFD\s+/i, '')
+        if (!/^(D\d{1,2}|\d{1,3})$/.test(id)) continue
+        rfds.add(id.startsWith('D') ? id : id.padStart(3, '0'))
     }
 
     return [...rfds].sort()

--- a/docs/.vitepress/rfd-summaries.json
+++ b/docs/.vitepress/rfd-summaries.json
@@ -1,6 +1,6 @@
 {
   "001-jp-rfd-process.md": {
-    "hash": "530085202f0a497981e72bffbc56f6cbf4164bb29f1fd45b50335dd4fecfba34",
+    "hash": "9a3a1f2bbaa8b805d56395bb34b5aac8fde84c8359d90cc046cc3d0cd612d65a",
     "summary": "Establishes lightweight Request for Discussion process for proposing and tracking design decisions with clear lifecycle states."
   },
   "002-using-llms.md": {
@@ -396,7 +396,7 @@
     "summary": "Conversations gain configurable key-value labels—static, command-backed, or CLI-set—managed through `jp c label` and used to filter by context like VCS branches."
   },
   "100-in-repo-ticket-tracking.md": {
-    "hash": "fe5755327f6da3db185b61ad49627b6e8196f701d246201dfac5c745f6b3099f",
+    "hash": "2acad9c85b40491156a158871f0d884fd79a12913df1342b6f05f4014e62ec39",
     "summary": "Lightweight markdown-based work items tracked in-repo, displacing GitHub issues from assistant context with kanban board and RFD promotion mechanics."
   },
   "102-collision-resistant-ticket-identifiers.md": {

--- a/docs/.vitepress/theme/RfdBoard.vue
+++ b/docs/.vitepress/theme/RfdBoard.vue
@@ -2,7 +2,7 @@
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 
 import { normalizePriority, TERMINAL_STATUSES } from '../loaders/rfd-priority.mjs'
-import { createSortable, isDev, loadBoard, saveBoard } from './board.mjs'
+import { createSortable, isDev, loadBoard, postBoard, saveBoard } from './board.mjs'
 
 const props = defineProps({
     entries: { type: Array, required: true },
@@ -98,12 +98,70 @@ function buildRows(p) {
 
 const items = ref([])
 
-// Which RFDs are being implemented. Read-only here: the flag is derived from
-// ticket state (a ticket carrying `Implements: NNN` in the In Progress column),
-// so the board reports it and never sets it.
-const inDev = computed(
-    () => new Set(props.entries.filter(e => e.inDevelopment).map(e => e.num))
+// Which RFDs are being implemented: their tracking ticket sits in the In
+// Progress column. Seeded from ticket state, refreshed on mount, and updated in
+// place as the checkbox writes, because the data loader caches for the dev
+// server's lifetime and `entries` never carries a write back.
+const inDev = ref(
+    new Set(props.entries.filter(e => e.inDevelopment).map(e => e.num))
 )
+
+// Statuses whose RFDs can be marked in development. `just rfd-track` refuses
+// anything earlier, where implementation has not begun (see RFD 001).
+const TRACKABLE_STATUSES = new Set(['Accepted', 'Implemented'])
+
+// Whether to offer the checkbox. An RFD already marked keeps it whatever its
+// status, so a mark left behind by an RFD moving back to Discussion can still
+// be turned off.
+function canToggleDev(rfd) {
+    return TRACKABLE_STATUSES.has(rfd.status) || inDev.value.has(rfd.num)
+}
+
+// RFDs with a checkbox write in flight. The first mark on an RFD files its
+// tracking ticket, which reads the RFD's implementation plan through a provider
+// and takes seconds.
+const devPending = ref(new Set())
+
+// Mark an RFD as in development, or stop it, by moving its tracking ticket.
+//
+// Local state moves only once the endpoint has written the ticket, so a failed
+// write leaves the board showing what the tickets hold. The checkbox is a DOM
+// input that has already flipped by then, and Vue does not re-render an
+// unchanged value, so it is put back by hand.
+async function toggleDev(rfd, event) {
+    if (devPending.value.has(rfd.num)) return
+
+    const active = !inDev.value.has(rfd.num)
+    devPending.value = new Set(devPending.value).add(rfd.num)
+    setNotice(
+        active
+            ? `RFD ${rfd.num}: starting its tracking ticket…`
+            : `RFD ${rfd.num}: moving its tracking ticket back to Todo…`,
+        'warn',
+    )
+
+    const { ok, output } = await postBoard('/__rfd-development', {
+        num: rfd.num,
+        active,
+    })
+
+    const pending = new Set(devPending.value)
+    pending.delete(rfd.num)
+    devPending.value = pending
+
+    if (!ok) {
+        if (event?.target) event.target.checked = !active
+        setNotice(output, 'err', 8000)
+        return
+    }
+
+    const marked = new Set(inDev.value)
+    if (active) marked.add(rfd.num)
+    else marked.delete(rfd.num)
+    inDev.value = marked
+    setNotice(output || (active ? 'In development' : 'Back in Todo'), 'ok', 4000)
+}
+
 // Initial board state from the build-time data. On the dev server the same
 // function rebuilds it from a fresh fetch on mount.
 applyPriority(props.priority)
@@ -458,9 +516,19 @@ async function loadFreshPriority() {
     if (fresh) applyPriority(fresh)
 }
 
+// Re-read which RFDs are in development. Writing a ticket file reloads the
+// page, and the cached loader data shows the state the page was built with.
+async function loadFreshInDev() {
+    const fresh = await loadBoard('/__rfd-development')
+    if (Array.isArray(fresh?.inDevelopment)) {
+        inDev.value = new Set(fresh.inDevelopment)
+    }
+}
+
 onMounted(() => {
     if (!isDev) return
     loadFreshPriority()
+    loadFreshInDev()
     import('sortablejs').then(({ default: Sortable }) => {
         if (!listRef.value) return
         sortable = Sortable.create(listRef.value, {
@@ -497,7 +565,7 @@ onBeforeUnmount(() => {
 <div class="rfd-board">
     <div v-if="isDev" class="rfd-board-status">
         <span v-if="notice" :class="'rfd-board-' + notice.kind">{{ notice.text }}</span>
-        <span v-else class="rfd-board-hint">Drag a row to reorder; hover the gap between rows to add a milestone. Changes save automatically.</span>
+        <span v-else class="rfd-board-hint">Drag a row to reorder; hover the gap between rows to add a milestone; tick <code>dev</code> to start an RFD. Changes save automatically.</span>
     </div>
     <p v-else class="rfd-board-note">
         The active backlog in priority order. Top of the list is worked on first.
@@ -580,6 +648,20 @@ onBeforeUnmount(() => {
                     </div>
                     <div v-if="rfd.summary" class="rfd-board-summary">{{ rfd.summary }}</div>
                 </div>
+                <label
+                    v-if="isDev && canToggleDev(rfd)"
+                    class="rfd-board-devtoggle"
+                    :class="{ 'is-pending': devPending.has(rfd.num) }"
+                    title="Mark as in development: files the RFD's tracking ticket if it has none, and moves it to In Progress"
+                >
+                    <input
+                        type="checkbox"
+                        :checked="inDev.has(rfd.num)"
+                        :disabled="devPending.has(rfd.num)"
+                        @change="toggleDev(rfd, $event)"
+                    />
+                    dev
+                </label>
                 <span v-if="isDev" class="rfd-board-jump">
                     <button class="rfd-board-jump-btn" title="Move to top of section" @click="moveTo(rfd, 'top')">▲</button>
                     <button class="rfd-board-jump-btn" title="Move to bottom of section" @click="moveTo(rfd, 'bottom')">▼</button>
@@ -818,5 +900,9 @@ onBeforeUnmount(() => {
     color: var(--vp-c-text-3);
     cursor: pointer;
     white-space: nowrap;
+}
+.rfd-board-devtoggle.is-pending {
+    cursor: progress;
+    opacity: 0.5;
 }
 </style>

--- a/docs/.vitepress/theme/board.mjs
+++ b/docs/.vitepress/theme/board.mjs
@@ -43,18 +43,39 @@ export async function loadBoard(endpoint) {
     return null
 }
 
-/// Persist board state, returning an error message or `null` on success.
-export async function saveBoard(endpoint, body) {
+/// POST to a dev-server endpoint, returning whether it succeeded and what it
+/// said.
+///
+/// `output` carries the endpoint's message on success as well as on failure.
+/// It is empty when an endpoint answers a bare `{ ok: true }`, and holds the
+/// response body when a request is rejected.
+export async function postBoard(endpoint, body) {
+    let res
+    let text
     try {
-        const res = await fetch(endpoint, {
+        res = await fetch(endpoint, {
             method: 'POST',
             headers: { 'content-type': 'application/json' },
             body: JSON.stringify(body),
         })
-        if (!res.ok) return await res.text()
+        text = (await res.text()).trim()
     } catch (err) {
-        return String(err.message || err)
+        return { ok: false, output: String(err.message || err) }
     }
 
-    return null
+    // Success is JSON; a rejected request answers in plain text.
+    let output = text
+    try {
+        const parsed = JSON.parse(text)
+        output = typeof parsed?.output === 'string' ? parsed.output.trim() : ''
+    } catch { /* keep the plain-text body */ }
+
+    return { ok: res.ok, output: output || (res.ok ? '' : res.statusText) }
+}
+
+/// Persist board state, returning an error message or `null` on success.
+export async function saveBoard(endpoint, body) {
+    const { ok, output } = await postBoard(endpoint, body)
+
+    return ok ? null : output
 }

--- a/docs/architecture/ubiquitous-language.md
+++ b/docs/architecture/ubiquitous-language.md
@@ -349,6 +349,17 @@ Tool calls are events within a Turn.
 The tool itself can be a built-in, a local command, an MCP-provided tool, or a
 plugin.
 
+### Tracking Ticket
+
+The single ticket that stands for an RFD's implementation as a whole, carrying
+its implementation plan as the description.
+It is the ticket whose `Implements` field names the RFD and whose labels include
+`type=tracking`; an RFD has at most one.
+Whether that ticket is In Progress is what "this RFD is in development" means.
+
+**Not the same as** a phase ticket, which names the same RFD in `Implements` but
+carries no `type=tracking` label and covers one slice of the work.
+
 ### Turn
 
 A group of conversation events delimited by a `TurnStart` marker: one user chat

--- a/docs/rfd/001-jp-rfd-process.md
+++ b/docs/rfd/001-jp-rfd-process.md
@@ -339,16 +339,16 @@ All categories use the same metadata:
 
 Implementation progress is tracked in [tickets], not in the metadata header.
 When `just rfd-promote` advances an RFD from Discussion to Accepted, it offers
-to turn each phase of the Implementation Plan into a ticket carrying
-`Implements: NNN`.
-The phases are read out of the document by `jp`, so the tickets match the plan
-rather than a fixed template, and whoever accepts the prompt reviews them before
-they land.
+to file the RFD's tracking ticket: one ticket carrying `Implements: NNN` and the
+label `type=tracking`, with the Implementation Plan as its description.
+The plan is read out of the document by `jp`, so the ticket matches the RFD
+rather than a fixed template, and whoever accepts the prompt reviews it before
+it lands.
 
 Accepting an RFD records an agreed direction, not a commitment to start
-building, which is why the tickets are offered rather than created.
-Decline the prompt and file them later with `just ticket-create` when the work
-actually starts.
+building, which is why the ticket is offered rather than created.
+Decline the prompt and file it later with `just rfd-track NNN`, which is also
+what marking the RFD in development on the [priority board] runs.
 
 A handful of older RFDs still carry a `Tracking Issue` field pointing at a
 GitHub issue.
@@ -450,8 +450,8 @@ filled in automatically by `rfd-promote`.
    The promotion is gated on the RFD's `Requires` *and* `Extends` fields: every
    entry in either field must be at status `Accepted`, `Implemented`, or
    `Superseded`.
-2. Accept the prompt to file a ticket per implementation phase, or decline it
-   and file them when the work starts.
+2. Accept the prompt to file the RFD's tracking ticket, or decline it and file
+   it when the work starts.
 3. Merge the pull request.
 
 ### After Acceptance
@@ -483,7 +483,12 @@ Run `just --list --group rfd` to see them.
 | `just rfd-draft CATEGORY TITLE` | Create a new draft under `drafts/`.      |
 | `just rfd-promote NNN`          | Advance status. Draft → Discussion       |
 |                                 | assigns number; Discussion → Accepted    |
-|                                 | offers phase tickets.                    |
+|                                 | offers the tracking ticket.              |
+| `just rfd-track NNN`            | File or refresh the RFD's tracking       |
+|                                 | ticket, printing its id.                 |
+| `just rfd-start NNN`            | Mark the RFD in development: its         |
+|                                 | tracking ticket moves to In Progress.    |
+| `just rfd-stop NNN`             | Move that ticket back to Todo.           |
 | `just rfd-extend NNN MMM`       | Record that RFD MMM extends RFD NNN,     |
 |                                 | updating both. Accepts draft IDs (DNN)   |
 |                                 | on either side.                          |
@@ -607,4 +612,5 @@ The steps are:
 [`000-design-template.md`]: 000-design-template.md
 [`000-guide-template.md`]: 000-guide-template.md
 [`000-process-template.md`]: 000-process-template.md
+[priority board]: priority.md
 [tickets]: 100-in-repo-ticket-tracking.md

--- a/docs/rfd/100-in-repo-ticket-tracking.md
+++ b/docs/rfd/100-in-repo-ticket-tracking.md
@@ -297,17 +297,26 @@ Tickets and RFDs are separate document kinds with separate numbering and
 separate lifecycles.
 They meet in three places.
 
-### RFD phases become tickets, optionally
+### An accepted RFD gets a tracking ticket, optionally
 
-When an RFD is accepted, `rfd-promote` offers to turn each phase of its
-Implementation Plan into a ticket carrying `Implements: 045`.
+When an RFD is accepted, `rfd-promote` offers to file its tracking ticket: one
+ticket carrying `Implements: 045` and the label `type=tracking`, with the phases
+of the Implementation Plan as its description.
 A prompt, not an automatic step — the same shape as the existing tracking-issue
 prompt — because acceptance records an agreed direction, not a commitment to
 start building.
-Whoever accepts the prompt reviews the resulting tickets before they land.
+Whoever accepts the prompt reviews the ticket before it lands.
 
-This replaces the GitHub tracking issue from [RFD 041] §2, and one ticket now
-serves as both the tracking item and the prioritized work item.
+The same operation runs when the RFD board's box is checked, so an RFD that was
+accepted without a ticket gets one at the moment work starts.
+It is idempotent: an existing tracking ticket is reused, never duplicated.
+
+A phase that needs its own card is filed separately and carries `Implements:
+045` without the label.
+The fan-out is a decision made when the work is picked up, not at acceptance,
+where the phases are still a plan.
+
+This replaces the GitHub tracking issue from [RFD 041] §2.
 
 ### Tickets promote to RFDs
 
@@ -316,15 +325,32 @@ seeds an RFD draft from the ticket, and the ticket closes as `Done` with
 `Promoted to` pointing at the draft.
 The work item is finished; the work moved.
 
-### The RFD board keeps ordering; it loses `inDevelopment`
+### The RFD board keeps ordering; `inDevelopment` moves to the ticket
 
 The `inDevelopment` flag leaves `docs/rfd/priority.json`.
 "Someone is currently writing code for this" is a property of a work item, not
 of a design document — it was on the RFD board only because tickets did not
 exist.
-It becomes **derived**: an RFD is in development when any ticket carrying
-`Implements: NNN` sits in the In Progress column.
-Derived, not synced, so there is nothing to keep in step.
+
+Each RFD gets at most one **tracking ticket**: a ticket carrying `Implements:
+NNN` and the label `type=tracking`, holding the implementation plan as its
+description.
+It plays the role a tracking issue plays elsewhere; a phase that needs its own
+card gets a separate ticket, which carries `Implements: NNN` without the label.
+
+The flag becomes **derived** from that one ticket: an RFD is in development when
+its tracking ticket sits in the In Progress column.
+Phase tickets never light the flag.
+
+The RFD board is a control surface over that ticket, not a second store, the
+same way dragging a card between columns is.
+Checking an RFD's box creates the tracking ticket if it doesn't exist and sets
+it to In Progress; unchecking sets it back to Todo.
+No status history is written to the ticket — the file's git history already
+dates every change.
+The box is offered from Accepted onward, which is where implementation begins: a
+draft or an RFD still under discussion is something to prioritise finishing, not
+to start building.
 
 RFD priority ordering stays.
 The two boards rank different things:
@@ -410,9 +436,10 @@ How the tooling gets there is not fixed.
 2. **Assistant tools.** `ticket_*` tools through `.jp/mcp/tools/`.
    The point of the exercise.
 3. **Website and board.** A `/ticket/` index and the kanban board.
-   Retire `inDevelopment` and derive it from ticket state.
+   Retire the `inDevelopment` field and derive it from the tracking ticket,
+   which the RFD board's checkbox moves.
 4. **GitHub import.** One-way, issues and comments.
-5. **RFD seams.** The phase-ticket prompt and ticket-to-RFD promotion, which
+5. **RFD seams.** The tracking-ticket prompt and ticket-to-RFD promotion, which
    needs an idempotent retry story.
    Amend [RFD 001] and [RFD 041], including 041's stale claim that tracking
    issues are created at Discussion, and add a TIP to 041 once this RFD holds a

--- a/docs/rfd/priority.md
+++ b/docs/rfd/priority.md
@@ -8,7 +8,11 @@ next: false
 
 The active RFD backlog in priority order — highest first, including **draft**
 RFDs you want to prioritise finishing.
-RFDs marked **in development** have a [ticket] in progress against them.
+Checking an RFD's box marks it **in development**: its tracking [ticket] is
+created if it doesn't exist yet and moved to In Progress; unchecking moves that
+ticket back to Todo.
+The box appears from **Accepted** onward, since that is where implementation
+begins.
 Every RFD above a **milestone** line targets that release.
 Implemented, superseded, and abandoned RFDs are not shown here; see the [full
 RFD index] for those.

--- a/docs/ticket/.labels.json
+++ b/docs/ticket/.labels.json
@@ -39,7 +39,8 @@
       "follow-up",
       "pre-rfd",
       "question",
-      "task"
+      "task",
+      "tracking"
     ]
   },
   "package": {

--- a/docs/ticket/0gm2pey-tool-access-grants.md
+++ b/docs/ticket/0gm2pey-tool-access-grants.md
@@ -1,0 +1,48 @@
+# Tool Access Grants
+
+- **Status**: Todo
+- **Kind**: Feature
+- **Authors**: Jean Mertz <git@jeanmertz.com>
+- **Date**: 2026-09-10
+- **Implements**: 076
+- **Label**: type=tracking
+
+Tracking ticket for [RFD 076].
+
+## Implementation plan
+
+- **Add access policy types and evaluation to jp_tool**: Introduces
+  `AccessPolicy`, `FsRule`, `NetRule`, `EnvRule`, and `FsAccessError`, plus the
+  path-canonicalization helper and `Context::check_*` methods.
+  Implements structured net matching with host normalization and explicit-`*`
+  env prefix matching, with unit tests for workspace escape, symlinks, host
+  normalization, port defaulting, and env ties.
+  No dependency; can merge independently.
+- **Add config types in jp_config**: Adds `AccessConfig`, `FsRuleConfig`,
+  `NetRuleConfig`, `EnvRuleConfig` with `MergeableVec` wrappers and standard
+  partial/delta/`ToPartial` impls, plus an `access` field on `ToolConfig` and an
+  accessor on `ToolConfigWithDefaults`.
+  Implements the `AccessConfig` to `AccessPolicy` conversion, canonicalizing
+  rule paths and normalizing hosts, and adds post-merge validation rejecting
+  `access` on builtin or mcp tools.
+  Depends on Phase 1.
+- **Plumb access policy through jp_llm**: Includes the access policy in the JSON
+  context passed to tool commands in `execute_local()` and the `FormatArguments`
+  path.
+  Depends on Phase 2.
+- **Enforce access checks in fs_* tools**: Replaces ad-hoc path joining in the
+  `fs_*` tool family with `ctx.check_read()`, `check_create()`,
+  `check_update()`, `check_delete()`, and `check_execute()`, returning clear
+  denial errors that name the capability and list configured grants.
+  Keeps `unix_utils` out of scope for grant enforcement, only wiring its
+  existing argument scanner to the shared canonicalization helper.
+  Depends on Phase 3.
+- **Support wildcard-scope grants and fix --mount**: Adds `access` to
+  `ToolsDefaultsConfig` and resolves it under the replace rule in
+  `ToolConfigWithDefaults::access()`, skipping builtin and MCP tools, and
+  narrows post-merge validation to tool-declared access.
+  Updates `--mount` so injected rules preserve a tool's prior reach across both
+  scope and resource-type edges instead of silently widening or revoking access.
+  Depends on Phase 2; independent of Phases 3 and 4.
+
+[RFD 076]: ../rfd/076-tool-access-grants.md

--- a/justfile
+++ b/justfile
@@ -1763,9 +1763,9 @@ _rfd-link SOURCE TARGET FORWARD INVERSE:
 # Advance an RFD's status: Draft -> Discussion -> Accepted -> Implemented.
 #
 # For drafts (DNN-prefixed files), assigns the next available permanent number
-# and renames the file. When promoting to Accepted, offers to turn each phase of
-# the Implementation Plan into a ticket carrying `Implements: NNN` (prompting on
-# TTY, defaulting to yes in non-interactive runs).
+# and renames the file. When promoting to Accepted, offers to file the RFD's
+# tracking ticket (prompting on TTY, defaulting to yes in non-interactive runs);
+# see `rfd-track`.
 #
 # Renaming a draft rewrites references to its old id across every RFD and every
 # ticket under `docs/ticket/`. Ticket link targets move from
@@ -2069,19 +2069,19 @@ rfd-promote NNN: _install-jp _install-comfort _install-ticket
             echo "Updated ${updated} cross-reference(s) in RFDs and tickets."
         fi
 
-    # --- Discussion -> Accepted: offer to seed phase tickets ---
+    # --- Discussion -> Accepted: offer to file the tracking ticket ---
     elif [ "$current" = "Discussion" ]; then
         sed "s/^- \*\*Status\*\*: Discussion/- **Status**: Accepted/" "$file" > "${file}.tmp"
         mv "${file}.tmp" "$file"
         echo "${file}: Discussion -> Accepted"
 
         # Acceptance records an agreed direction, not a commitment to start
-        # building, so the tickets are offered rather than created. Whoever
-        # accepts reviews them before they land. Non-interactive runs default to
-        # creating them.
+        # building, so the ticket is offered rather than created. Whoever
+        # accepts reviews it before it lands. Non-interactive runs default to
+        # creating it.
         create_tickets=true
         if [ -r /dev/tty ] && [ -w /dev/tty ]; then
-            printf "Create phase tickets for %s? [Y/n] " "$(basename "$file")" > /dev/tty
+            printf "File the tracking ticket for %s? [Y/n] " "$(basename "$file")" > /dev/tty
             if IFS= read -r answer < /dev/tty; then
                 case "$answer" in
                     n|N|no|No|NO) create_tickets=false ;;
@@ -2090,38 +2090,16 @@ rfd-promote NNN: _install-jp _install-comfort _install-ticket
         fi
 
         if [ "$create_tickets" = true ]; then
-            # The phases differ per RFD, so they're read out of the document
-            # rather than templated. Structured output keeps the result parseable.
-            SCHEMA='{"type":"object","properties":{"phases":{"type":"array","description":"One entry per phase of the Implementation Plan, in order","items":{"type":"object","properties":{"title":{"type":"string","description":"Imperative title, at most 60 characters"},"summary":{"type":"string","description":"What the phase delivers, one to three sentences of markdown"}},"required":["title","summary"]}}},"required":["phases"]}'
-            PROMPT="Read the attached RFD and list the phases of its Implementation Plan, in order. Give each a short imperative title and a summary of what it delivers. Return an empty array if the RFD has no Implementation Plan."
-
-            result=$(
-                jp query --new --local --tmp=5m --format=json --no-reasoning --no-tools \
-                    --schema "$SCHEMA" \
-                    --attachment "$file" \
-                    "$PROMPT" \
-                | jq -s '.[-1]' 2>/dev/null
-            ) || true
-
-            count=$(echo "$result" | jq '.phases | length' 2>/dev/null || echo 0)
-            count=${count:-0}
-
-            if [ "$count" -eq 0 ]; then
-                echo "No implementation phases found; no tickets created." >&2
+            # The status is already written, so a ticket that cannot be filed
+            # must not take the promotion down with it. `rfd-track` is
+            # idempotent, so the suggested retry is safe.
+            if ticket=$(just rfd-track "$rfd_id"); then
+                echo "Review ${ticket} before committing it; 'just ticket-list' shows the board."
             else
-                i=0
-                while [ "$i" -lt "$count" ]; do
-                    title=$(echo "$result" | jq -r ".phases[$i].title")
-                    summary=$(echo "$result" | jq -r ".phases[$i].summary")
-                    jp ticket add feature "$title" \
-                        --implements "$rfd_id" \
-                        --body "$summary"
-                    i=$((i + 1))
-                done
-                echo "Review the tickets before committing them; 'just ticket-list' shows the board."
+                echo "Could not file the tracking ticket; run 'just rfd-track ${rfd_id}' to retry." >&2
             fi
         else
-            echo "Skipped phase tickets. File them later with 'just ticket-add'." >&2
+            echo "Skipped the tracking ticket. File it later with 'just rfd-track ${rfd_id}'." >&2
         fi
 
     # --- Accepted -> Implemented ---
@@ -2223,6 +2201,196 @@ rfd-promote NNN: _install-jp _install-comfort _install-ticket
     # consolidate reference-style link definitions at the bottom, matching the
     # markdown formatting CI enforces (`fmt-markdown-ci`).
     comfort --language markdown --format-markdown --reference-links "$final_file"
+
+# File or refresh an RFD's tracking ticket, printing its id on stdout.
+#
+# The tracking ticket stands for the RFD's implementation as a whole: one ticket
+# carrying `Implements: NNN` and the label `type=tracking`, holding the
+# Implementation Plan as its description. A phase that needs its own card is
+# filed separately and carries `Implements: NNN` without the label.
+#
+# Idempotent: an existing tracking ticket is reused, never duplicated. Reading
+# the plan needs a provider, so a run without one files the ticket with a
+# `<!-- rfd-plan: pending -->` marker in place of the plan, and the next run
+# fills it in.
+#
+# Only Accepted and Implemented RFDs carry a tracking ticket; anything earlier
+# is refused.
+[group('rfd')]
+rfd-track NNN: _install-jp _install-ticket
+    #!/usr/bin/env sh
+    set -eu
+
+    out=$(just _rfd-resolve "{{NNN}}") || exit 1
+    rfd_id="${out%% *}"
+    file="${out#* }"
+
+    just _rfd-trackable "$file" || exit 1
+
+    id=$(just _rfd-tracking "$rfd_id")
+
+    if [ -z "$id" ]; then
+        title=$(sed -n 's/^# RFD [0-9A-Z]*: //p' "$file" | head -1)
+        if [ -z "$title" ]; then
+            echo "No heading found in ${file}; cannot title the ticket." >&2
+            exit 1
+        fi
+        # Read into a variable rather than inline: a command substitution in an
+        # argument list keeps its exit status to itself, so an interrupted plan
+        # read would file a ticket with an empty description.
+        plan=$(just _rfd-plan "$rfd_id" "$file")
+        jp ticket add feature "$title" \
+            --implements "$rfd_id" \
+            --label type=tracking \
+            --body "$plan" >&2
+        id=$(just _rfd-tracking "$rfd_id")
+        if [ -z "$id" ]; then
+            echo "Filed a tracking ticket for RFD ${rfd_id} but cannot find it back." >&2
+            exit 1
+        fi
+    else
+        # Only a ticket still carrying the marker is rewritten: the description
+        # is editable by hand, and a later run must not overwrite that.
+        detail=$(jp ticket show "$id" --json)
+        body=$(printf '%s' "$detail" | jq -r '.description')
+        case "$body" in
+            *'<!-- rfd-plan: pending -->'*)
+                plan=$(just _rfd-plan "$rfd_id" "$file")
+                case "$plan" in
+                    *'<!-- rfd-plan: pending -->'*) ;;
+                    *) jp ticket edit "$id" --body "$plan" >&2 ;;
+                esac
+                ;;
+        esac
+    fi
+
+    echo "$id"
+
+# Mark an RFD as in development.
+#
+# Files the RFD's tracking ticket if it has none, then moves that ticket to In
+# Progress — which is what the priority board reports as "in development". This
+# is what the board's checkbox runs, so the first mark on an RFD takes as long
+# as reading its plan (see `rfd-track`).
+[group('rfd')]
+rfd-start NNN:
+    #!/usr/bin/env sh
+    set -eu
+
+    id=$(just rfd-track "{{NNN}}") || exit 1
+    jp ticket edit "$id" --status "In Progress"
+
+# Mark an RFD as no longer in development.
+#
+# Moves the RFD's tracking ticket back to Todo. Phase tickets are left where
+# they are, and an RFD without a tracking ticket is already not in development,
+# so nothing is filed.
+[group('rfd')]
+rfd-stop NNN: _install-jp _install-ticket
+    #!/usr/bin/env sh
+    set -eu
+
+    # Allowed at any status, unlike marking: a mark left behind by an RFD moving
+    # back to Discussion must still be clearable, and stopping files nothing.
+    id=$(just _rfd-tracking "{{NNN}}") || exit 1
+    if [ -z "$id" ]; then
+        echo "RFD {{NNN}} has no tracking ticket; nothing to stop."
+        exit 0
+    fi
+    jp ticket edit "$id" --status Todo
+
+# Internal: refuse an RFD that is not far enough along to be built.
+#
+# Implementation begins at Accepted (see RFD 001), so a tracking ticket does
+# too. Drafts and Discussion RFDs pass `_rfd-resolve`, and get a meaningful
+# "is 'Draft'" error here rather than a filed ticket.
+[private]
+_rfd-trackable FILE:
+    #!/usr/bin/env sh
+    set -eu
+
+    file="{{FILE}}"
+    status=$(sed -n 's/^- \*\*Status\*\*: \([A-Za-z]*\).*/\1/p' "$file" | head -1)
+    case "$status" in
+        Accepted|Implemented) ;;
+        *)
+            echo "Cannot track: $(basename "$file") is '${status}'." >&2
+            echo "Only Accepted or Implemented RFDs carry a tracking ticket." >&2
+            exit 1 ;;
+    esac
+
+# Internal: print an RFD's tracking ticket id, or nothing when it has none.
+#
+# The tracking ticket is the one carrying both `Implements: NNN` and the label
+# `type=tracking`. Phase tickets name the same RFD without the label, so they
+# are never returned here.
+[private]
+_rfd-tracking NNN:
+    #!/usr/bin/env sh
+    set -eu
+
+    out=$(just _rfd-resolve "{{NNN}}") || exit 1
+    rfd_id="${out%% *}"
+
+    # Read into a variable first: in a pipeline, `jq` succeeding on empty input
+    # hides a failure from `jp` and reports the RFD as having no tracking
+    # ticket, which is how a second one gets filed.
+    tickets=$(jp ticket list --json --label type=tracking)
+
+    # The flag has already filtered by label; the selector repeats it so the
+    # whole rule reads in one place.
+    printf '%s' "$tickets" \
+        | jq -r --arg rfd "$rfd_id" '
+            first(
+                .[]
+                | select((.labels.type // []) | index("tracking"))
+                | select(((.implements // "") | sub("^RFD +"; "")) == $rfd)
+                | .id
+            ) // empty'
+
+# Internal: render the description for an RFD's tracking ticket.
+#
+# Prints a link to the RFD followed by its Implementation Plan as a list. The
+# plan is read out of the document by `jp query` rather than templated, because
+# the phases differ per RFD; structured output keeps the result parseable.
+#
+# When the query fails, or the RFD has no Implementation Plan, the marker
+# `<!-- rfd-plan: pending -->` stands in for the plan. `rfd-track` retries while
+# that marker is present.
+[private]
+_rfd-plan NNN FILE:
+    #!/usr/bin/env sh
+    set -eu
+
+    rfd_id="{{NNN}}"
+    file="{{FILE}}"
+
+    # Tickets live one directory over from the RFDs, so their links to an RFD
+    # are `../rfd/<file>`.
+    link="../${file#docs/}"
+    printf 'Tracking ticket for [RFD %s](%s).\n' "$rfd_id" "$link"
+
+    SCHEMA='{"type":"object","properties":{"phases":{"type":"array","description":"One entry per phase of the Implementation Plan, in order","items":{"type":"object","properties":{"title":{"type":"string","description":"Imperative title, at most 60 characters"},"summary":{"type":"string","description":"What the phase delivers, one to three sentences of markdown"}},"required":["title","summary"]}}},"required":["phases"]}'
+    PROMPT="Read the attached RFD and list the phases of its Implementation Plan, in order. Give each a short imperative title and a summary of what it delivers. Return an empty array if the RFD has no Implementation Plan."
+
+    result=$(
+        jp query --new --local --tmp=5m --format=json --no-reasoning --no-tools \
+            --schema "$SCHEMA" \
+            --attachment "$file" \
+            "$PROMPT" \
+        | jq -s '.[-1]' 2>/dev/null
+    ) || true
+
+    count=$(echo "$result" | jq '.phases | length' 2>/dev/null || echo 0)
+    count=${count:-0}
+
+    if [ "$count" -eq 0 ]; then
+        printf '\n<!-- rfd-plan: pending -->\n'
+        exit 0
+    fi
+
+    printf '\n## Implementation plan\n\n'
+    echo "$result" | jq -r '.phases[] | "- **" + .title + "**: " + .summary'
 
 # Renumber an RFD to a new id, updating every cross-reference.
 #
@@ -3324,6 +3492,29 @@ plugin-build-local: _install-jp (plugin-build "")
         chmod +x "${dir}/jp-${id}"
         echo "Installed jp-${id} → ${dir}/jp-${id}"
     done
+
+# Build one command plugin from this checkout and install it onto `$PATH`.
+#
+# PLUGIN is a directory name under `crates/plugins/command/`; run without a
+# valid one to list them. The binary lands in `~/.cargo/bin` as `jp-<plugin>`,
+# where `jp` finds it ahead of a released build.
+#
+# The `_install-*` recipes skip their rebuild whenever the binary is already on
+# `$PATH`, so a plugin built before a source change keeps running until this
+# replaces it.
+[group('plugins')]
+install-plugin PLUGIN:
+    #!/usr/bin/env sh
+    set -eu
+
+    dir="crates/plugins/command/{{PLUGIN}}"
+    if [ ! -f "${dir}/Cargo.toml" ]; then
+        echo "No command plugin named '{{PLUGIN}}'. Available:" >&2
+        ls crates/plugins/command | sed 's/^/  /' >&2
+        exit 1
+    fi
+
+    cargo install {{quiet_flag}} --locked --path "$dir" --debug
 
 # Run all formatting-related tasks
 fmt: (_rustup_component "rustfmt") _install-comfort


### PR DESCRIPTION
Accepted RFDs can have one tracking ticket that carries their implementation plan. The priority board can mark an RFD in development, filing that ticket when needed and moving it to In Progress.

Phase tickets remain separate work items and do not affect an RFD's development state. `just rfd-track`, `rfd-start`, and `rfd-stop` keep the board state derived from the tracking ticket.