### PR TITLE
fix(config): Align the schema with accepted inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,6 +2382,7 @@ dependencies = [
  "jp_id",
  "jp_label",
  "pretty_assertions",
+ "regex",
  "relative-path",
  "schematic",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4057,6 +4057,7 @@ dependencies = [
  "convert_case 0.11.0",
  "indexmap",
  "json-strip-comments",
+ "schematic",
  "schematic_macros",
  "schematic_types",
  "serde",

--- a/crates/contrib/schematic/Cargo.toml
+++ b/crates/contrib/schematic/Cargo.toml
@@ -31,6 +31,11 @@ toml = { workspace = true, optional = true, features = ["parse", "display"] }
 # yaml
 serde_yaml = { workspace = true, optional = true }
 
+# Self-dependency so the crate's own tests can exercise the schema derive,
+# which the default feature set leaves out.
+[dev-dependencies]
+schematic = { path = ".", features = ["schema"] }
+
 [features]
 default = ["config", "env"]
 config = ["dep:serde_path_to_error", "schematic_macros/config"]

--- a/crates/contrib/schematic/src/internal.rs
+++ b/crates/contrib/schematic/src/internal.rs
@@ -174,6 +174,12 @@ pub fn partialize_schema(schema: &mut Schema, force_partial: bool) {
                 partialize_schema(variant, false);
             }
         }
+        // A reference points at a type by name, and the struct arm above
+        // renames what it points at. Renaming both keeps the two in step, so a
+        // consumer resolving a recursive type still finds its target.
+        SchemaType::Reference(inner) if !inner.name.starts_with("Partial") => {
+            inner.name = format!("Partial{}", inner.name);
+        }
         _ => {}
     }
 }

--- a/crates/contrib/schematic/tests/enum_schema.rs
+++ b/crates/contrib/schematic/tests/enum_schema.rs
@@ -1,0 +1,123 @@
+//! The shape `#[derive(Schematic)]` gives an enum's variants.
+//!
+//! An enum mixing unit and payload variants is described as a union, one
+//! variant at a time, and each variant has to be described in the shape serde
+//! writes it in rather than in the shape the Rust declaration suggests.
+
+use schematic::{
+    Schema, SchemaBuilder, SchemaType, Schematic,
+    schema::{LiteralValue, UnionType},
+};
+
+/// An enum mixing a unit variant with a payload variant, on serde's default
+/// (externally tagged) representation.
+#[derive(Default, Schematic)]
+#[expect(dead_code, reason = "only the generated schema is under test")]
+enum Target {
+    /// The whole tree.
+    #[default]
+    Everything,
+
+    /// A named entry.
+    Named,
+
+    /// Reserved for internal use, and not part of the wire vocabulary.
+    #[schema(skip)]
+    Internal,
+
+    /// One path.
+    Path(String),
+}
+
+/// An enum whose variants are all units, which is described as an enumeration
+/// rather than a union.
+#[derive(Schematic)]
+#[expect(dead_code, reason = "only the generated schema is under test")]
+enum Mode {
+    Fast,
+    Slow,
+}
+
+fn union_of<T: Schematic>() -> UnionType {
+    let schema = SchemaBuilder::build_root::<T>();
+
+    match schema.ty {
+        SchemaType::Union(union) => *union,
+        other => panic!("expected a union, got {other:?}"),
+    }
+}
+
+fn literal_of(schema: &Schema) -> Option<&str> {
+    match &schema.ty {
+        SchemaType::Literal(literal) => match &literal.value {
+            LiteralValue::String(value) => Some(value),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// A unit variant is written as the bare variant name, so it is described as
+/// that string and not as a single-key table holding it.
+#[test]
+fn a_unit_variant_is_described_as_its_own_name() {
+    let union = union_of::<Target>();
+    let names: Vec<_> = union
+        .variants_types
+        .iter()
+        .filter_map(|variant| literal_of(variant))
+        .collect();
+
+    assert_eq!(names, ["everything", "named"]);
+}
+
+/// A payload variant keeps the wrapper serde writes around it.
+#[test]
+fn a_payload_variant_keeps_its_tag() {
+    let union = union_of::<Target>();
+    let tagged: Vec<_> = union
+        .variants_types
+        .iter()
+        .filter_map(|variant| match &variant.ty {
+            SchemaType::Struct(inner) => Some(inner.fields.keys().cloned().collect::<Vec<_>>()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(tagged, [["path".to_owned()]]);
+}
+
+/// A skipped variant is not input a user may write, so it is left out.
+#[test]
+fn a_skipped_variant_is_left_out() {
+    let union = union_of::<Target>();
+
+    assert_eq!(
+        union.variants_types.len(),
+        3,
+        "two unit variants and one payload variant, with the skipped one gone"
+    );
+}
+
+/// `#[default]` names the same thing to a schema reader as
+/// `#[setting(default)]` does, so the derive reads both.
+#[test]
+fn the_derive_default_attribute_sets_the_default_index() {
+    let union = union_of::<Target>();
+
+    assert_eq!(union.default_index, Some(0));
+}
+
+#[test]
+fn an_all_unit_enum_is_described_as_an_enumeration() {
+    let schema = SchemaBuilder::build_root::<Mode>();
+
+    let SchemaType::Enum(enum_type) = schema.ty else {
+        panic!("expected an enumeration");
+    };
+
+    assert_eq!(enum_type.values, [
+        LiteralValue::String("fast".to_owned()),
+        LiteralValue::String("slow".to_owned()),
+    ]);
+}

--- a/crates/contrib/schematic_macros/src/common/container.rs
+++ b/crates/contrib/schematic_macros/src/common/container.rs
@@ -196,7 +196,7 @@ fn generate_enum_schema(
 
         let index = variants_types.len();
 
-        if variant.is_default() {
+        if variant.is_schema_default() {
             default_index = Some(index);
         }
 

--- a/crates/contrib/schematic_macros/src/common/field.rs
+++ b/crates/contrib/schematic_macros/src/common/field.rs
@@ -365,7 +365,11 @@ impl Field<'_> {
         let deprecated = map_option_field_quote("deprecated", extract_deprecated(&self.attrs));
         let env_var = map_option_field_quote("env_var", self.get_env_var());
 
-        let value = self.value;
+        // A `partial_via` field is written in the shape of its via type, not of
+        // the type it resolves to: `attachments` holds a `Vec<AttachmentConfig>`
+        // once resolved, but a document writes either a bare list or the merge
+        // wrapper carrying one, and the via type is what describes both.
+        let value = self.partial_via_ty.as_ref().unwrap_or(self.value);
         let mut inner_schema = if self.is_nested() {
             quote! { schema.infer_as_nested::<#value>() }
         } else {

--- a/crates/contrib/schematic_macros/src/common/field.rs
+++ b/crates/contrib/schematic_macros/src/common/field.rs
@@ -7,7 +7,7 @@ use syn::{Attribute, Expr, ExprPath, Field as NativeField, Type};
 
 use crate::{
     common::{FieldValue, PartialAttr, TypeInfo, extract_inner_type, macros::ContainerSerdeArgs},
-    utils::{extract_common_attrs, format_case, parse_default},
+    utils::{DefaultAttr, extract_common_attrs, format_case, parse_default},
 };
 
 // #[serde()]
@@ -43,7 +43,7 @@ pub struct FieldArgs {
 
     // config
     #[darling(with = parse_default)]
-    pub default: Option<Expr>,
+    pub default: DefaultAttr,
     #[cfg(feature = "env")]
     pub env: Option<String>,
     pub merge: Option<ExprPath>,
@@ -180,7 +180,7 @@ impl Field<'_> {
 
     #[cfg(feature = "schema")]
     pub fn is_optional(&self) -> bool {
-        self.serde_args.default || self.args.default.is_some()
+        self.serde_args.default || self.args.default.is_declared()
     }
 
     pub fn is_required(&self) -> bool {
@@ -364,7 +364,7 @@ impl Field<'_> {
             quote! { schema.infer::<#value>() }
         };
 
-        if let Some(Expr::Lit(lit)) = &self.args.default {
+        if let Some(Expr::Lit(lit)) = self.args.default.expr() {
             let lit_value = match &lit.lit {
                 Lit::Str(v) => quote! { LiteralValue::String(#v.into()) },
                 Lit::Int(v) => {

--- a/crates/contrib/schematic_macros/src/common/field.rs
+++ b/crates/contrib/schematic_macros/src/common/field.rs
@@ -56,6 +56,14 @@ pub struct FieldArgs {
     pub is_empty: Option<ExprPath>,
     pub partial_via: Option<ExprPath>,
 
+    // Declare input shapes the field's type does not describe, for a field
+    // whose `deserialize_with` accepts more than the type alone would.
+    //
+    // Names a `fn(&SchemaBuilder) -> Vec<Schema>`. The inferred schema is
+    // unioned with the returned variants and marked as the expanded form, so
+    // the field's own keys stay addressable alongside the extra shapes.
+    pub schema_union_with: Option<ExprPath>,
+
     // serde
     pub alias: Option<String>,
     pub deserialize_with: Option<String>,
@@ -364,6 +372,10 @@ impl Field<'_> {
             quote! { schema.infer::<#value>() }
         };
 
+        if let Some(path) = &self.args.schema_union_with {
+            inner_schema = union_with_declared_shapes(path, &inner_schema);
+        }
+
         if let Some(Expr::Lit(lit)) = self.args.default.expr() {
             let lit_value = match &lit.lit {
                 Lit::Str(v) => quote! { LiteralValue::String(#v.into()) },
@@ -438,6 +450,27 @@ impl Field<'_> {
                     }
                 }
             }
+        }
+    }
+}
+
+/// Union a field's inferred schema with shapes its type cannot describe.
+///
+/// The inferred schema goes last and is marked as the expanded form: the
+/// declared variants are shorthand spellings of it, so a consumer resolving
+/// keys follows the inferred fields.
+#[cfg(feature = "schema")]
+fn union_with_declared_shapes(path: &ExprPath, inner_schema: &TokenStream) -> TokenStream {
+    quote! {
+        {
+            let described = #inner_schema;
+            let mut variants = #path(&schema);
+
+            let expanded = variants.len();
+            variants.push(described);
+
+            let mut nested = schema.nest();
+            nested.union(UnionType::new_any(variants).with_expanded_index(expanded))
         }
     }
 }

--- a/crates/contrib/schematic_macros/src/common/field.rs
+++ b/crates/contrib/schematic_macros/src/common/field.rs
@@ -16,6 +16,7 @@ use crate::{
 pub struct FieldSerdeArgs {
     pub alias: Option<String>,
     pub default: bool,
+    pub deserialize_with: Option<String>,
     pub flatten: bool,
     pub rename: Option<String>,
     pub skip: bool,
@@ -328,7 +329,18 @@ impl Field<'_> {
 
             if self.args.skip_deserializing || self.serde_args.skip_deserializing {
                 meta.push(quote! { skip_deserializing });
-            } else if let Some(deserialize_with) = &self.args.deserialize_with {
+            } else if let Some(deserialize_with) = self
+                .args
+                .deserialize_with
+                .as_ref()
+                .or(self.serde_args.deserialize_with.as_ref())
+            {
+                // A field reads the same way in both forms, so the partial
+                // takes the custom deserializer whichever namespace declared
+                // it. Reading only `#[setting]` here would leave a field that
+                // used `#[serde]` parsing one way as a resolved config and
+                // another as a layer.
+                //
                 // `deserialize_with` disables serde's implicit "missing
                 // `Option` field is `None`" handling, so the partial field
                 // needs an explicit default to stay optional.

--- a/crates/contrib/schematic_macros/src/common/variant.rs
+++ b/crates/contrib/schematic_macros/src/common/variant.rs
@@ -80,9 +80,30 @@ impl Variant<'_> {
         self.args.default
     }
 
+    /// Whether the schema reports this variant as the enum's default.
+    ///
+    /// Reads `#[setting(default)]` and the `#[default]` helper attribute of
+    /// `#[derive(Default)]`, which describe the same thing to a schema reader.
+    /// Only feeds the schema's `default_index`; the variant that
+    /// `PartialConfig::empty` and `default_values` construct is selected by
+    /// [`Self::is_default`] alone, so widening this cannot change what those
+    /// build.
+    #[cfg(feature = "schema")]
+    pub fn is_schema_default(&self) -> bool {
+        self.args.default
+            || self
+                .attrs
+                .iter()
+                .any(|attr| crate::utils::get_meta_path(&attr.meta).is_ident("default"))
+    }
+
+    /// Whether the variant is left out of the generated schema.
+    ///
+    /// A variant serde skips is not part of the wire vocabulary, so listing it
+    /// would advertise input the deserializer rejects.
     #[cfg(feature = "schema")]
     pub fn is_excluded(&self) -> bool {
-        self.args.exclude
+        self.args.exclude || self.args.skip || self.serde_args.skip
     }
 
     pub fn is_nested(&self) -> bool {
@@ -169,6 +190,7 @@ impl Variant<'_> {
             || self.args.untagged
             || self.serde_args.untagged;
         let partial = self.is_nested();
+        let is_unit = matches!(self.value.fields, Fields::Unit);
 
         let inner = self.build_variant_inner(partial, untagged, &name);
         let partial_statement = if partial {
@@ -177,7 +199,14 @@ impl Variant<'_> {
             quote! {}
         };
 
-        wrap_variant_tagged(tagged_format, &name, &inner, &partial_statement, partial)
+        wrap_variant_tagged(
+            tagged_format,
+            &name,
+            &inner,
+            &partial_statement,
+            partial,
+            is_unit,
+        )
     }
 
     #[cfg(feature = "schema")]
@@ -235,6 +264,13 @@ impl Variant<'_> {
     }
 }
 
+/// Wrap a variant's payload schema in the shape serde gives it on the wire.
+///
+/// A unit variant carries no payload, so every tagged form collapses: serde
+/// writes the bare variant name for the externally tagged form, and the tag
+/// alone for the internally and adjacently tagged ones.
+/// The `Unit` format keeps its wrapper regardless, because it carries the
+/// variant name that `EnumType::from_schemas` reads back out.
 #[cfg(feature = "schema")]
 fn wrap_variant_tagged(
     tagged_format: &TaggedFormat,
@@ -242,7 +278,16 @@ fn wrap_variant_tagged(
     inner: &TokenStream,
     partial_statement: &TokenStream,
     partial: bool,
+    is_unit: bool,
 ) -> TokenStream {
+    let tag_only = |tag: &String| {
+        quote! {
+            Schema::structure(StructType::new([
+                (#tag.into(), Schema::literal_value(LiteralValue::String(#name.into()))),
+            ]))
+        }
+    };
+
     match tagged_format {
         TaggedFormat::Unit => quote! {
             Schema {
@@ -252,6 +297,8 @@ fn wrap_variant_tagged(
             }
         },
         TaggedFormat::Untagged => inner.clone(),
+        TaggedFormat::External if is_unit => inner.clone(),
+        TaggedFormat::Internal(tag) | TaggedFormat::Adjacent(tag, _) if is_unit => tag_only(tag),
         TaggedFormat::External => {
             let outer = quote! {
                 Schema::structure(StructType::new([

--- a/crates/contrib/schematic_macros/src/config/field_value.rs
+++ b/crates/contrib/schematic_macros/src/config/field_value.rs
@@ -52,7 +52,7 @@ impl FieldValue {
             Self::Value { value, .. } => (quote!(#value), false),
         };
 
-        match args.default.as_ref() {
+        match args.default.expr() {
             Some(expr) => match expr {
                 Expr::Array(_) | Expr::Call(_) | Expr::Macro(_) | Expr::Tuple(_) => {
                     quote! { Some(#expr) }

--- a/crates/contrib/schematic_macros/src/config_enum/mod.rs
+++ b/crates/contrib/schematic_macros/src/config_enum/mod.rs
@@ -122,13 +122,13 @@ fn collect_variant_tokens(variants: Vec<Variant<'_>>) -> CollectedVariants {
     let mut default_index = None;
 
     for variant in variants {
-        // `FromStr` and `Display` cover every variant so a skipped one stays
-        // constructible in Rust; the schema and `variants()` describe what a
-        // user may write, which is what skipping it takes it out of.
+        // Every parser covers every variant, so a hidden one keeps working;
+        // the schema and `variants()` are what the type advertises, and that
+        // is what hiding takes it out of.
         display_stmts.push(variant.get_display_fmt());
         from_stmts.push(variant.get_from_str());
 
-        if !variant.skipped {
+        if !variant.hidden {
             #[cfg(feature = "schema")]
             if variant.default {
                 default_index = Some(schema_types.len());

--- a/crates/contrib/schematic_macros/src/config_enum/mod.rs
+++ b/crates/contrib/schematic_macros/src/config_enum/mod.rs
@@ -13,6 +13,16 @@ use crate::{common::ContainerSerdeArgs, config_enum::variant::Variant};
 pub struct ConfigEnumArgs {
     before_parse: Option<String>,
 
+    /// Emit `Serialize` and `Deserialize` that go through `Display` and
+    /// `FromStr`.
+    ///
+    /// The derive already owns the variant list, the accepted spellings and the
+    /// schema; routing serde through the same pair leaves one description of
+    /// what the type accepts instead of two that can disagree.
+    /// Types that derive serde's own impls, or hand-write them to accept shapes
+    /// other than a string, leave this off.
+    serde_as_string: bool,
+
     // serde
     rename: Option<String>,
     rename_all: Option<String>,
@@ -67,6 +77,10 @@ pub fn macro_impl(item: TokenStream) -> TokenStream {
         &from_fallback,
     )];
 
+    if args.serde_as_string {
+        impls.push(emit_serde_as_string_impls(enum_name));
+    }
+
     #[cfg(feature = "schema")]
     impls.push(emit_enum_schematic_impl(
         enum_name,
@@ -107,16 +121,21 @@ fn collect_variant_tokens(variants: Vec<Variant<'_>>) -> CollectedVariants {
     #[cfg(feature = "schema")]
     let mut default_index = None;
 
-    #[cfg_attr(not(feature = "schema"), allow(unused_variables))]
-    for (index, variant) in variants.into_iter().enumerate() {
-        unit_names.push(variant.get_unit_name());
+    for variant in variants {
+        // `FromStr` and `Display` cover every variant so a skipped one stays
+        // constructible in Rust; the schema and `variants()` describe what a
+        // user may write, which is what skipping it takes it out of.
         display_stmts.push(variant.get_display_fmt());
         from_stmts.push(variant.get_from_str());
-        schema_types.push(variant.get_schema_type());
 
-        #[cfg(feature = "schema")]
-        if variant.default {
-            default_index = Some(index);
+        if !variant.skipped {
+            #[cfg(feature = "schema")]
+            if variant.default {
+                default_index = Some(schema_types.len());
+            }
+
+            unit_names.push(variant.get_unit_name());
+            schema_types.push(variant.get_schema_type());
         }
 
         if variant.args.fallback {
@@ -228,6 +247,38 @@ fn emit_enum_impls(
                 write!(f, "{}", match self {
                     #(#display_stmts)*
                 })
+            }
+        }
+    }
+}
+
+/// Emit `Serialize` and `Deserialize` routed through `Display` and `FromStr`.
+///
+/// The wire form is a string, so a value written in any spelling `FromStr`
+/// accepts round-trips back out in the canonical one.
+fn emit_serde_as_string_impls(enum_name: &syn::Ident) -> proc_macro2::TokenStream {
+    quote! {
+        #[automatically_derived]
+        impl schematic::serde::Serialize for #enum_name {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: schematic::serde::Serializer,
+            {
+                serializer.serialize_str(&self.to_string())
+            }
+        }
+
+        #[automatically_derived]
+        impl<'de> schematic::serde::Deserialize<'de> for #enum_name {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: schematic::serde::Deserializer<'de>,
+            {
+                use schematic::serde::de::Error as _;
+
+                let value = <String as schematic::serde::Deserialize>::deserialize(deserializer)?;
+
+                <Self as std::str::FromStr>::from_str(&value).map_err(D::Error::custom)
             }
         }
     }

--- a/crates/contrib/schematic_macros/src/config_enum/variant.rs
+++ b/crates/contrib/schematic_macros/src/config_enum/variant.rs
@@ -17,12 +17,25 @@ use crate::{
 pub struct VariantArgs {
     pub fallback: bool,
     pub value: Option<String>,
+
+    /// Extra spellings `FromStr` accepts for this variant.
+    ///
+    /// Written as `#[variant(aliases("strip_responses", "sres"))]`.
+    /// The schema keeps the canonical value as the variant's literal and lists
+    /// these beside it, so a consumer can offer one and still accept all.
+    pub aliases: Vec<syn::LitStr>,
 }
 
 pub struct Variant<'l> {
     pub args: VariantArgs,
     #[cfg_attr(not(feature = "schema"), allow(dead_code))]
     pub default: bool,
+    /// Whether serde leaves this variant out of the wire vocabulary.
+    ///
+    /// `FromStr` and `Display` still handle it, so a variant reserved for
+    /// internal use stays constructible from a string in Rust while never being
+    /// offered to, or accepted from, a user.
+    pub skipped: bool,
     pub serde_args: FieldSerdeArgs,
     pub attrs: Vec<&'l Attribute>,
     pub name: &'l Ident,
@@ -71,12 +84,26 @@ impl Variant<'_> {
             default: attrs
                 .iter()
                 .any(|v| get_meta_path(&v.meta).is_ident("default")),
+            skipped: serde_args.skip,
             attrs,
             name: &variant.ident,
             value,
             args,
             serde_args,
         }
+    }
+
+    /// Every spelling other than the canonical one that `FromStr` accepts.
+    pub fn aliases(&self) -> Vec<String> {
+        let mut aliases: Vec<String> = self.args.aliases.iter().map(syn::LitStr::value).collect();
+
+        if let Some(alias) = &self.serde_args.alias
+            && !aliases.contains(alias)
+        {
+            aliases.push(alias.clone());
+        }
+
+        aliases
     }
 
     pub fn get_display_fmt(&self) -> TokenStream {
@@ -99,21 +126,19 @@ impl Variant<'_> {
         let value = &self.value;
 
         if self.args.fallback {
-            quote! {
+            return quote! {
                 fallback => Self::#name(
                     fallback.try_into().map_err(|_| {
                         schematic::ConfigError::EnumInvalidFallback(fallback.to_string())
                     })?
                 ),
-            }
-        } else if let Some(alias) = &self.serde_args.alias {
-            quote! {
-                #value | #alias => Self::#name,
-            }
-        } else {
-            quote! {
-                #value => Self::#name,
-            }
+            };
+        }
+
+        let spellings = self.aliases();
+
+        quote! {
+            #value #(| #spellings)* => Self::#name,
         }
     }
 
@@ -121,6 +146,7 @@ impl Variant<'_> {
         let name = self.name.to_string();
         let comment = map_option_field_quote("comment", extract_comment(&self.attrs));
         let deprecated = map_option_field_quote("deprecated", extract_deprecated(&self.attrs));
+        let aliases = crate::utils::map_vec_field_quote("aliases", &self.aliases());
 
         let inner_schema = if self.args.fallback {
             quote! {
@@ -134,7 +160,7 @@ impl Variant<'_> {
             }
         };
 
-        if comment.is_none() && deprecated.is_none() {
+        if comment.is_none() && deprecated.is_none() && aliases.is_none() {
             quote! {
                 (#name.into(), SchemaField::new(#inner_schema))
             }
@@ -144,6 +170,7 @@ impl Variant<'_> {
                     let mut field = SchemaField::new(#inner_schema);
                     #comment
                     #deprecated
+                    #aliases
                     field
                 })
             }

--- a/crates/contrib/schematic_macros/src/config_enum/variant.rs
+++ b/crates/contrib/schematic_macros/src/config_enum/variant.rs
@@ -24,18 +24,25 @@ pub struct VariantArgs {
     /// The schema keeps the canonical value as the variant's literal and lists
     /// these beside it, so a consumer can offer one and still accept all.
     pub aliases: Vec<syn::LitStr>,
+
+    /// Keep this variant out of the schema and out of `variants()`.
+    ///
+    /// For a variant that works but is not offered: a provider backed by a
+    /// mock, say, which a user should never be shown or steered towards but
+    /// which still has to parse when a test names it.
+    pub hidden: bool,
 }
 
 pub struct Variant<'l> {
     pub args: VariantArgs,
     #[cfg_attr(not(feature = "schema"), allow(dead_code))]
     pub default: bool,
-    /// Whether serde leaves this variant out of the wire vocabulary.
+    /// Whether the variant is left out of what the type advertises.
     ///
-    /// `FromStr` and `Display` still handle it, so a variant reserved for
-    /// internal use stays constructible from a string in Rust while never being
-    /// offered to, or accepted from, a user.
-    pub skipped: bool,
+    /// Every parser still handles it; only the schema and `variants()` leave it
+    /// out, so a variant reserved for internal use keeps working without being
+    /// offered to a user.
+    pub hidden: bool,
     pub serde_args: FieldSerdeArgs,
     pub attrs: Vec<&'l Attribute>,
     pub name: &'l Ident,
@@ -84,7 +91,7 @@ impl Variant<'_> {
             default: attrs
                 .iter()
                 .any(|v| get_meta_path(&v.meta).is_ident("default")),
-            skipped: serde_args.skip,
+            hidden: args.hidden || serde_args.skip,
             attrs,
             name: &variant.ident,
             value,

--- a/crates/contrib/schematic_macros/src/utils.rs
+++ b/crates/contrib/schematic_macros/src/utils.rs
@@ -178,7 +178,6 @@ pub fn map_bool_field_quote(name: &str, value: bool) -> Option<proc_macro2::Toke
     }
 }
 
-#[cfg(feature = "schema")]
 pub fn map_vec_field_quote(name: &str, value: &[String]) -> Option<proc_macro2::TokenStream> {
     if value.is_empty() {
         None

--- a/crates/contrib/schematic_macros/src/utils.rs
+++ b/crates/contrib/schematic_macros/src/utils.rs
@@ -39,17 +39,47 @@ pub fn preserve_str_literal(meta: &Meta) -> darling::Result<Expr> {
     }
 }
 
+/// What a field's `#[setting(default)]` attribute declared, if anything.
+///
+/// The bare and absent forms produce the same value at runtime — both fall
+/// back to the type's `Default` impl — but only the bare form is a statement
+/// by the author that the field has a default, which is what a schema reader
+/// needs to know to report the field as optional.
+#[derive(Debug, Default)]
+pub enum DefaultAttr {
+    /// No `default` argument on the field.
+    #[default]
+    Absent,
+
+    /// `#[setting(default)]`, falling back to the type's `Default` impl.
+    Bare,
+
+    /// `#[setting(default = <expr>)]`.
+    Expr(Expr),
+}
+
+impl DefaultAttr {
+    /// The declared default expression, for the two forms that have one.
+    pub const fn expr(&self) -> Option<&Expr> {
+        match self {
+            Self::Expr(expr) => Some(expr),
+            Self::Absent | Self::Bare => None,
+        }
+    }
+
+    /// Whether the field declares a default at all, in either form.
+    pub const fn is_declared(&self) -> bool {
+        !matches!(self, Self::Absent)
+    }
+}
+
 /// Parse a `default` argument, which accepts both `default` and `default =
 /// <expr>`.
-///
-/// The bare form states that the field falls back to its type's `Default` impl,
-/// which is what the generated code emits when no default expression is
-/// present, so it parses to `None`.
-pub fn parse_default(meta: &Meta) -> darling::Result<Option<Expr>> {
+pub fn parse_default(meta: &Meta) -> darling::Result<DefaultAttr> {
     match meta {
-        Meta::Path(_) => Ok(None),
+        Meta::Path(_) => Ok(DefaultAttr::Bare),
         Meta::List(_) => Err(darling::Error::unsupported_format("list").with_span(meta)),
-        Meta::NameValue(nv) => Ok(Some(nv.value.clone())),
+        Meta::NameValue(nv) => Ok(DefaultAttr::Expr(nv.value.clone())),
     }
 }
 

--- a/crates/jp_config/Cargo.toml
+++ b/crates/jp_config/Cargo.toml
@@ -54,6 +54,7 @@ camino-tempfile = { workspace = true }
 indoc = { workspace = true }
 insta = { workspace = true }
 pretty_assertions = { workspace = true, features = ["std"] }
+regex = { workspace = true, features = ["std", "perf", "unicode"] }
 serial_test = { workspace = true }
 test-log = { workspace = true }
 

--- a/crates/jp_config/src/conversation.rs
+++ b/crates/jp_config/src/conversation.rs
@@ -6,13 +6,9 @@ pub mod label;
 pub mod title;
 pub mod tool;
 
-use std::{fmt, str::FromStr};
-
-use schematic::{Config, ConfigError, HandlerError, Schematic};
-use serde::{Deserialize, Serialize};
+use schematic::{Config, ConfigEnum, ConfigError, HandlerError};
 
 use crate::{
-    BoxedError,
     assignment::{AssignKeyValue, AssignResult, KvAssignment, missing_key},
     assistant::{AssistantConfig, PartialAssistantConfig},
     conversation::{
@@ -316,35 +312,28 @@ impl ToPartial for InquiryConfig {
 /// This is read during conversation resolution, before the full config is
 /// built.
 /// It cannot be set per-conversation (circular dependency).
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Schematic)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq, Default, ConfigEnum)]
+#[config(serde_as_string)]
 pub enum DefaultConversationId {
     /// Show an interactive picker (TTY) or error (non-interactive).
     #[default]
     Ask,
 
     /// Most recently activated conversation (any session).
+    #[variant(aliases("last", "last_activated"))]
     LastActivated,
 
     /// Most recently created conversation.
+    #[variant(aliases("last_created"))]
     LastCreated,
 
     /// Session's previously active conversation.
+    #[variant(aliases("prev"))]
     Previous,
 
     /// A specific conversation ID.
-    #[serde(skip)]
+    #[variant(fallback)]
     Id(String),
-}
-
-impl<'de> Deserialize<'de> for DefaultConversationId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        s.parse().map_err(serde::de::Error::custom)
-    }
 }
 
 impl DefaultConversationId {
@@ -352,32 +341,6 @@ impl DefaultConversationId {
     #[must_use]
     pub const fn is_ask(&self) -> bool {
         matches!(self, Self::Ask)
-    }
-}
-
-impl FromStr for DefaultConversationId {
-    type Err = BoxedError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "ask" => Ok(Self::Ask),
-            "last" | "last-activated" | "last_activated" => Ok(Self::LastActivated),
-            "last-created" | "last_created" => Ok(Self::LastCreated),
-            "previous" | "prev" => Ok(Self::Previous),
-            _ => Ok(Self::Id(s.to_owned())),
-        }
-    }
-}
-
-impl fmt::Display for DefaultConversationId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Ask => write!(f, "ask"),
-            Self::LastActivated => write!(f, "last-activated"),
-            Self::LastCreated => write!(f, "last-created"),
-            Self::Previous => write!(f, "previous"),
-            Self::Id(id) => write!(f, "{id}"),
-        }
     }
 }
 

--- a/crates/jp_config/src/conversation/compaction.rs
+++ b/crates/jp_config/src/conversation/compaction.rs
@@ -576,66 +576,29 @@ pub enum ReasoningMode {
 
 /// How to handle tool calls during compaction.
 ///
-/// Parses from strings for config ergonomics, with short aliases:
-///
-/// - `"strip"` / `"s"` → strip both request arguments and response content
-/// - `"strip-responses"` / `"sres"` → strip response content only
-/// - `"strip-requests"` / `"sreq"` → strip request arguments only
-/// - `"omit"` / `"o"` → remove tool call pairs entirely
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// - `strip` / `s`: strip both request arguments and response content
+/// - `strip-responses` / `strip_responses` / `sres`: strip response content
+///   only
+/// - `strip-requests` / `strip_requests` / `sreq`: strip request arguments only
+/// - `omit` / `o`: remove tool call pairs entirely
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ConfigEnum)]
+#[config(serde_as_string)]
 pub enum ToolCallsMode {
     /// Strip both request arguments and response content.
+    #[variant(aliases("s"))]
     Strip,
+
     /// Strip response content only, keep request arguments.
+    #[variant(aliases("strip_responses", "sres"))]
     StripResponses,
+
     /// Strip request arguments only, keep response content.
+    #[variant(aliases("strip_requests", "sreq"))]
     StripRequests,
+
     /// Remove tool call pairs entirely.
+    #[variant(aliases("o"))]
     Omit,
-}
-
-impl FromStr for ToolCallsMode {
-    type Err = BoxedError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "strip" | "s" => Ok(Self::Strip),
-            "strip-responses" | "strip_responses" | "sres" => Ok(Self::StripResponses),
-            "strip-requests" | "strip_requests" | "sreq" => Ok(Self::StripRequests),
-            "omit" | "o" => Ok(Self::Omit),
-            _ => Err(format!("unknown tool_calls mode: `{s}`").into()),
-        }
-    }
-}
-
-impl fmt::Display for ToolCallsMode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Strip => write!(f, "strip"),
-            Self::StripResponses => write!(f, "strip-responses"),
-            Self::StripRequests => write!(f, "strip-requests"),
-            Self::Omit => write!(f, "omit"),
-        }
-    }
-}
-
-impl serde::Serialize for ToolCallsMode {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&self.to_string())
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for ToolCallsMode {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let s = String::deserialize(deserializer)?;
-        s.parse().map_err(serde::de::Error::custom)
-    }
-}
-
-impl schematic::Schematic for ToolCallsMode {
-    fn build_schema(mut schema: schematic::SchemaBuilder) -> schematic::Schema {
-        schema.string_default()
-    }
 }
 
 #[cfg(test)]

--- a/crates/jp_config/src/conversation/tool.rs
+++ b/crates/jp_config/src/conversation/tool.rs
@@ -961,7 +961,18 @@ impl schematic::Schematic for ToolSource {
     }
 
     fn build_schema(mut schema: schematic::SchemaBuilder) -> schematic::Schema {
-        schema.string(schematic::schema::StringType::default())
+        // The three prefixes are the whole vocabulary, and `mcp` is the only
+        // one that requires a name after it. A bare string would accept
+        // `source = "nonsense"`, which `FromStr` rejects.
+        let mut schema = schema.string(schematic::schema::StringType {
+            pattern: Some(r"^(builtin|local)(\..+)?$|^mcp\.[^.]+(\..+)?$".to_owned()),
+            ..schematic::schema::StringType::default()
+        });
+        schema.set_description(
+            "Where a tool comes from: `builtin[.<tool>]`, `local[.<tool>]`, or \
+             `mcp.<server>[.<tool>]`.",
+        );
+        schema
     }
 }
 

--- a/crates/jp_config/src/conversation/tool_tests.rs
+++ b/crates/jp_config/src/conversation/tool_tests.rs
@@ -1103,11 +1103,46 @@ fn test_tool_config_json_merge_unknown_key_errors() {
     assert!(err.contains("bogus"), "expected 'bogus' in error: {err}");
 }
 
+/// The pattern the schema publishes has to accept exactly what `FromStr`
+/// accepts.
+///
+/// The two are written separately, so only comparing them over real inputs
+/// keeps a change to the parser from leaving the schema behind.
 #[test]
-fn test_tool_source_schema() {
+fn the_tool_source_pattern_agrees_with_the_parser() {
     let schema = SchemaBuilder::build_root::<ToolSource>();
     assert_eq!(schema.name, Some("tool_source".to_owned()));
-    assert_eq!(schema.ty, SchemaType::String(Box::default()));
+
+    let SchemaType::String(string) = &schema.ty else {
+        panic!("expected a string, got {:?}", schema.ty);
+    };
+    let pattern = string.pattern.as_ref().expect("a pattern");
+    let pattern = regex::Regex::new(pattern).expect("a valid pattern");
+
+    for input in [
+        "builtin",
+        "builtin.read_file",
+        "builtin.a.b",
+        "local",
+        "local.fmt",
+        "mcp.bookworm",
+        "mcp.bookworm.crate_readme",
+        "mcp.bookworm.a.b",
+        // Rejected by the parser: no server named, an empty server, or a
+        // prefix that is not a source at all.
+        "mcp",
+        "mcp.",
+        "mcp..tool",
+        "nonsense",
+        "",
+        "builtinx",
+    ] {
+        assert_eq!(
+            pattern.is_match(input),
+            input.parse::<ToolSource>().is_ok(),
+            "the schema and the parser disagree about {input:?}"
+        );
+    }
 }
 
 #[test]

--- a/crates/jp_config/src/conversation_tests.rs
+++ b/crates/jp_config/src/conversation_tests.rs
@@ -71,6 +71,44 @@ fn deserialize_from_toml() {
     assert_eq!(w.id, DefaultConversationId::Id("jp-c17528832001".into()));
 }
 
+/// A conversation ID has to survive being written back out.
+///
+/// The value reaches disk through a config delta and the base config snapshot,
+/// so a variant that parses but cannot serialize fails the moment a user with
+/// `default_id = "jp-c…"` runs a query.
+#[test]
+fn every_variant_round_trips_through_serde() {
+    let cases = [
+        (DefaultConversationId::Ask, "\"ask\""),
+        (DefaultConversationId::LastActivated, "\"last-activated\""),
+        (DefaultConversationId::LastCreated, "\"last-created\""),
+        (DefaultConversationId::Previous, "\"previous\""),
+        (
+            DefaultConversationId::Id("jp-c17528832001".into()),
+            "\"jp-c17528832001\"",
+        ),
+    ];
+
+    for (value, encoded) in cases {
+        assert_eq!(serde_json::to_string(&value).unwrap(), encoded);
+        assert_eq!(
+            serde_json::from_str::<DefaultConversationId>(encoded).unwrap(),
+            value
+        );
+    }
+}
+
+/// An alias is an input spelling, not a second output spelling.
+#[test]
+fn an_alias_serializes_as_its_canonical_value() {
+    let parsed: DefaultConversationId = serde_json::from_str("\"last\"").unwrap();
+
+    assert_eq!(
+        serde_json::to_string(&parsed).unwrap(),
+        "\"last-activated\""
+    );
+}
+
 #[test]
 fn default_is_ask() {
     assert!(DefaultConversationId::default().is_ask());

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -47,6 +47,10 @@ pub mod model;
 mod partial;
 pub mod plugins;
 pub mod providers;
+#[cfg(test)]
+mod schema_probe;
+#[cfg(test)]
+mod schema_shape;
 pub mod style;
 pub mod template;
 pub mod types;

--- a/crates/jp_config/src/lib.rs
+++ b/crates/jp_config/src/lib.rs
@@ -455,9 +455,17 @@ impl AppConfig {
 
     /// Build the schema for the configuration.
     ///
-    /// Returns a [`Schema`] tree describing the structure of `AppConfig`, with
-    /// [`SchemaType::Struct`] at each nested level containing a `fields` map of
-    /// valid field names.
+    /// Returns a [`Schema`] tree describing what a config document may contain,
+    /// with [`SchemaType::Struct`] at each nested level containing a `fields`
+    /// map of valid field names.
+    /// A field written through a merge wrapper is described as accepting both
+    /// the bare value and the wrapper, matching what a file may write rather
+    /// than what the field resolves to.
+    ///
+    /// Every field is described as though it were set.
+    /// Use [`PartialAppConfig::schema`] for the form that also marks each one
+    /// optional and nullable, which is how a single layer arrives before
+    /// merging.
     #[must_use]
     pub fn schema() -> Schema {
         Self::build_schema(SchemaBuilder::default())
@@ -703,6 +711,16 @@ impl PartialAppConfig {
     #[must_use]
     pub fn empty() -> Self {
         <Self as PartialConfig>::empty()
+    }
+
+    /// Build the schema for one config layer.
+    ///
+    /// Describes the same field tree as [`AppConfig::schema`], with every field
+    /// marked optional and nullable: a single file, environment layer or stored
+    /// delta carries only what it states, and merging is what fills the rest.
+    #[must_use]
+    pub fn schema() -> Schema {
+        <Self as Schematic>::build_schema(SchemaBuilder::default())
     }
 
     /// Clear the field at `path`, leaving it unset.

--- a/crates/jp_config/src/lib_tests.rs
+++ b/crates/jp_config/src/lib_tests.rs
@@ -25,6 +25,16 @@ fn test_app_config_fields() {
     insta::assert_debug_snapshot!(AppConfig::fields());
 }
 
+/// The shape every config key accepts, as the schema describes it.
+///
+/// A schema consumer validating a user's config file sees exactly this, so a
+/// diff here is a change to what JP tells the outside world it accepts.
+/// Read it against the parser before accepting one.
+#[test]
+fn test_app_config_schema_shape() {
+    insta::assert_snapshot!(crate::schema_shape::render(&AppConfig::schema()));
+}
+
 /// A reference has to name a type the partial schema still contains.
 ///
 /// Partializing renames each named struct to `Partial*`.

--- a/crates/jp_config/src/lib_tests.rs
+++ b/crates/jp_config/src/lib_tests.rs
@@ -25,6 +25,62 @@ fn test_app_config_fields() {
     insta::assert_debug_snapshot!(AppConfig::fields());
 }
 
+/// A reference has to name a type the partial schema still contains.
+///
+/// Partializing renames each named struct to `Partial*`.
+/// A reference left pointing at the old name resolves to nothing, and a
+/// consumer walking a recursive type stops there without saying why.
+#[test]
+fn the_partial_schema_keeps_its_references_resolvable() {
+    /// Collect the name every reference in the tree points at.
+    fn references(schema: &Schema, seen: &mut Vec<String>, out: &mut Vec<String>) {
+        if let Some(name) = &schema.name {
+            if seen.contains(name) {
+                return;
+            }
+            seen.push(name.clone());
+        }
+
+        match &schema.ty {
+            SchemaType::Reference(inner) => out.push(inner.name.clone()),
+            SchemaType::Struct(inner) => {
+                for field in inner.fields.values() {
+                    references(&field.schema, seen, out);
+                }
+            }
+            SchemaType::Object(inner) => references(&inner.value_type, seen, out),
+            SchemaType::Array(inner) => references(&inner.items_type, seen, out),
+            SchemaType::Union(inner) => {
+                for variant in &inner.variants_types {
+                    references(variant, seen, out);
+                }
+            }
+            _ => {}
+        }
+
+        if schema.name.is_some() {
+            seen.pop();
+        }
+    }
+
+    let mut names = Vec::new();
+    references(&PartialAppConfig::schema(), &mut Vec::new(), &mut names);
+
+    // The tool parameter tree is the recursive type that reaches disk, so the
+    // walk has something to check rather than passing over an empty list.
+    assert!(!names.is_empty(), "the walk found no references at all");
+
+    let dangling: Vec<_> = names
+        .iter()
+        .filter(|name| !name.starts_with("Partial"))
+        .collect();
+
+    assert!(
+        dangling.is_empty(),
+        "references left pointing at pre-partial names: {dangling:#?}"
+    );
+}
+
 /// Setting one field in the inquiry request block leaves its siblings
 /// inheriting from the top-level assistant, rather than resolving to `0`.
 #[test]

--- a/crates/jp_config/src/model/id.rs
+++ b/crates/jp_config/src/model/id.rs
@@ -566,21 +566,8 @@ impl FromStr for PartialModelIdConfig {
 }
 
 /// The list of supported providers.
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Default,
-    Serialize,
-    Deserialize,
-    ConfigEnum,
-)]
-#[serde(rename_all = "lowercase")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, ConfigEnum)]
+#[config(rename_all = "lowercase", serde_as_string)]
 pub enum ProviderId {
     #[default]
     /// Anthropic provider.
@@ -615,7 +602,7 @@ pub enum ProviderId {
 
     /// Test provider for unit and integration tests.
     /// Not a real provider.
-    #[serde(skip)]
+    #[variant(hidden)]
     Test,
 }
 

--- a/crates/jp_config/src/model/id_tests.rs
+++ b/crates/jp_config/src/model/id_tests.rs
@@ -2,6 +2,30 @@ use serde_json::{Value, json};
 
 use super::*;
 
+/// `jp init` offers `variants()` to the user, so a provider serde refuses to
+/// read back must not appear there.
+#[test]
+fn the_variant_list_leaves_out_the_test_provider() {
+    use schematic::ConfigEnum as _;
+
+    let names: Vec<_> = ProviderId::variants()
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+
+    assert_eq!(names, [
+        "anthropic",
+        "cerebras",
+        "deepseek",
+        "google",
+        "llamacpp",
+        "ollama",
+        "openai",
+        "openrouter",
+        "xai"
+    ]);
+}
+
 #[test]
 fn test_model_id_config_deserialize() {
     struct TestCase {

--- a/crates/jp_config/src/model/id_tests.rs
+++ b/crates/jp_config/src/model/id_tests.rs
@@ -2,8 +2,28 @@ use serde_json::{Value, json};
 
 use super::*;
 
-/// `jp init` offers `variants()` to the user, so a provider serde refuses to
-/// read back must not appear there.
+/// A model id reads the same whether it is written as a string or a table.
+///
+/// The two spellings reach the provider through different code, so only
+/// checking them side by side keeps one from accepting a value the other
+/// rejects.
+#[test]
+fn both_spellings_of_a_model_id_accept_the_same_providers() {
+    for provider in ["anthropic", "openai", "test"] {
+        let string: PartialModelIdConfig =
+            serde_json::from_value(json!(format!("{provider}/some-model"))).unwrap();
+
+        let table: PartialModelIdConfig =
+            serde_json::from_value(json!({ "provider": provider, "name": "some-model" })).unwrap();
+
+        assert_eq!(string, table, "the two spellings disagree about {provider}");
+    }
+}
+
+/// A hidden provider is reachable but never offered.
+///
+/// `jp init` builds its picker from `variants()`, and `test` is backed by a
+/// mock rather than a real API, so it has no business being on that list.
 #[test]
 fn the_variant_list_leaves_out_the_test_provider() {
     use schematic::ConfigEnum as _;

--- a/crates/jp_config/src/schema_probe.rs
+++ b/crates/jp_config/src/schema_probe.rs
@@ -1,0 +1,497 @@
+//! Turn a [`Schema`] into concrete documents that exercise what it advertises.
+//!
+//! [`probes`] walks the schema and, for every string value it says is writable,
+//! produces the smallest JSON document placing that value where the schema puts
+//! it.
+//! Feeding those documents to the real deserializer is what keeps the two
+//! descriptions of the config's vocabulary from drifting apart: the schema is
+//! derived from Rust types, the parser from `Deserialize`, and nothing else
+//! forces them to agree.
+//!
+//! [`closed_vocabulary`] answers the other half.
+//! An enum with no catch-all variant accepts exactly the values it lists, so a
+//! value outside that list has to be rejected.
+//! Without that check a schema could advertise four spellings while the parser
+//! quietly took anything, and every positive probe would still pass.
+
+use schematic::{
+    Schema, SchemaType,
+    schema::{EnumType, LiteralValue, StructType},
+};
+use serde_json::{Value, json};
+
+/// One value the schema says is writable, and the document that writes it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Probe {
+    /// Where the value sits, for a failure message to point at.
+    pub path: String,
+
+    /// The value being written.
+    pub value: String,
+
+    /// The smallest document placing `value` at `path`.
+    pub document: Value,
+}
+
+/// A step from a parent schema into one of its children.
+#[derive(Debug, Clone)]
+enum Step {
+    /// A named field of a struct, alongside the sibling keys its type needs.
+    ///
+    /// A struct reached through an internal tag or an untagged union is only
+    /// recognised once enough of it is present: the tag that names the variant,
+    /// the path a strategy qualifies.
+    /// Carrying those siblings keeps a probe a test of the value at the end of
+    /// the path rather than of whether the document around it happened to be
+    /// well-formed.
+    Field {
+        name: String,
+        siblings: serde_json::Map<String, Value>,
+    },
+
+    /// The value side of a map, reached under an arbitrary key.
+    MapEntry,
+
+    /// An element of an array.
+    Item,
+}
+
+/// The map key every probe uses, so a failure names something searchable.
+const PROBE_KEY: &str = "probe";
+
+/// Every string value the schema advertises, as a document that writes it.
+///
+/// Aliases count: a spelling listed beside a variant is a spelling the schema
+/// promises the parser takes.
+#[must_use]
+pub fn probes(schema: &Schema) -> Vec<Probe> {
+    let mut out = Vec::new();
+    let mut path = Vec::new();
+    let mut enclosing = Vec::new();
+
+    collect(
+        schema,
+        &mut path,
+        &mut out,
+        &mut enclosing,
+        StringFill::Skip,
+    );
+    out
+}
+
+/// The exact set of values a schema accepts, when that set is finite.
+///
+/// `None` when any variant admits values beyond a fixed list — a string, a
+/// number, a struct, an unknown — because then no value can be assumed
+/// invalid.
+/// A `null` variant is ignored, since it makes the field optional rather than
+/// open-ended.
+#[must_use]
+pub fn closed_vocabulary(schema: &Schema) -> Option<Vec<String>> {
+    match &schema.ty {
+        SchemaType::Literal(literal) => match &literal.value {
+            LiteralValue::String(value) => Some(vec![value.clone()]),
+            _ => None,
+        },
+        SchemaType::Enum(enum_type) => closed_enum_vocabulary(enum_type),
+        SchemaType::Union(union) => {
+            let mut values = Vec::new();
+
+            for variant in &union.variants_types {
+                if variant.ty.is_null() {
+                    continue;
+                }
+
+                values.extend(closed_vocabulary(variant)?);
+            }
+
+            (!values.is_empty()).then_some(values)
+        }
+        _ => None,
+    }
+}
+
+/// The values a closed enum accepts, including every alias.
+fn closed_enum_vocabulary(enum_type: &EnumType) -> Option<Vec<String>> {
+    // A hand-written schema built from `EnumType::new` carries values without
+    // per-variant detail. Those values are the whole vocabulary, since there is
+    // no variant there that could widen it.
+    let Some(variants) = enum_type.variants.as_ref() else {
+        return enum_type
+            .values
+            .iter()
+            .map(|value| match value {
+                LiteralValue::String(value) => Some(value.clone()),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()
+            .filter(|values| !values.is_empty());
+    };
+
+    let mut values = Vec::new();
+
+    for field in variants.values() {
+        let SchemaType::Literal(literal) = &field.schema.ty else {
+            // A variant that is not a fixed value (a catch-all accepting any
+            // string) opens the whole enum up.
+            return None;
+        };
+
+        let LiteralValue::String(value) = &literal.value else {
+            return None;
+        };
+
+        values.push(value.clone());
+        values.extend(field.aliases.iter().cloned());
+    }
+
+    (!values.is_empty()).then_some(values)
+}
+
+/// Walk a schema, recording a probe for every string value it advertises.
+fn collect(
+    schema: &Schema,
+    path: &mut Vec<Step>,
+    out: &mut Vec<Probe>,
+    enclosing: &mut Vec<String>,
+    strings: StringFill,
+) {
+    if let Some(name) = &schema.name {
+        if enclosing.contains(name) {
+            return;
+        }
+        enclosing.push(name.clone());
+    }
+
+    collect_type(schema, path, out, enclosing, strings);
+
+    if schema.name.is_some() {
+        enclosing.pop();
+    }
+}
+
+/// Walk a schema's shape, recording probes and descending into its children.
+fn collect_type(
+    schema: &Schema,
+    path: &mut Vec<Step>,
+    out: &mut Vec<Probe>,
+    enclosing: &mut Vec<String>,
+    strings: StringFill,
+) {
+    match &schema.ty {
+        SchemaType::Literal(literal) => {
+            if let LiteralValue::String(value) = &literal.value {
+                out.push(probe(path, value));
+            }
+        }
+        SchemaType::Enum(enum_type) => collect_enum(enum_type, path, out),
+        SchemaType::Struct(struct_type) => {
+            for (name, field) in &struct_type.fields {
+                if field.hidden {
+                    continue;
+                }
+
+                // A flattened field's keys sit at the parent's level, which is
+                // where a document has to put them for the parser to find them.
+                if !field.flatten {
+                    path.push(Step::Field {
+                        name: name.clone(),
+                        siblings: siblings_of(struct_type, name, strings),
+                    });
+                }
+
+                // Below this struct's own keys the document is unambiguous
+                // again, so the conservative fill applies from here down.
+                collect(&field.schema, path, out, enclosing, StringFill::Skip);
+
+                if !field.flatten {
+                    path.pop();
+                }
+            }
+        }
+        SchemaType::Object(object) => {
+            path.push(Step::MapEntry);
+            collect(&object.value_type, path, out, enclosing, strings);
+            path.pop();
+        }
+        SchemaType::Array(array) => {
+            path.push(Step::Item);
+            collect(&array.items_type, path, out, enclosing, strings);
+            path.pop();
+        }
+        SchemaType::Union(union) => {
+            for variant in &union.variants_types {
+                collect(variant, path, out, enclosing, StringFill::Invent);
+            }
+        }
+        // A reference names a type already being walked further up, so its
+        // values are recorded there.
+        _ => {}
+    }
+}
+
+/// The smallest values for every field of `struct_type` other than `skip`.
+///
+/// Fields whose shape has no obvious smallest value are left out; a partial
+/// config treats an absent key as unset, so omitting one is safe where
+/// inventing a value would not be.
+fn siblings_of(
+    struct_type: &StructType,
+    skip: &str,
+    strings: StringFill,
+) -> serde_json::Map<String, Value> {
+    let mut siblings = serde_json::Map::new();
+
+    for (name, field) in &struct_type.fields {
+        if name == skip || field.hidden || field.flatten {
+            continue;
+        }
+
+        if let Some(value) = smallest_value(&field.schema, strings) {
+            siblings.insert(name.clone(), value);
+        }
+    }
+
+    siblings
+}
+
+/// Whether a field typed as a plain string may be filled with a made-up value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StringFill {
+    /// Leave it out.
+    /// A schema saying `string` may sit in front of a parser that accepts a
+    /// fixed set of words, and inventing one would fail for a reason that has
+    /// nothing to do with the value under test.
+    Skip,
+
+    /// Fill it.
+    /// Inside an untagged union no field stands alone: the document has to
+    /// carry enough of the variant to be recognised as that variant at all, so
+    /// leaving a string out fails just as surely.
+    Invent,
+}
+
+/// The least elaborate value a schema accepts, when one is obvious.
+///
+/// Structs collapse to `{}` rather than being filled out: every field of a
+/// partial is optional, so an empty table satisfies one without this having to
+/// know anything about what it contains.
+fn smallest_value(schema: &Schema, strings: StringFill) -> Option<Value> {
+    match &schema.ty {
+        SchemaType::Boolean(_) => Some(json!(true)),
+        SchemaType::Integer(_) => Some(json!(1)),
+        SchemaType::Float(_) => Some(json!(1.0)),
+        SchemaType::String(_) => (strings == StringFill::Invent).then(|| json!("x")),
+        SchemaType::Array(_) => Some(json!([])),
+        SchemaType::Object(_) => Some(json!({})),
+        SchemaType::Struct(struct_type) => {
+            // Every field of a partial is optional unless the schema says
+            // otherwise, so an empty table usually does. A struct that names
+            // required fields has to carry them.
+            let mut object = serde_json::Map::new();
+
+            for name in struct_type.required.iter().flatten() {
+                let field = struct_type.fields.get(name)?;
+                object.insert(
+                    name.clone(),
+                    smallest_value(&field.schema, StringFill::Invent)?,
+                );
+            }
+
+            Some(Value::Object(object))
+        }
+        SchemaType::Literal(literal) => match &literal.value {
+            LiteralValue::String(value) => Some(json!(value)),
+            LiteralValue::Bool(value) => Some(json!(value)),
+            LiteralValue::Int(value) => Some(json!(value)),
+            LiteralValue::UInt(value) => Some(json!(value)),
+            LiteralValue::F32(value) => Some(json!(value)),
+            LiteralValue::F64(value) => Some(json!(value)),
+        },
+        SchemaType::Enum(enum_type) => enum_type.values.first().and_then(|value| match value {
+            LiteralValue::String(value) => Some(json!(value)),
+            _ => None,
+        }),
+        SchemaType::Union(union) => union
+            .variants_types
+            .iter()
+            .filter(|variant| !variant.ty.is_null())
+            .find_map(|variant| smallest_value(variant, strings)),
+        SchemaType::Null
+        | SchemaType::Unknown
+        | SchemaType::Reference(_)
+        | SchemaType::Tuple(_) => None,
+    }
+}
+
+/// Record one probe per value an enum advertises, aliases included.
+fn collect_enum(enum_type: &EnumType, path: &[Step], out: &mut Vec<Probe>) {
+    let Some(variants) = &enum_type.variants else {
+        for value in &enum_type.values {
+            if let LiteralValue::String(value) = value {
+                out.push(probe(path, value));
+            }
+        }
+        return;
+    };
+
+    for field in variants.values() {
+        let SchemaType::Literal(literal) = &field.schema.ty else {
+            continue;
+        };
+
+        let LiteralValue::String(value) = &literal.value else {
+            continue;
+        };
+
+        out.push(probe(path, value));
+
+        for alias in &field.aliases {
+            out.push(probe(path, alias));
+        }
+    }
+}
+
+/// The value used to check that a closed vocabulary really is closed.
+pub const SENTINEL: &str = "__jp_schema_probe_invalid__";
+
+/// A document per closed vocabulary in the schema, writing a value outside it.
+///
+/// Each of these must be *rejected*.
+/// A path whose schema admits any string is left out, since nothing there can
+/// be assumed invalid.
+#[must_use]
+pub fn rejections(schema: &Schema) -> Vec<Probe> {
+    let mut out = Vec::new();
+    let mut path = Vec::new();
+    let mut enclosing = Vec::new();
+
+    collect_rejections(
+        schema,
+        &mut path,
+        &mut out,
+        &mut enclosing,
+        StringFill::Skip,
+    );
+    out
+}
+
+/// Walk a schema, stopping at each node whose accepted values are finite.
+fn collect_rejections(
+    schema: &Schema,
+    path: &mut Vec<Step>,
+    out: &mut Vec<Probe>,
+    enclosing: &mut Vec<String>,
+    strings: StringFill,
+) {
+    if closed_vocabulary(schema).is_some() {
+        out.push(probe(path, SENTINEL));
+        return;
+    }
+
+    if let Some(name) = &schema.name {
+        if enclosing.contains(name) {
+            return;
+        }
+        enclosing.push(name.clone());
+    }
+
+    match &schema.ty {
+        SchemaType::Struct(struct_type) => {
+            for (name, field) in &struct_type.fields {
+                if field.hidden {
+                    continue;
+                }
+
+                if !field.flatten {
+                    path.push(Step::Field {
+                        name: name.clone(),
+                        siblings: siblings_of(struct_type, name, strings),
+                    });
+                }
+
+                collect_rejections(&field.schema, path, out, enclosing, StringFill::Skip);
+
+                if !field.flatten {
+                    path.pop();
+                }
+            }
+        }
+        SchemaType::Object(object) => {
+            path.push(Step::MapEntry);
+            collect_rejections(&object.value_type, path, out, enclosing, strings);
+            path.pop();
+        }
+        SchemaType::Array(array) => {
+            path.push(Step::Item);
+            collect_rejections(&array.items_type, path, out, enclosing, strings);
+            path.pop();
+        }
+        SchemaType::Union(union) => {
+            // The union as a whole is open, or the check above would have
+            // stopped here. Descending into a scalar variant would claim a
+            // fixed vocabulary at a path where a sibling variant takes anything
+            // — a container variant has its own keys, which stay checkable.
+            for variant in &union.variants_types {
+                if matches!(variant.ty, SchemaType::Struct(_) | SchemaType::Object(_)) {
+                    collect_rejections(variant, path, out, enclosing, StringFill::Invent);
+                }
+            }
+        }
+        _ => {}
+    }
+
+    if schema.name.is_some() {
+        enclosing.pop();
+    }
+}
+
+/// Build the document that writes `value` at `path`.
+fn probe(path: &[Step], value: &str) -> Probe {
+    let mut document = json!(value);
+
+    for step in path.iter().rev() {
+        document = match step {
+            Step::Field { name, siblings } => {
+                let mut object = siblings.clone();
+                object.insert(name.clone(), document);
+                Value::Object(object)
+            }
+            Step::MapEntry => json!({ PROBE_KEY: document }),
+            Step::Item => json!([document]),
+        };
+    }
+
+    Probe {
+        path: render_path(path),
+        value: value.to_owned(),
+        document,
+    }
+}
+
+/// A readable location for a failure message.
+fn render_path(path: &[Step]) -> String {
+    let mut rendered = String::new();
+
+    for step in path {
+        match step {
+            Step::Field { name, .. } => {
+                if !rendered.is_empty() {
+                    rendered.push('.');
+                }
+                rendered.push_str(name);
+            }
+            Step::MapEntry => {
+                rendered.push('.');
+                rendered.push_str(PROBE_KEY);
+            }
+            Step::Item => rendered.push_str("[0]"),
+        }
+    }
+
+    rendered
+}
+
+#[cfg(test)]
+#[path = "schema_probe_tests.rs"]
+mod tests;

--- a/crates/jp_config/src/schema_probe_tests.rs
+++ b/crates/jp_config/src/schema_probe_tests.rs
@@ -1,0 +1,231 @@
+use std::collections::BTreeSet;
+
+use schematic::{
+    Schema,
+    schema::{
+        ArrayType, BooleanType, EnumType, LiteralValue, ObjectType, SchemaField, StringType,
+        StructType, UnionType,
+    },
+};
+use serde_json::json;
+
+use super::{Probe, SENTINEL, closed_vocabulary, probes, rejections};
+use crate::{AppConfig, PartialAppConfig};
+
+#[test]
+fn writes_an_enum_value_at_its_field() {
+    let schema = Schema::structure(StructType::new([(
+        "mode".to_owned(),
+        Schema::enumerable(EnumType::new([LiteralValue::String("fast".to_owned())])),
+    )]));
+
+    assert_eq!(probes(&schema), vec![Probe {
+        path: "mode".to_owned(),
+        value: "fast".to_owned(),
+        document: json!({ "mode": "fast" }),
+    }]);
+}
+
+#[test]
+fn writes_a_probe_for_every_alias() {
+    let mut variant = SchemaField::new(Schema::literal_value(LiteralValue::String(
+        "strip-responses".to_owned(),
+    )));
+    variant.aliases = vec!["sres".to_owned()];
+
+    let schema = Schema::enumerable(EnumType::from_fields(
+        [("StripResponses".to_owned(), variant)],
+        None,
+    ));
+
+    let values: Vec<_> = probes(&schema).into_iter().map(|p| p.value).collect();
+
+    assert_eq!(values, ["strip-responses", "sres"]);
+}
+
+#[test]
+fn wraps_a_value_in_the_collections_above_it() {
+    let item = Schema::structure(StructType::new([(
+        "kind".to_owned(),
+        Schema::literal_value(LiteralValue::String("file".to_owned())),
+    )]));
+
+    let schema = Schema::structure(StructType::new([(
+        "tools".to_owned(),
+        Schema::object(ObjectType::new(
+            Schema::string(StringType::default()),
+            Schema::array(ArrayType::new(item)),
+        )),
+    )]));
+
+    assert_eq!(probes(&schema), vec![Probe {
+        path: "tools.probe[0].kind".to_owned(),
+        value: "file".to_owned(),
+        document: json!({ "tools": { "probe": [{ "kind": "file" }] } }),
+    }]);
+}
+
+/// A flattened field's keys live at the parent's level on the wire, so a
+/// document that nested them under the field's own name would not parse.
+#[test]
+fn writes_a_flattened_fields_keys_at_the_parent_level() {
+    let mut flattened = SchemaField::new(Schema::object(ObjectType::new(
+        Schema::string(StringType::default()),
+        Schema::enumerable(EnumType::new([LiteralValue::String("on".to_owned())])),
+    )));
+    flattened.flatten = true;
+
+    let schema = Schema::structure(StructType::new([("overrides".to_owned(), flattened)]));
+
+    assert_eq!(probes(&schema)[0].document, json!({ "probe": "on" }));
+}
+
+#[test]
+fn a_closed_enum_reports_its_values_and_aliases() {
+    let mut variant = SchemaField::new(Schema::literal_value(LiteralValue::String(
+        "always".to_owned(),
+    )));
+    variant.aliases = vec!["yes".to_owned()];
+
+    let schema = Schema::enumerable(EnumType::from_fields(
+        [("Always".to_owned(), variant)],
+        None,
+    ));
+
+    assert_eq!(
+        closed_vocabulary(&schema),
+        Some(vec!["always".to_owned(), "yes".to_owned()])
+    );
+}
+
+/// A catch-all variant accepts values nobody listed, so the enum as a whole
+/// cannot be checked for rejection.
+#[test]
+fn an_enum_with_a_catch_all_is_not_closed() {
+    let schema = Schema::enumerable(EnumType::from_fields(
+        [
+            (
+                "Off".to_owned(),
+                SchemaField::new(Schema::literal_value(LiteralValue::String(
+                    "off".to_owned(),
+                ))),
+            ),
+            (
+                "Lines".to_owned(),
+                SchemaField::new(Schema::string(StringType::default())),
+            ),
+        ],
+        None,
+    ));
+
+    assert_eq!(closed_vocabulary(&schema), None);
+}
+
+#[test]
+fn a_nullable_closed_enum_stays_closed() {
+    let schema = Schema::union(UnionType::new_any([
+        Schema::enumerable(EnumType::new([LiteralValue::String("on".to_owned())])),
+        Schema::null(),
+    ]));
+
+    assert_eq!(closed_vocabulary(&schema), Some(vec!["on".to_owned()]));
+}
+
+#[test]
+fn a_union_with_a_free_form_variant_is_not_closed() {
+    let schema = Schema::union(UnionType::new_any([
+        Schema::enumerable(EnumType::new([LiteralValue::String("on".to_owned())])),
+        Schema::boolean(BooleanType::default()),
+    ]));
+
+    assert_eq!(closed_vocabulary(&schema), None);
+}
+
+#[test]
+fn a_rejection_probe_stops_at_the_closed_node() {
+    let schema = Schema::structure(StructType::new([(
+        "mode".to_owned(),
+        Schema::enumerable(EnumType::new([LiteralValue::String("fast".to_owned())])),
+    )]));
+
+    assert_eq!(rejections(&schema), vec![Probe {
+        path: "mode".to_owned(),
+        value: SENTINEL.to_owned(),
+        document: json!({ "mode": SENTINEL }),
+    }]);
+}
+
+/// Every string value the schema advertises has to deserialize.
+///
+/// The schema comes from the Rust types, the parser from `Deserialize`, and
+/// only this test connects them.
+/// A failure means one of the two describes a vocabulary the other does not
+/// have — fix whichever is wrong rather than dropping the path from the walk.
+#[test]
+fn the_parser_accepts_every_value_the_schema_advertises() {
+    let schema = AppConfig::schema();
+    let mut failures = Vec::new();
+
+    for probe in probes(&schema) {
+        if let Err(error) = serde_json::from_value::<PartialAppConfig>(probe.document.clone()) {
+            failures.push(format!(
+                "{} = {:?}\n    document: {}\n    error: {error}",
+                probe.path, probe.value, probe.document
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "the schema advertises {} value(s) the parser rejects:\n\n{}",
+        failures.len(),
+        failures.join("\n\n")
+    );
+}
+
+/// Every value the schema says is the whole vocabulary has to be the whole
+/// vocabulary.
+///
+/// Without this, a schema could list four spellings while the parser took
+/// anything at all, and every positive probe would still pass.
+#[test]
+fn the_parser_rejects_values_outside_a_closed_vocabulary() {
+    let schema = AppConfig::schema();
+    let mut failures = Vec::new();
+
+    for probe in rejections(&schema) {
+        if serde_json::from_value::<PartialAppConfig>(probe.document.clone()).is_ok() {
+            failures.push(format!("{}\n    document: {}", probe.path, probe.document));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "the schema claims a fixed set of values at {} path(s) where the parser takes \
+         anything:\n\n{}",
+        failures.len(),
+        failures.join("\n\n")
+    );
+}
+
+/// The walk has to actually reach the config, not quietly cover nothing.
+///
+/// A cycle guard or an early return that stops too soon would leave both
+/// conformance tests passing over an empty list.
+#[test]
+fn the_walk_reaches_the_config_it_describes() {
+    let schema = AppConfig::schema();
+    let paths: BTreeSet<_> = probes(&schema).into_iter().map(|p| p.path).collect();
+
+    for expected in [
+        "assistant.model.id.provider",
+        "conversation.default_id",
+        "conversation.tools.probe.run",
+        "style.reasoning.display",
+    ] {
+        assert!(
+            paths.contains(expected),
+            "{expected} is missing from the probe walk"
+        );
+    }
+}

--- a/crates/jp_config/src/schema_shape.rs
+++ b/crates/jp_config/src/schema_shape.rs
@@ -1,0 +1,215 @@
+//! A compact, line-oriented rendering of a [`Schema`] tree.
+//!
+//! [`render`] is the entry point.
+//! It turns a schema into an indented outline where each line is one field and
+//! the shape it accepts, so a change to what the config claims to accept shows
+//! up as a small diff in a snapshot instead of a few lines buried in several
+//! thousand of `Debug` output.
+//!
+//! Scalar shapes are rendered inline (`"a" | "b" | int`); structs, maps, arrays
+//! and unions open an indented block whose children are labelled by their
+//! position: a struct field by its name, a map value by `*`, an array item by
+//! `[]`, and a union variant by `|`.
+//! A trailing `?` on a label marks a field the schema reports as optional.
+//!
+//! A named type that encloses itself renders as `@Name` rather than being
+//! expanded again, matching how the schema builder represents the same cycle.
+
+use std::fmt::Write as _;
+
+use schematic::{
+    Schema, SchemaType,
+    schema::{EnumType, LiteralValue, StructType, UnionType},
+};
+
+/// Render a schema as an indented outline, one line per field.
+///
+/// The output ends with a newline and is stable across runs: struct fields come
+/// from a `BTreeMap` and every other collection keeps declaration order.
+#[must_use]
+pub fn render(schema: &Schema) -> String {
+    let mut out = String::new();
+    let mut enclosing = Vec::new();
+
+    if is_inline(schema) {
+        let _ = writeln!(out, "{}", inline(schema));
+    } else {
+        write_body(&mut out, schema, 0, &mut enclosing);
+    }
+
+    out
+}
+
+/// Whether a schema renders as a single inline token rather than a block.
+fn is_inline(schema: &Schema) -> bool {
+    match &schema.ty {
+        SchemaType::Struct(_) | SchemaType::Object(_) => false,
+        SchemaType::Array(array) => is_inline(&array.items_type),
+        SchemaType::Union(union) => union.variants_types.iter().all(|v| is_inline(v)),
+        _ => true,
+    }
+}
+
+/// Render a schema that fits on one line.
+fn inline(schema: &Schema) -> String {
+    match &schema.ty {
+        SchemaType::Null => "null".to_owned(),
+        SchemaType::Unknown => "unknown".to_owned(),
+        SchemaType::Boolean(_) => "bool".to_owned(),
+        SchemaType::Integer(_) => "int".to_owned(),
+        SchemaType::Float(_) => "float".to_owned(),
+        SchemaType::String(string) => string
+            .pattern
+            .as_ref()
+            .map_or_else(|| "string".to_owned(), |p| format!("string(/{p}/)")),
+        SchemaType::Literal(literal) => literal.value.to_string(),
+        SchemaType::Enum(enum_type) => inline_enum(enum_type),
+        SchemaType::Reference(reference) => format!("@{}", reference.name),
+        SchemaType::Array(array) => format!("[{}]", inline(&array.items_type)),
+        SchemaType::Tuple(tuple) => {
+            let items: Vec<_> = tuple.items_types.iter().map(|i| inline(i)).collect();
+            format!("({})", items.join(", "))
+        }
+        SchemaType::Union(union) => {
+            let variants: Vec<_> = union.variants_types.iter().map(|v| inline(v)).collect();
+            variants.join(" | ")
+        }
+        // `is_inline` sends both of these to `write_body` instead.
+        SchemaType::Struct(_) => "struct".to_owned(),
+        SchemaType::Object(_) => "map".to_owned(),
+    }
+}
+
+/// Render an enum's accepted values, with each variant's aliases beside it.
+///
+/// `variants` is the richer of the two representations an [`EnumType`] carries:
+/// it holds every variant, including one whose shape is not a literal (a
+/// catch-all accepting any string, say), which `values` alone cannot express.
+fn inline_enum(enum_type: &EnumType) -> String {
+    let Some(variants) = &enum_type.variants else {
+        let values: Vec<_> = enum_type
+            .values
+            .iter()
+            .map(LiteralValue::to_string)
+            .collect();
+        return values.join(" | ");
+    };
+
+    let rendered: Vec<_> = variants
+        .values()
+        .map(|field| {
+            let value = inline(&field.schema);
+            if field.aliases.is_empty() {
+                value
+            } else {
+                format!("{value} (aka {})", field.aliases.join(", "))
+            }
+        })
+        .collect();
+
+    rendered.join(" | ")
+}
+
+/// Write the children of a block schema, each at `depth`.
+fn write_body(out: &mut String, schema: &Schema, depth: usize, enclosing: &mut Vec<String>) {
+    match &schema.ty {
+        SchemaType::Struct(struct_type) => write_struct_body(out, struct_type, depth, enclosing),
+        SchemaType::Object(object) => {
+            write_labelled(out, "*", &object.value_type, depth, enclosing);
+        }
+        SchemaType::Array(array) => {
+            write_labelled(out, "[]", &array.items_type, depth, enclosing);
+        }
+        SchemaType::Union(union) => write_union_body(out, union, depth, enclosing),
+        _ => {
+            let _ = writeln!(out, "{}{}", "  ".repeat(depth), inline(schema));
+        }
+    }
+}
+
+/// Write a struct's fields, one label per field, sorted by field name.
+fn write_struct_body(
+    out: &mut String,
+    struct_type: &StructType,
+    depth: usize,
+    enclosing: &mut Vec<String>,
+) {
+    if struct_type.fields.is_empty() {
+        let _ = writeln!(out, "{}(no fields)", "  ".repeat(depth));
+        return;
+    }
+
+    for (name, field) in &struct_type.fields {
+        let mut label = name.clone();
+
+        if field.optional {
+            label.push('?');
+        }
+        if field.flatten {
+            label.push_str(" (flattened)");
+        }
+        if field.hidden {
+            label.push_str(" (hidden)");
+        }
+        if !field.aliases.is_empty() {
+            let _ = write!(label, " (aka {})", field.aliases.join(", "));
+        }
+
+        write_labelled(out, &label, &field.schema, depth, enclosing);
+    }
+}
+
+/// Write a union's variants, marking the one the others are shorthand for.
+fn write_union_body(
+    out: &mut String,
+    union: &UnionType,
+    depth: usize,
+    enclosing: &mut Vec<String>,
+) {
+    for (index, variant) in union.variants_types.iter().enumerate() {
+        let label = if Some(index) == union.expanded_index {
+            "| (expanded)"
+        } else {
+            "|"
+        };
+
+        write_labelled(out, label, variant, depth, enclosing);
+    }
+}
+
+/// Write `label: <shape>` on one line, or `label:` followed by an indented
+/// block.
+fn write_labelled(
+    out: &mut String,
+    label: &str,
+    schema: &Schema,
+    depth: usize,
+    enclosing: &mut Vec<String>,
+) {
+    let pad = "  ".repeat(depth);
+
+    if is_inline(schema) {
+        let _ = writeln!(out, "{pad}{label}: {}", inline(schema));
+        return;
+    }
+
+    if let Some(name) = &schema.name {
+        if enclosing.contains(name) {
+            let _ = writeln!(out, "{pad}{label}: @{name}");
+            return;
+        }
+
+        let _ = writeln!(out, "{pad}{label}: {name}");
+        enclosing.push(name.clone());
+        write_body(out, schema, depth + 1, enclosing);
+        enclosing.pop();
+        return;
+    }
+
+    let _ = writeln!(out, "{pad}{label}:");
+    write_body(out, schema, depth + 1, enclosing);
+}
+
+#[cfg(test)]
+#[path = "schema_shape_tests.rs"]
+mod tests;

--- a/crates/jp_config/src/schema_shape_tests.rs
+++ b/crates/jp_config/src/schema_shape_tests.rs
@@ -1,0 +1,157 @@
+use schematic::{
+    Schema,
+    schema::{
+        ArrayType, BooleanType, EnumType, LiteralValue, ObjectType, SchemaField, StringType,
+        StructType, UnionType,
+    },
+};
+
+use super::render;
+
+#[test]
+fn renders_a_scalar_on_one_line() {
+    let schema = Schema::boolean(BooleanType::default());
+
+    assert_eq!(render(&schema), "bool\n");
+}
+
+#[test]
+fn renders_struct_fields_one_per_line() {
+    let schema = Schema::structure(StructType::new([
+        ("name".to_owned(), Schema::string(StringType::default())),
+        (
+            "enabled".to_owned(),
+            Schema::boolean(BooleanType::default()),
+        ),
+    ]));
+
+    // Fields come from a `BTreeMap`, so they sort by name rather than by
+    // declaration order.
+    assert_eq!(render(&schema), "enabled: bool\nname: string\n");
+}
+
+#[test]
+fn marks_an_optional_field() {
+    let mut field = SchemaField::new(Schema::string(StringType::default()));
+    field.optional = true;
+
+    let schema = Schema::structure(StructType::new([("name".to_owned(), field)]));
+
+    assert_eq!(render(&schema), "name?: string\n");
+}
+
+#[test]
+fn renders_an_enum_with_its_accepted_values() {
+    let schema = Schema::enumerable(EnumType::new([
+        LiteralValue::String("off".to_owned()),
+        LiteralValue::String("full".to_owned()),
+    ]));
+
+    assert_eq!(render(&schema), "\"off\" | \"full\"\n");
+}
+
+#[test]
+fn renders_variant_aliases_beside_the_canonical_value() {
+    let mut variant = SchemaField::new(Schema::literal_value(LiteralValue::String(
+        "strip-responses".to_owned(),
+    )));
+    variant.aliases = vec!["strip_responses".to_owned(), "sres".to_owned()];
+
+    let schema = Schema::enumerable(EnumType::from_fields(
+        [("StripResponses".to_owned(), variant)],
+        None,
+    ));
+
+    assert_eq!(
+        render(&schema),
+        "\"strip-responses\" (aka strip_responses, sres)\n"
+    );
+}
+
+#[test]
+fn renders_a_string_pattern() {
+    let schema = Schema::string(StringType {
+        pattern: Some("^[a-z]+$".to_owned()),
+        ..StringType::default()
+    });
+
+    assert_eq!(render(&schema), "string(/^[a-z]+$/)\n");
+}
+
+#[test]
+fn renders_an_array_of_scalars_inline() {
+    let schema = Schema::array(ArrayType::new(Schema::string(StringType::default())));
+
+    assert_eq!(render(&schema), "[string]\n");
+}
+
+#[test]
+fn opens_a_block_for_an_array_of_structs() {
+    let item = Schema::structure(StructType::new([(
+        "uri".to_owned(),
+        Schema::string(StringType::default()),
+    )]));
+
+    let schema = Schema::structure(StructType::new([(
+        "attachments".to_owned(),
+        Schema::array(ArrayType::new(item)),
+    )]));
+
+    assert_eq!(render(&schema), "attachments:\n  []:\n    uri: string\n");
+}
+
+#[test]
+fn labels_a_map_value_with_a_star() {
+    let schema = Schema::object(ObjectType::new(
+        Schema::string(StringType::default()),
+        Schema::structure(StructType::new([(
+            "enabled".to_owned(),
+            Schema::boolean(BooleanType::default()),
+        )])),
+    ));
+
+    assert_eq!(render(&schema), "*:\n  enabled: bool\n");
+}
+
+#[test]
+fn renders_a_union_of_scalars_inline() {
+    let schema = Schema::union(UnionType::new_any([
+        Schema::boolean(BooleanType::default()),
+        Schema::null(),
+    ]));
+
+    assert_eq!(render(&schema), "bool | null\n");
+}
+
+#[test]
+fn marks_the_expanded_variant_of_a_union() {
+    let table = Schema::structure(StructType::new([(
+        "state".to_owned(),
+        Schema::boolean(BooleanType::default()),
+    )]));
+
+    let schema = Schema::union(
+        UnionType::new_any([Schema::boolean(BooleanType::default()), table]).with_expanded_index(1),
+    );
+
+    assert_eq!(render(&schema), "|: bool\n| (expanded):\n  state: bool\n");
+}
+
+/// A named type that encloses itself is emitted as a reference by the schema
+/// builder, and the renderer has to stop there or it would not terminate.
+#[test]
+fn collapses_a_type_that_encloses_itself() {
+    let mut inner = Schema::structure(StructType::new([(
+        "child".to_owned(),
+        Schema::structure(StructType::default()),
+    )]));
+    inner.name = Some("Node".to_owned());
+
+    // Stand in for what `SchemaBuilder::infer` produces on the second visit.
+    let mut outer = Schema::structure(StructType::new([("child".to_owned(), inner)]));
+    outer.name = Some("Node".to_owned());
+
+    let schema = Schema::structure(StructType::new([("root".to_owned(), outer)]));
+
+    assert_eq!(render(&schema), "root: Node\n  child: @Node\n");
+}

--- a/crates/jp_config/src/snapshots/jp_config__tests__app_config_schema_shape.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__app_config_schema_shape.snap
@@ -1,0 +1,784 @@
+---
+source: crates/jp_config/src/lib_tests.rs
+expression: "crate::schema_shape::render(&AppConfig::schema())"
+---
+assistant: AssistantConfig
+  instructions?: MergeableVec
+    |:
+      []: InstructionsConfig
+        description: string | null
+        examples:
+          []: ExampleConfig
+            |: string
+            |: ContrastConfig
+              bad: string
+              good: string
+              reason: string | null
+        items: [string]
+        position?: int
+        title: string | null
+    |: MergedVec
+      dedup?: "inherit" | "true" | "false" | bool | null
+      discard_when_merged?: bool
+      strategy?: "append" | "prepend" | "replace" | null
+      value?:
+        []: InstructionsConfig
+          description: string | null
+          examples:
+            []: ExampleConfig
+              |: string
+              |: ContrastConfig
+                bad: string
+                good: string
+                reason: string | null
+          items: [string]
+          position?: int
+          title: string | null
+  model: ModelConfig
+    id: ModelIdOrAliasConfig
+      |: ModelIdConfig
+        name: string
+        provider: "anthropic" | "cerebras" | "deepseek" | "google" | "llamacpp" | "ollama" | "openai" | "openrouter" | "xai"
+      |: string
+    parameters: ParametersConfig
+      max_tokens: int | null
+      other?:
+        *: unknown
+      reasoning:
+        |: ReasoningConfig
+          |: "off"
+          |: "auto"
+          |: CustomReasoningConfig
+            effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string
+            exclude?: bool
+        |: null
+      stop_words?: [string]
+      temperature: float | null
+      top_k: int | null
+      top_p: float | null
+  name: string | null
+  request: RequestConfig
+    base_backoff_ms?: int
+    cache?: bool | "off" | "short" | "long" | string
+    max_backoff_secs?: int
+    max_response_bytes?: int | "disabled" | "off" | bool
+    max_retries?: int
+    stream_idle_timeout_secs?: int
+  system_prompt?: MergeableString
+    |: string
+    |: MergedString
+      dedup: bool | "inherit" | "off" | "exact" | "block" | "contains" | null
+      discard_when_merged?: bool
+      separator?: "none" | "space" | "line" | "paragraph"
+      strategy?: "append" | "prepend" | "replace"
+      value?: string
+  system_prompt_sections?: MergeableVec
+    |:
+      []: SectionConfig
+        content: string
+        position?: int
+        tag: string | null
+        title: string | null
+    |: MergedVec
+      dedup?: "inherit" | "true" | "false" | bool | null
+      discard_when_merged?: bool
+      strategy?: "append" | "prepend" | "replace" | null
+      value?:
+        []: SectionConfig
+          content: string
+          position?: int
+          tag: string | null
+          title: string | null
+  tool_choice?: "auto" | "none" | "required" | string
+config_load_paths: [string]
+conversation: ConversationConfig
+  attachments?: MergeableVec
+    |:
+      []: AttachmentConfig
+        |: string
+        |: AttachmentObjectConfig
+          params:
+            *: unknown
+          path: string
+          type: string
+    |: MergedVec
+      dedup?: "inherit" | "true" | "false" | bool | null
+      discard_when_merged?: bool
+      strategy?: "append" | "prepend" | "replace" | null
+      value?:
+        []: AttachmentConfig
+          |: string
+          |: AttachmentObjectConfig
+            params:
+              *: unknown
+            path: string
+            type: string
+  compaction: CompactionConfig
+    rules?: MergeableVec
+      |:
+        []: CompactionRuleConfig
+          keep_first?: int | string
+          keep_last?: int | string
+          reasoning:
+            |:
+              |: "strip"
+              |:
+                over: int | string
+                policy: "strip"
+            |: null
+          summary:
+            |: SummaryConfig
+              context: string | null
+              instructions: string | null
+              model:
+                |: ModelConfig
+                  id: ModelIdOrAliasConfig
+                    |: ModelIdConfig
+                      name: string
+                      provider: "anthropic" | "cerebras" | "deepseek" | "google" | "llamacpp" | "ollama" | "openai" | "openrouter" | "xai"
+                    |: string
+                  parameters: ParametersConfig
+                    max_tokens: int | null
+                    other?:
+                      *: unknown
+                    reasoning:
+                      |: ReasoningConfig
+                        |: "off"
+                        |: "auto"
+                        |: CustomReasoningConfig
+                          effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string
+                          exclude?: bool
+                      |: null
+                    stop_words?: [string]
+                    temperature: float | null
+                    top_k: int | null
+                    top_p: float | null
+                |: null
+              text: string | null
+            |: null
+          tool_calls:
+            |:
+              |: "strip" (aka s) | "strip-responses" (aka strip_responses, sres) | "strip-requests" (aka strip_requests, sreq) | "omit" (aka o)
+              |:
+                over: int | string
+                policy: "strip" (aka s) | "strip-responses" (aka strip_responses, sres) | "strip-requests" (aka strip_requests, sreq) | "omit" (aka o)
+            |: null
+      |: MergedVec
+        dedup?: "inherit" | "true" | "false" | bool | null
+        discard_when_merged?: bool
+        strategy?: "append" | "prepend" | "replace" | null
+        value?:
+          []: CompactionRuleConfig
+            keep_first?: int | string
+            keep_last?: int | string
+            reasoning:
+              |:
+                |: "strip"
+                |:
+                  over: int | string
+                  policy: "strip"
+              |: null
+            summary:
+              |: SummaryConfig
+                context: string | null
+                instructions: string | null
+                model:
+                  |: ModelConfig
+                    id: ModelIdOrAliasConfig
+                      |: ModelIdConfig
+                        name: string
+                        provider: "anthropic" | "cerebras" | "deepseek" | "google" | "llamacpp" | "ollama" | "openai" | "openrouter" | "xai"
+                      |: string
+                    parameters: ParametersConfig
+                      max_tokens: int | null
+                      other?:
+                        *: unknown
+                      reasoning:
+                        |: ReasoningConfig
+                          |: "off"
+                          |: "auto"
+                          |: CustomReasoningConfig
+                            effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string
+                            exclude?: bool
+                        |: null
+                      stop_words?: [string]
+                      temperature: float | null
+                      top_k: int | null
+                      top_p: float | null
+                  |: null
+                text: string | null
+              |: null
+            tool_calls:
+              |:
+                |: "strip" (aka s) | "strip-responses" (aka strip_responses, sres) | "strip-requests" (aka strip_requests, sreq) | "omit" (aka o)
+                |:
+                  over: int | string
+                  policy: "strip" (aka s) | "strip-responses" (aka strip_responses, sres) | "strip-requests" (aka strip_requests, sreq) | "omit" (aka o)
+              |: null
+  default_id: "ask" | "last-activated" (aka last, last_activated) | "last-created" (aka last_created) | "previous" (aka prev) | string | null
+  inquiry: InquiryConfig
+    assistant: AssistantConfig
+      instructions?: MergeableVec
+        |:
+          []: InstructionsConfig
+            description: string | null
+            examples:
+              []: ExampleConfig
+                |: string
+                |: ContrastConfig
+                  bad: string
+                  good: string
+                  reason: string | null
+            items: [string]
+            position?: int
+            title: string | null
+        |: MergedVec
+          dedup?: "inherit" | "true" | "false" | bool | null
+          discard_when_merged?: bool
+          strategy?: "append" | "prepend" | "replace" | null
+          value?:
+            []: InstructionsConfig
+              description: string | null
+              examples:
+                []: ExampleConfig
+                  |: string
+                  |: ContrastConfig
+                    bad: string
+                    good: string
+                    reason: string | null
+              items: [string]
+              position?: int
+              title: string | null
+      model: ModelConfig
+        id: ModelIdOrAliasConfig
+          |: ModelIdConfig
+            name: string
+            provider: "anthropic" | "cerebras" | "deepseek" | "google" | "llamacpp" | "ollama" | "openai" | "openrouter" | "xai"
+          |: string
+        parameters: ParametersConfig
+          max_tokens: int | null
+          other?:
+            *: unknown
+          reasoning:
+            |: ReasoningConfig
+              |: "off"
+              |: "auto"
+              |: CustomReasoningConfig
+                effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string
+                exclude?: bool
+            |: null
+          stop_words?: [string]
+          temperature: float | null
+          top_k: int | null
+          top_p: float | null
+      name: string | null
+      request: RequestConfig
+        base_backoff_ms?: int
+        cache?: bool | "off" | "short" | "long" | string
+        max_backoff_secs?: int
+        max_response_bytes?: int | "disabled" | "off" | bool
+        max_retries?: int
+        stream_idle_timeout_secs?: int
+      system_prompt?: MergeableString
+        |: string
+        |: MergedString
+          dedup: bool | "inherit" | "off" | "exact" | "block" | "contains" | null
+          discard_when_merged?: bool
+          separator?: "none" | "space" | "line" | "paragraph"
+          strategy?: "append" | "prepend" | "replace"
+          value?: string
+      system_prompt_sections?: MergeableVec
+        |:
+          []: SectionConfig
+            content: string
+            position?: int
+            tag: string | null
+            title: string | null
+        |: MergedVec
+          dedup?: "inherit" | "true" | "false" | bool | null
+          discard_when_merged?: bool
+          strategy?: "append" | "prepend" | "replace" | null
+          value?:
+            []: SectionConfig
+              content: string
+              position?: int
+              tag: string | null
+              title: string | null
+      tool_choice?: "auto" | "none" | "required" | string
+  labels: MergeableMap
+    |:
+      *: LabelConfig
+        |: string
+        |: [string]
+        |: LabelObject
+          apply_on?: ApplyOn
+            fork?: bool
+            new?: bool
+          optional?: bool
+          run?: "ask" | "unattended" | "deny"
+          value?: LabelValue
+            |: string
+            |: [string]
+            |: LabelCommand
+              cmd: CommandConfigOrString
+                |: string
+                | (expanded): CommandConfig
+                  args?: [string]
+                  program: string
+                  shell?: bool
+    |: MergedMap
+      discard_when_merged?: bool
+      strategy?: "deep_merge" | "merge" | "keep" | "replace" | null
+      value?:
+        *: LabelConfig
+          |: string
+          |: [string]
+          |: LabelObject
+            apply_on?: ApplyOn
+              fork?: bool
+              new?: bool
+            optional?: bool
+            run?: "ask" | "unattended" | "deny"
+            value?: LabelValue
+              |: string
+              |: [string]
+              |: LabelCommand
+                cmd: CommandConfigOrString
+                  |: string
+                  | (expanded): CommandConfig
+                    args?: [string]
+                    program: string
+                    shell?: bool
+  start_local?: bool
+  title: TitleConfig
+    from_heading?: bool
+    generate: GenerateConfig
+      auto?: bool
+      model:
+        |: ModelConfig
+          id: ModelIdOrAliasConfig
+            |: ModelIdConfig
+              name: string
+              provider: "anthropic" | "cerebras" | "deepseek" | "google" | "llamacpp" | "ollama" | "openai" | "openrouter" | "xai"
+            |: string
+          parameters: ParametersConfig
+            max_tokens: int | null
+            other?:
+              *: unknown
+            reasoning:
+              |: ReasoningConfig
+                |: "off"
+                |: "auto"
+                |: CustomReasoningConfig
+                  effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string
+                  exclude?: bool
+              |: null
+            stop_words?: [string]
+            temperature: float | null
+            top_k: int | null
+            top_p: float | null
+        |: null
+  tools: ToolsConfig
+    *: ToolsDefaultsConfig
+      cancellation_response?: string
+      enable:
+        |:
+          |: bool
+          |: "on" | "off" | "always" | "explicit"
+          | (expanded): EnableConfig
+            allow_toggle: "any" | "never" | "if_named" | "if_named_or_group" | null
+            state: bool | null
+        |: null
+      format: "ask" | "unattended" | null
+      result?: "unattended" | "ask" | "edit" | "skip"
+      run: "ask" | "unattended" | "edit" | "skip"
+      style: DisplayStyleConfig
+        error: ErrorStyleConfig
+          inline_results: "off" | "full" | string | null
+          results_file_link: "full" | "osc8" | "off" | null
+        hidden?: bool
+        inline_results?: "off" | "full" | string
+        parameters?: ParametersStyle
+          |: "json"
+          |: "function_call"
+          |: "off"
+          |: CommandConfigOrString
+            |: string
+            | (expanded): CommandConfig
+              args?: [string]
+              program: string
+              shell?: bool
+        results_file_link?: "full" | "osc8" | "off"
+    tools (flattened):
+      *: ToolConfig
+        access:
+          |: AccessConfig
+            env: MergeableVec
+              |:
+                []: EnvRuleConfig
+                  name: string
+                  read: bool | null
+              |: MergedVec
+                dedup?: "inherit" | "true" | "false" | bool | null
+                discard_when_merged?: bool
+                strategy?: "append" | "prepend" | "replace" | null
+                value?:
+                  []: EnvRuleConfig
+                    name: string
+                    read: bool | null
+            fs: MergeableVec
+              |:
+                []: FsRuleConfig
+                  create: bool | null
+                  delete: bool | null
+                  execute: bool | null
+                  external: bool | null
+                  path: string
+                  read: bool | null
+                  update: bool | null
+                  write: bool | null
+              |: MergedVec
+                dedup?: "inherit" | "true" | "false" | bool | null
+                discard_when_merged?: bool
+                strategy?: "append" | "prepend" | "replace" | null
+                value?:
+                  []: FsRuleConfig
+                    create: bool | null
+                    delete: bool | null
+                    execute: bool | null
+                    external: bool | null
+                    path: string
+                    read: bool | null
+                    update: bool | null
+                    write: bool | null
+          |: null
+        cancellation_response: string | null
+        command:
+          |: CommandConfigOrString
+            |: string
+            | (expanded): CommandConfig
+              args?: [string]
+              program: string
+              shell?: bool
+          |: null
+        description: string | null
+        enable:
+          |:
+            |: bool
+            |: "on" | "off" | "always" | "explicit"
+            | (expanded): EnableConfig
+              allow_toggle: "any" | "never" | "if_named" | "if_named_or_group" | null
+              state: bool | null
+          |: null
+        examples: string | null
+        format: "ask" | "unattended" | null
+        options:
+          *: unknown
+        parameters:
+          *: ToolParameterConfig
+            default?: unknown | null
+            description?: string | null
+            enum?: [unknown] | null
+            examples?: string | null
+            items?: @ToolParameterConfig | null
+            properties?:
+              *: @ToolParameterConfig
+            required?: bool | null
+            summary?: string | null
+            type?: string | [string] | null
+        questions:
+          *: QuestionConfig
+            answer: unknown | null
+            target: QuestionTarget
+              |: "user" | "assistant"
+              |: PartialAssistantConfig
+                instructions?:
+                  |: PartialMergeableVec
+                    |:
+                      []: InstructionsConfig
+                        description: string | null
+                        examples:
+                          []: PartialExampleConfig
+                            |: string
+                            |: PartialContrastConfig
+                              bad?: string | null
+                              good?: string | null
+                              reason?: string | null
+                        items: [string]
+                        position?: int
+                        title: string | null
+                    |: PartialMergedVec
+                      dedup?: "inherit" | "true" | "false" | bool | null | null
+                      discard_when_merged?: bool | null
+                      strategy?: "append" | "prepend" | "replace" | null
+                      value?:
+                        |:
+                          []: InstructionsConfig
+                            description: string | null
+                            examples:
+                              []: PartialExampleConfig
+                                |: string
+                                |: PartialContrastConfig
+                                  bad?: string | null
+                                  good?: string | null
+                                  reason?: string | null
+                            items: [string]
+                            position?: int
+                            title: string | null
+                        |: null
+                  |: null
+                model?:
+                  |: PartialModelConfig
+                    id?:
+                      |: PartialModelIdOrAliasConfig
+                        |: PartialModelIdConfig
+                          name?: string | null
+                          provider?: "anthropic" | "cerebras" | "deepseek" | "google" | "llamacpp" | "ollama" | "openai" | "openrouter" | "xai" | null
+                        |: string
+                      |: null
+                    parameters?:
+                      |: PartialParametersConfig
+                        max_tokens?: int | null
+                        other?:
+                          |:
+                            *: unknown
+                          |: null
+                        reasoning?:
+                          |: PartialReasoningConfig
+                            |: "off"
+                            |: "auto"
+                            |: PartialCustomReasoningConfig
+                              effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string | null
+                              exclude?: bool | null
+                          |: null
+                        stop_words?: [string] | null
+                        temperature?: float | null
+                        top_k?: int | null
+                        top_p?: float | null
+                      |: null
+                  |: null
+                name?: string | null
+                request?:
+                  |: PartialRequestConfig
+                    base_backoff_ms?: int | null
+                    cache?: bool | "off" | "short" | "long" | string | null
+                    max_backoff_secs?: int | null
+                    max_response_bytes?: int | "disabled" | "off" | bool | null
+                    max_retries?: int | null
+                    stream_idle_timeout_secs?: int | null
+                  |: null
+                system_prompt?:
+                  |: PartialMergeableString
+                    |: string
+                    |: PartialMergedString
+                      dedup?: bool | "inherit" | "off" | "exact" | "block" | "contains" | null | null
+                      discard_when_merged?: bool | null
+                      separator?: "none" | "space" | "line" | "paragraph" | null
+                      strategy?: "append" | "prepend" | "replace" | null
+                      value?: string | null
+                  |: null
+                system_prompt_sections?:
+                  |: PartialMergeableVec
+                    |:
+                      []: SectionConfig
+                        content: string
+                        position?: int
+                        tag: string | null
+                        title: string | null
+                    |: PartialMergedVec
+                      dedup?: "inherit" | "true" | "false" | bool | null | null
+                      discard_when_merged?: bool | null
+                      strategy?: "append" | "prepend" | "replace" | null
+                      value?:
+                        |:
+                          []: SectionConfig
+                            content: string
+                            position?: int
+                            tag: string | null
+                            title: string | null
+                        |: null
+                  |: null
+                tool_choice?: "auto" | "none" | "required" | string | null
+        result: "unattended" | "ask" | "edit" | "skip" | null
+        run: "ask" | "unattended" | "edit" | "skip" | null
+        source: string
+        style:
+          |: DisplayStyleConfig
+            error: ErrorStyleConfig
+              inline_results: "off" | "full" | string | null
+              results_file_link: "full" | "osc8" | "off" | null
+            hidden?: bool
+            inline_results?: "off" | "full" | string
+            parameters?: ParametersStyle
+              |: "json"
+              |: "function_call"
+              |: "off"
+              |: CommandConfigOrString
+                |: string
+                | (expanded): CommandConfig
+                  args?: [string]
+                  program: string
+                  shell?: bool
+            results_file_link?: "full" | "osc8" | "off"
+          |: null
+        summary: string | null
+editor: EditorConfig
+  cmd:
+    |: CommandConfigOrString
+      |: string
+      | (expanded): CommandConfig
+        args?: [string]
+        program: string
+        shell?: bool
+    |: null
+  envs?: [string]
+  inline: InlineEditorConfig
+    edit_mode?: "emacs" | "vi"
+extends?:
+  []: ExtendingRelativePath
+    |: string
+    |: RelativePathWithStrategy
+      path: string
+      strategy?: "before" | "after"
+inherit: bool
+interrupt: InterruptConfig
+  escalation_cooldown_secs?: int
+  streaming: StreamingInterruptConfig
+    action?: "prompt" | "continue" | "stop" | "abort" | "reply"
+    compose_in_editor?: bool | "always" | "never"
+  tool_call: ToolInterruptConfig
+    action?: "prompt" | "continue" | "restart" | "respond" | "stop"
+    compose_in_editor?: bool | "always" | "never"
+loader: LoaderConfig
+  reset: "none" | null
+plugins: PluginsConfig
+  auto_install?: bool
+  command:
+    *: CommandPluginConfig
+      checksum:
+        |: ChecksumConfig
+          algorithm?: "sha256" | "sha1"
+          value: string
+        |: null
+      install: bool | null
+      options: unknown | null
+      run: "ask" | "unattended" | "deny" | null
+  shutdown_timeout_secs?: int
+providers: ProviderConfig
+  llm: LlmProviderConfig
+    aliases:
+      *: ModelIdOrAliasConfig
+        |: ModelIdConfig
+          name: string
+          provider: "anthropic" | "cerebras" | "deepseek" | "google" | "llamacpp" | "ollama" | "openai" | "openrouter" | "xai"
+        |: string
+    anthropic: AnthropicConfig
+      api_key_env?: string
+      base_url?: string
+      beta_headers?: [string]
+      chain_on_max_tokens?: bool
+    cerebras: CerebrasConfig
+      api_key_env?: string
+      base_url?: string
+    deepseek: DeepseekConfig
+      api_key_env?: string
+      base_url?: string
+    google: GoogleConfig
+      api_key_env?: string
+      base_url?: string
+      service_tier: "flex" | "priority" | "standard" | null
+    llamacpp: LlamacppConfig
+      base_url?: string
+    ollama: OllamaConfig
+      base_url?: string
+    openai: OpenaiConfig
+      api_key_env?: string
+      base_url?: string
+      base_url_env?: string
+    openrouter: OpenrouterConfig
+      api_key_env?: string
+      app_name?: string
+      app_referrer: string | null
+      base_url?: string
+  mcp:
+    *: McpProviderConfig
+      |: StdioConfig
+        arguments?: [string]
+        checksum:
+          |: ChecksumConfig
+            algorithm?: "sha256" | "sha1"
+            value: string
+          |: null
+        command: string
+        optional?: bool
+        startup_timeout_secs?: int
+        type: "stdio"
+        variables?: [string]
+style: StyleConfig
+  code: CodeConfig
+    color?: bool
+    copy_link?: "off" | "full" | "osc8"
+    file_link?: "off" | "full" | "osc8"
+    line_numbers?: bool
+  inline_code: InlineCodeConfig
+    background: int | string | null
+  lock_wait: LockWaitConfig
+    delay_secs?: int
+    interval_ms?: int
+    show?: bool
+    timeout_secs?: int
+  markdown: MarkdownConfig
+    hr_style?: "markdown" | "line"
+    table_continuation_edge?: bool
+    table_max_column_width?: int
+    theme?: string | null
+    wrap_width?: int
+  mcp_startup: McpStartupConfig
+    delay_secs?: int
+    interval_ms?: int
+    show?: bool
+  reasoning: ReasoningConfig
+    background?: int | string | null
+    display?: "hidden" | "summary" | "static" | "progress" | "timer" | "full" | string
+    extend_across_tool_calls?: bool
+    summary_model:
+      |: ModelConfig
+        id: ModelIdOrAliasConfig
+          |: ModelIdConfig
+            name: string
+            provider: "anthropic" | "cerebras" | "deepseek" | "google" | "llamacpp" | "ollama" | "openai" | "openrouter" | "xai"
+          |: string
+        parameters: ParametersConfig
+          max_tokens: int | null
+          other?:
+            *: unknown
+          reasoning: @ReasoningConfig | null
+          stop_words?: [string]
+          temperature: float | null
+          top_k: int | null
+          top_p: float | null
+      |: null
+  streaming: StreamingConfig
+    progress: ProgressConfig
+      delay_secs?: int
+      interval_ms?: int
+      show?: bool
+  tool_call: ToolCallConfig
+    preparing: PreparingConfig
+      delay_secs?: int
+      interval_ms?: int
+      show?: bool
+    progress: ProgressConfig
+      delay_secs?: int
+      interval_ms?: int
+      show?: bool
+    show?: bool
+  typewriter: TypewriterConfig
+    code_delay?: string
+    max_latency?: string
+    text_delay?: string
+template: TemplateConfig
+  values:
+    *: unknown
+user: UserConfig
+  name: string | null

--- a/crates/jp_config/src/snapshots/jp_config__tests__app_config_schema_shape.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__app_config_schema_shape.snap
@@ -52,6 +52,7 @@ assistant: AssistantConfig
             effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string
             exclude?: bool
         |: null
+      service_tier: "off" | "flex" | "standard" | "priority" | null
       stop_words?: [string]
       temperature: float | null
       top_k: int | null
@@ -149,6 +150,7 @@ conversation: ConversationConfig
                           effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string
                           exclude?: bool
                       |: null
+                    service_tier: "off" | "flex" | "standard" | "priority" | null
                     stop_words?: [string]
                     temperature: float | null
                     top_k: int | null
@@ -201,6 +203,7 @@ conversation: ConversationConfig
                             effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string
                             exclude?: bool
                         |: null
+                      service_tier: "off" | "flex" | "standard" | "priority" | null
                       stop_words?: [string]
                       temperature: float | null
                       top_k: int | null
@@ -267,6 +270,7 @@ conversation: ConversationConfig
                 effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string
                 exclude?: bool
             |: null
+          service_tier: "off" | "flex" | "standard" | "priority" | null
           stop_words?: [string]
           temperature: float | null
           top_k: int | null
@@ -373,6 +377,7 @@ conversation: ConversationConfig
                   effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string
                   exclude?: bool
               |: null
+            service_tier: "off" | "flex" | "standard" | "priority" | null
             stop_words?: [string]
             temperature: float | null
             top_k: int | null
@@ -380,6 +385,47 @@ conversation: ConversationConfig
         |: null
   tools: ToolsConfig
     *: ToolsDefaultsConfig
+      access:
+        |: AccessConfig
+          env: MergeableVec
+            |:
+              []: EnvRuleConfig
+                name: string
+                read: bool | null
+            |: MergedVec
+              dedup?: "inherit" | "true" | "false" | bool | null
+              discard_when_merged?: bool
+              strategy?: "append" | "prepend" | "replace" | null
+              value?:
+                []: EnvRuleConfig
+                  name: string
+                  read: bool | null
+          fs: MergeableVec
+            |:
+              []: FsRuleConfig
+                create: bool | null
+                delete: bool | null
+                execute: bool | null
+                external: bool | null
+                path: string
+                read: bool | null
+                update: bool | null
+                write: bool | null
+            |: MergedVec
+              dedup?: "inherit" | "true" | "false" | bool | null
+              discard_when_merged?: bool
+              strategy?: "append" | "prepend" | "replace" | null
+              value?:
+                []: FsRuleConfig
+                  create: bool | null
+                  delete: bool | null
+                  execute: bool | null
+                  external: bool | null
+                  path: string
+                  read: bool | null
+                  update: bool | null
+                  write: bool | null
+        |: null
       cancellation_response?: string
       enable:
         |:
@@ -408,6 +454,7 @@ conversation: ConversationConfig
               args?: [string]
               program: string
               shell?: bool
+        print_stderr?: bool
         results_file_link?: "full" | "osc8" | "off"
     tools (flattened):
       *: ToolConfig
@@ -551,6 +598,7 @@ conversation: ConversationConfig
                               effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string | null
                               exclude?: bool | null
                           |: null
+                        service_tier?: "off" | "flex" | "standard" | "priority" | null
                         stop_words?: [string] | null
                         temperature?: float | null
                         top_k?: int | null
@@ -619,6 +667,7 @@ conversation: ConversationConfig
                   args?: [string]
                   program: string
                   shell?: bool
+            print_stderr?: bool
             results_file_link?: "full" | "osc8" | "off"
           |: null
         summary: string | null
@@ -686,7 +735,6 @@ providers: ProviderConfig
     google: GoogleConfig
       api_key_env?: string
       base_url?: string
-      service_tier: "flex" | "priority" | "standard" | null
     llamacpp: LlamacppConfig
       base_url?: string
     ollama: OllamaConfig
@@ -737,6 +785,7 @@ style: StyleConfig
     delay_secs?: int
     interval_ms?: int
     show?: bool
+    stderr_rows?: "off" (aka false) | "auto" (aka true) | string
   reasoning: ReasoningConfig
     background?: int | string | null
     display?: "hidden" | "summary" | "static" | "progress" | "timer" | "full" | string
@@ -753,6 +802,7 @@ style: StyleConfig
           other?:
             *: unknown
           reasoning: @ReasoningConfig | null
+          service_tier: "off" | "flex" | "standard" | "priority" | null
           stop_words?: [string]
           temperature: float | null
           top_k: int | null
@@ -768,10 +818,11 @@ style: StyleConfig
       delay_secs?: int
       interval_ms?: int
       show?: bool
-    progress: ProgressConfig
+    progress: ToolProgressConfig
       delay_secs?: int
       interval_ms?: int
       show?: bool
+      stderr_rows?: "off" (aka false) | "auto" (aka true) | string
     show?: bool
   typewriter: TypewriterConfig
     code_delay?: string

--- a/crates/jp_config/src/snapshots/jp_config__tests__app_config_schema_shape.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__app_config_schema_shape.snap
@@ -649,7 +649,7 @@ conversation: ConversationConfig
                 tool_choice?: "auto" | "none" | "required" | string | null
         result: "unattended" | "ask" | "edit" | "skip" | null
         run: "ask" | "unattended" | "edit" | "skip" | null
-        source: string
+        source: string(/^(builtin|local)(\..+)?$|^mcp\.[^.]+(\..+)?$/)
         style:
           |: DisplayStyleConfig
             error: ErrorStyleConfig

--- a/crates/jp_config/src/types.rs
+++ b/crates/jp_config/src/types.rs
@@ -10,7 +10,23 @@ pub mod policy_spec;
 pub mod string;
 pub mod vec;
 
+use schematic::{
+    Schema, SchemaBuilder,
+    schema::{EnumType, LiteralValue},
+};
 use serde::de::{Deserializer, Error as DeError, Visitor};
+
+/// The non-boolean shapes a `dedup` field accepts, for the schema.
+///
+/// The boolean is described by the field's own type; these are the strings
+/// [`deserialize_dedup`] also takes, which the field type cannot express.
+pub(crate) fn dedup_input_shapes(schema: &SchemaBuilder) -> Vec<Schema> {
+    vec![schema.nest().enumerable(EnumType::new([
+        LiteralValue::String("inherit".into()),
+        LiteralValue::String("true".into()),
+        LiteralValue::String("false".into()),
+    ]))]
+}
 
 /// Deserialize a `dedup` field from `true`, `false`, or `"inherit"`.
 ///

--- a/crates/jp_config/src/types/policy_spec_tests.rs
+++ b/crates/jp_config/src/types/policy_spec_tests.rs
@@ -140,10 +140,9 @@ fn reports_the_policy_error_for_an_unreadable_value() {
         .unwrap_err()
         .to_string();
 
-    assert!(
-        err.contains("unknown tool_calls mode"),
-        "unexpected error: {err}"
-    );
+    // The policy's own error surfaces, rather than a generic "did not match any
+    // variant" from the union around it.
+    assert_eq!(err, "Unknown enum variant nonsense.");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/jp_config/src/types/string.rs
+++ b/crates/jp_config/src/types/string.rs
@@ -230,7 +230,8 @@ pub struct MergedString {
     /// the previous merge, falling back to `block`.
     #[setting(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_string_dedup"
+        deserialize_with = "deserialize_string_dedup",
+        schema_union_with = string_dedup_input_shapes
     )]
     pub dedup: Option<StringDedup>,
 }
@@ -391,6 +392,22 @@ impl FromStr for StringDedupSetting {
     }
 }
 
+/// The non-mode shapes `style.*.dedup` accepts, for the schema.
+///
+/// The mode names are described by the field's own type; these are the boolean
+/// shorthand and `"inherit"` that [`deserialize_string_dedup`] also takes,
+/// which the field type cannot express.
+fn string_dedup_input_shapes(schema: &schematic::SchemaBuilder) -> Vec<schematic::Schema> {
+    use schematic::schema::{BooleanType, EnumType, LiteralValue};
+
+    vec![
+        schema.nest().boolean(BooleanType::default()),
+        schema
+            .nest()
+            .enumerable(EnumType::new([LiteralValue::String("inherit".into())])),
+    ]
+}
+
 /// Deserialize a `dedup` field from a mode name, a boolean, or `"inherit"`.
 ///
 /// `"inherit"` and an absent field both produce `None`, which the merge
@@ -460,3 +477,7 @@ impl MergedStringSeparator {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "string_tests.rs"]
+mod tests;

--- a/crates/jp_config/src/types/string_tests.rs
+++ b/crates/jp_config/src/types/string_tests.rs
@@ -1,0 +1,78 @@
+use schematic::{Schema, SchemaBuilder, SchemaType};
+
+use super::*;
+
+/// The shapes a named field of a struct schema accepts, flattened.
+///
+/// A union contributes each of its variants; anything else contributes itself.
+fn field_shapes(schema: &Schema, field: &str) -> Vec<String> {
+    let SchemaType::Struct(struct_type) = &schema.ty else {
+        panic!("expected a struct");
+    };
+
+    let field = struct_type.fields.get(field).expect("the field exists");
+
+    fn describe(schema: &Schema, out: &mut Vec<String>) {
+        match &schema.ty {
+            SchemaType::Union(union) => {
+                for variant in &union.variants_types {
+                    describe(variant, out);
+                }
+            }
+            SchemaType::Enum(enum_type) => {
+                for value in &enum_type.values {
+                    out.push(value.to_string());
+                }
+            }
+            SchemaType::Boolean(_) => out.push("bool".to_owned()),
+            SchemaType::Null => out.push("null".to_owned()),
+            other => panic!("unexpected shape: {other:?}"),
+        }
+    }
+
+    let mut out = Vec::new();
+    describe(&field.schema, &mut out);
+    out
+}
+
+/// `dedup` takes more than its `Option<StringDedup>` type says, and the schema
+/// has to say so too.
+///
+/// `deserialize_string_dedup` also accepts the boolean shorthand the field's
+/// documentation advertises, and `"inherit"`.
+/// The field type cannot express either, so they are declared alongside it.
+#[test]
+fn the_dedup_schema_describes_every_shape_the_parser_takes() {
+    let schema = SchemaBuilder::build_root::<MergedString>();
+
+    assert_eq!(field_shapes(&schema, "dedup"), [
+        "bool",
+        "\"inherit\"",
+        "\"off\"",
+        "\"exact\"",
+        "\"block\"",
+        "\"contains\"",
+        "null"
+    ]);
+}
+
+/// Each shape the schema lists has to survive a round trip through the parser.
+#[test]
+fn the_parser_takes_every_dedup_shape_the_schema_lists() {
+    // `false` and `"off"` are a stated opinion (do not deduplicate), which is
+    // not the same as `"inherit"` stating none.
+    for (input, expected) in [
+        (r#"{"dedup":true}"#, Some(StringDedup::Block)),
+        (r#"{"dedup":false}"#, Some(StringDedup::Off)),
+        (r#"{"dedup":"inherit"}"#, None),
+        (r#"{"dedup":"off"}"#, Some(StringDedup::Off)),
+        (r#"{"dedup":"exact"}"#, Some(StringDedup::Exact)),
+        (r#"{"dedup":"block"}"#, Some(StringDedup::Block)),
+        (r#"{"dedup":"contains"}"#, Some(StringDedup::Contains)),
+        (r"{}", None),
+    ] {
+        let parsed: PartialMergedString = serde_json::from_str(input).unwrap();
+
+        assert_eq!(parsed.dedup, expected, "parsing {input}");
+    }
+}

--- a/crates/jp_config/src/types/string_tests.rs
+++ b/crates/jp_config/src/types/string_tests.rs
@@ -2,33 +2,32 @@ use schematic::{Schema, SchemaBuilder, SchemaType};
 
 use super::*;
 
+/// Flatten a schema into the shapes it accepts, one name each.
+fn describe(schema: &Schema, out: &mut Vec<String>) {
+    match &schema.ty {
+        SchemaType::Union(union) => {
+            for variant in &union.variants_types {
+                describe(variant, out);
+            }
+        }
+        SchemaType::Enum(enum_type) => {
+            for value in &enum_type.values {
+                out.push(value.to_string());
+            }
+        }
+        SchemaType::Boolean(_) => out.push("bool".to_owned()),
+        SchemaType::Null => out.push("null".to_owned()),
+        other => panic!("unexpected shape: {other:?}"),
+    }
+}
+
 /// The shapes a named field of a struct schema accepts, flattened.
-///
-/// A union contributes each of its variants; anything else contributes itself.
 fn field_shapes(schema: &Schema, field: &str) -> Vec<String> {
     let SchemaType::Struct(struct_type) = &schema.ty else {
         panic!("expected a struct");
     };
 
     let field = struct_type.fields.get(field).expect("the field exists");
-
-    fn describe(schema: &Schema, out: &mut Vec<String>) {
-        match &schema.ty {
-            SchemaType::Union(union) => {
-                for variant in &union.variants_types {
-                    describe(variant, out);
-                }
-            }
-            SchemaType::Enum(enum_type) => {
-                for value in &enum_type.values {
-                    out.push(value.to_string());
-                }
-            }
-            SchemaType::Boolean(_) => out.push("bool".to_owned()),
-            SchemaType::Null => out.push("null".to_owned()),
-            other => panic!("unexpected shape: {other:?}"),
-        }
-    }
 
     let mut out = Vec::new();
     describe(&field.schema, &mut out);

--- a/crates/jp_config/src/types/vec.rs
+++ b/crates/jp_config/src/types/vec.rs
@@ -7,7 +7,10 @@ use serde::{Deserialize, Deserializer, Serialize, de::DeserializeOwned};
 use serde_untagged::UntaggedEnumVisitor;
 
 use crate::{
-    delta::PartialConfigDelta, fill::FillDefaults, partial::ToPartial, types::deserialize_dedup,
+    delta::PartialConfigDelta,
+    fill::FillDefaults,
+    partial::ToPartial,
+    types::{dedup_input_shapes, deserialize_dedup},
 };
 
 /// Vec of `T`'s, either defaulting to a merge strategy of `replace`, or
@@ -320,7 +323,11 @@ pub struct MergedVec<T> {
     ///
     /// `"inherit"` (or omitting the field) means "no opinion" — inherit from
     /// the previous merge, falling back to the per-strategy default above.
-    #[setting(default, skip_serializing_if = "Option::is_none")]
+    #[setting(
+        default,
+        skip_serializing_if = "Option::is_none",
+        schema_union_with = dedup_input_shapes
+    )]
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -372,3 +379,7 @@ pub enum MergedVecStrategy {
     /// Replace the previous value with the new value.
     Replace,
 }
+
+#[cfg(test)]
+#[path = "vec_tests.rs"]
+mod tests;

--- a/crates/jp_config/src/types/vec_tests.rs
+++ b/crates/jp_config/src/types/vec_tests.rs
@@ -1,0 +1,79 @@
+use schematic::{Schema, SchemaBuilder, SchemaType};
+
+use super::*;
+
+/// The shapes a named field of a struct schema accepts, flattened.
+///
+/// A union contributes each of its variants; anything else contributes itself.
+fn field_shapes(schema: &Schema, field: &str) -> Vec<String> {
+    let SchemaType::Struct(struct_type) = &schema.ty else {
+        panic!("expected a struct");
+    };
+
+    let field = struct_type.fields.get(field).expect("the field exists");
+
+    fn describe(schema: &Schema, out: &mut Vec<String>) {
+        match &schema.ty {
+            SchemaType::Union(union) => {
+                for variant in &union.variants_types {
+                    describe(variant, out);
+                }
+            }
+            SchemaType::Enum(enum_type) => {
+                for value in &enum_type.values {
+                    out.push(value.to_string());
+                }
+            }
+            SchemaType::Boolean(_) => out.push("bool".to_owned()),
+            SchemaType::Null => out.push("null".to_owned()),
+            other => panic!("unexpected shape: {other:?}"),
+        }
+    }
+
+    let mut out = Vec::new();
+    describe(&field.schema, &mut out);
+    out
+}
+
+/// `dedup` takes more than its `Option<bool>` type says, and the schema has to
+/// say so too.
+///
+/// `deserialize_dedup` also accepts `"inherit"`, `"true"` and `"false"`.
+/// The field type cannot express those, so they are declared alongside it.
+#[test]
+fn the_dedup_schema_describes_every_shape_the_parser_takes() {
+    let schema = SchemaBuilder::build_root::<MergedVec<String>>();
+
+    assert_eq!(field_shapes(&schema, "dedup"), [
+        "\"inherit\"",
+        "\"true\"",
+        "\"false\"",
+        "bool",
+        "null"
+    ]);
+}
+
+/// Each shape the schema lists has to survive a round trip through the parser.
+///
+/// Deserialization goes through `MergeableVec`, which is the type a config
+/// field holds; it recognises the wrapper by its keys and hands the rest to
+/// `MergedVec`.
+#[test]
+fn the_parser_takes_every_dedup_shape_the_schema_lists() {
+    for (input, expected) in [
+        (r#"{"value":[],"dedup":true}"#, Some(true)),
+        (r#"{"value":[],"dedup":false}"#, Some(false)),
+        (r#"{"value":[],"dedup":"true"}"#, Some(true)),
+        (r#"{"value":[],"dedup":"false"}"#, Some(false)),
+        (r#"{"value":[],"dedup":"inherit"}"#, None),
+        (r#"{"value":[]}"#, None),
+    ] {
+        let parsed: MergeableVec<String> = serde_json::from_str(input).unwrap();
+
+        let MergeableVec::Merged(merged) = parsed else {
+            panic!("the wrapper form parses as `Merged`: {input}");
+        };
+
+        assert_eq!(merged.dedup, expected, "parsing {input}");
+    }
+}

--- a/crates/jp_config/src/types/vec_tests.rs
+++ b/crates/jp_config/src/types/vec_tests.rs
@@ -2,33 +2,32 @@ use schematic::{Schema, SchemaBuilder, SchemaType};
 
 use super::*;
 
+/// Flatten a schema into the shapes it accepts, one name each.
+fn describe(schema: &Schema, out: &mut Vec<String>) {
+    match &schema.ty {
+        SchemaType::Union(union) => {
+            for variant in &union.variants_types {
+                describe(variant, out);
+            }
+        }
+        SchemaType::Enum(enum_type) => {
+            for value in &enum_type.values {
+                out.push(value.to_string());
+            }
+        }
+        SchemaType::Boolean(_) => out.push("bool".to_owned()),
+        SchemaType::Null => out.push("null".to_owned()),
+        other => panic!("unexpected shape: {other:?}"),
+    }
+}
+
 /// The shapes a named field of a struct schema accepts, flattened.
-///
-/// A union contributes each of its variants; anything else contributes itself.
 fn field_shapes(schema: &Schema, field: &str) -> Vec<String> {
     let SchemaType::Struct(struct_type) = &schema.ty else {
         panic!("expected a struct");
     };
 
     let field = struct_type.fields.get(field).expect("the field exists");
-
-    fn describe(schema: &Schema, out: &mut Vec<String>) {
-        match &schema.ty {
-            SchemaType::Union(union) => {
-                for variant in &union.variants_types {
-                    describe(variant, out);
-                }
-            }
-            SchemaType::Enum(enum_type) => {
-                for value in &enum_type.values {
-                    out.push(value.to_string());
-                }
-            }
-            SchemaType::Boolean(_) => out.push("bool".to_owned()),
-            SchemaType::Null => out.push("null".to_owned()),
-            other => panic!("unexpected shape: {other:?}"),
-        }
-    }
 
     let mut out = Vec::new();
     describe(&field.schema, &mut out);
@@ -51,6 +50,27 @@ fn the_dedup_schema_describes_every_shape_the_parser_takes() {
         "bool",
         "null"
     ]);
+}
+
+/// A layer reads `dedup` the same way a resolved config does.
+///
+/// The custom deserializer is declared in serde's namespace rather than
+/// schematic's, and the generated partial has to pick it up from there too.
+/// Without that, `PartialMergedVec` falls back to a plain `Option<bool>` and
+/// rejects the string forms the resolved type accepts.
+#[test]
+fn the_partial_reads_dedup_the_same_way() {
+    for (input, expected) in [
+        (r#"{"dedup":true}"#, Some(true)),
+        (r#"{"dedup":"true"}"#, Some(true)),
+        (r#"{"dedup":"false"}"#, Some(false)),
+        (r#"{"dedup":"inherit"}"#, None),
+        (r"{}", None),
+    ] {
+        let parsed: PartialMergedVec<String> = serde_json::from_str(input).unwrap();
+
+        assert_eq!(parsed.dedup, expected, "parsing {input}");
+    }
 }
 
 /// Each shape the schema lists has to survive a round trip through the parser.

--- a/crates/jp_conversation/src/compat.rs
+++ b/crates/jp_conversation/src/compat.rs
@@ -311,11 +311,11 @@ fn resolve<'a>(reference: &ReferenceType, enclosing: &Enclosing<'a>) -> Option<&
 ///
 /// A union of one type and null is an `Option`, and the value selects that type
 /// by being present at all, whatever shape it arrived in.
-/// That matters for a field declared with `partial_via = MergeableVec`: its
-/// schema says array while the value can be the `{ "value": [...] }` object,
-/// and [`strip_items`] is what knows how to reconcile the two.
 ///
 /// A union with several real variants is separated by shape instead.
+/// A list field written with a merge strategy arrives as the `{ "value": [...],
+/// "strategy": ... }` object, which only the wrapper variant accepts, while a
+/// bare list only matches the array variant.
 /// A table written at `conversation.tools.<name>.enable` can only be the `{
 /// state, allow_toggle }` struct, never the bool or the legacy strings beside
 /// it.
@@ -443,24 +443,13 @@ fn flattened_entry_schema(struct_type: &StructType) -> Option<&Schema> {
 }
 
 /// Walk each element of an array against the item schema.
-///
-/// A vector field declared with `partial_via = MergeableVec` reaches disk
-/// either as a bare array or as `{ "value": [...], "strategy": ... }`; both
-/// carry the same items.
-/// The wrapper's own keys are not part of the field's schema and are left
-/// alone.
 fn strip_items<'a>(
     value: &mut Value,
     items_schema: &'a Schema,
     enclosing: &mut Enclosing<'a>,
 ) -> usize {
-    let items = match value {
-        Value::Array(items) => items,
-        Value::Object(obj) => match obj.get_mut("value") {
-            Some(Value::Array(items)) => items,
-            _ => return 0,
-        },
-        _ => return 0,
+    let Some(items) = value.as_array_mut() else {
+        return 0;
     };
 
     items

--- a/docs/ticket/04hn6c8-toolcallsmode-schema-omits-its-accepted-values.md
+++ b/docs/ticket/04hn6c8-toolcallsmode-schema-omits-its-accepted-values.md
@@ -1,6 +1,6 @@
 # `ToolCallsMode` schema omits its accepted values
 
-- **Status**: Todo
+- **Status**: Done
 - **Kind**: Chore
 - **Authors**: jp
 - **Date**: 2026-08-18

--- a/docs/ticket/07vn4tn-bare-setting-default-fields-are-not-marked-optional-in-the-s.md
+++ b/docs/ticket/07vn4tn-bare-setting-default-fields-are-not-marked-optional-in-the-s.md
@@ -1,6 +1,6 @@
 # Bare `#[setting(default)]` fields are not marked optional in the schema
 
-- **Status**: Todo
+- **Status**: Done
 - **Kind**: Bug
 - **Authors**: jp
 - **Date**: 2026-08-24

--- a/docs/ticket/0dkct9c-dedup-field-schemas-omit-the-boolean-and-inherit-input-shape.md
+++ b/docs/ticket/0dkct9c-dedup-field-schemas-omit-the-boolean-and-inherit-input-shape.md
@@ -1,6 +1,6 @@
 # Dedup field schemas omit the boolean and `inherit` input shapes
 
-- **Status**: Todo
+- **Status**: Done
 - **Kind**: Bug
 - **Authors**: jp
 - **Date**: 2026-09-04


### PR DESCRIPTION
Setting `conversation.default_id` to an explicit conversation ID no
longer breaks conversation persistence. `jp init` excludes the internal
`test` provider from its picker, and `assistant.model.id` accepts that
provider consistently in string and table form.

The schema lists enum values and aliases, constrains tool sources, and
describes both bare values and merge wrappers. It includes the boolean
and `"inherit"` forms of `dedup` and marks fields with defaults as
optional. Assignable keys, `--cfg` arguments, and `JP_CFG_*` names are
unchanged. Invalid compaction tool-call policies report
`Unknown enum variant x.` rather than an unknown tool_calls mode.

`ConfigEnum` keeps accepted spellings and schema definitions together,
with optional string-based serialization through the same parser.
This reduces the risk of advertising values that config loading rejects.
Stored-config repair uses the wrapper schema rather than special-casing
wrapped arrays.

Closes: 04hn6c8
Closes: 0dkct9c
Closes: 07vn4tn