### PR TITLE
fix(cli): Preserve conversation config clears

### DIFF
--- a/crates/jp_cli/src/cmd.rs
+++ b/crates/jp_cli/src/cmd.rs
@@ -192,7 +192,7 @@ impl IntoPartialAppConfig for Commands {
         partial: PartialAppConfig,
         merged_config: Option<&PartialAppConfig>,
         handle: &jp_workspace::ConversationHandle,
-    ) -> Result<PartialAppConfig, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<(PartialAppConfig, Vec<String>), Box<dyn std::error::Error + Send + Sync>> {
         match self {
             Commands::Query(args) => {
                 args.apply_conversation_config(workspace, partial, merged_config, handle)
@@ -204,7 +204,7 @@ impl IntoPartialAppConfig for Commands {
             | Commands::Init(_)
             | Commands::Plugin(_)
             | Commands::Workspace(_)
-            | Commands::External(_) => Ok(partial),
+            | Commands::External(_) => Ok((partial, Vec::new())),
         }
     }
 }

--- a/crates/jp_cli/src/cmd/query.rs
+++ b/crates/jp_cli/src/cmd/query.rs
@@ -2431,10 +2431,15 @@ impl IntoPartialAppConfig for Query {
         partial: PartialAppConfig,
         _: Option<&PartialAppConfig>,
         handle: &ConversationHandle,
-    ) -> std::result::Result<PartialAppConfig, Box<dyn std::error::Error + Send + Sync>> {
-        let config = workspace.events(handle)?.config().map(|c| c.to_partial())?;
+    ) -> std::result::Result<
+        (PartialAppConfig, Vec<String>),
+        Box<dyn std::error::Error + Send + Sync>,
+    > {
+        let events = workspace.events(handle)?;
+        let config = events.config()?.to_partial();
+        let unsets = events.config_unsets()?;
 
-        load_partial(partial, config).map_err(Into::into)
+        Ok((load_partial(partial, config)?, unsets))
     }
 }
 

--- a/crates/jp_cli/src/cmd/query_tests.rs
+++ b/crates/jp_cli/src/cmd/query_tests.rs
@@ -39,9 +39,10 @@ use tokio::{runtime::Runtime, sync::broadcast};
 
 use super::*;
 use crate::{
-    Globals, KeyValueOrPath,
+    Cli, Globals, KeyValueOrPath,
     cmd::target::{ConversationTarget, PickerFilter},
     config_pipeline::ConfigPipeline,
+    resolve_config,
     signals::testing::detached_router,
 };
 
@@ -277,7 +278,9 @@ fn build_query_config(
     });
 
     let mut partial = match conversation_partial {
-        Some(conversation_partial) => pipeline.partial_with_conversation(conversation_partial),
+        Some((conversation_partial, unsets)) => {
+            pipeline.partial_with_conversation(conversation_partial, &unsets)
+        }
         None => pipeline.partial_without_conversation(),
     }
     .unwrap();
@@ -1297,6 +1300,69 @@ fn test_bool_disabled_builtin_can_still_be_forced() {
         query.effective_tool_choice(&AppConfig::new_test()),
         ToolChoice::Function("describe_tools".into())
     );
+}
+
+#[test]
+fn resolve_config_keeps_a_cleared_conversation_field_across_invocations() {
+    let tmp = Utf8TempDir::new().unwrap();
+    let mut workspace = Workspace::in_memory(tmp.path());
+    workspace.load_conversation_index();
+    let mut base = AppConfig::new_test();
+    base.assistant.name = Some("Bot".to_owned());
+    let base = Arc::new(base);
+    let conversation_id = make_id(4001);
+    workspace.create_conversation_with_id(
+        conversation_id,
+        Conversation::default(),
+        Arc::clone(&base),
+    );
+    let id = conversation_id.to_string();
+    let cli = Cli::try_parse_from([
+        "jp",
+        "query",
+        "--id",
+        &id,
+        "--cfg",
+        "assistant.name:=null",
+        "hello",
+    ])
+    .unwrap();
+
+    let (first, mut handles, _, _) = resolve_config(
+        &cli.command,
+        || Ok(base.to_partial()),
+        &cli.globals.config,
+        &mut workspace,
+        None,
+        None,
+        false,
+    )
+    .unwrap();
+    assert_eq!(first.assistant.name, None);
+    {
+        let lock = workspace.test_lock(handles.remove(0));
+        let delta = turn_config_delta(&first, &lock).unwrap().unwrap();
+        assert_eq!(delta.unsets, ["assistant.name"]);
+        lock.as_mut()
+            .update_events(|events| events.add_config_delta(delta));
+        assert_eq!(lock.events().config().unwrap().assistant.name, None);
+    }
+
+    let cli = Cli::try_parse_from(["jp", "query", "--id", &id, "hello again"]).unwrap();
+    let (second, mut handles, _, _) = resolve_config(
+        &cli.command,
+        || Ok(base.to_partial()),
+        &cli.globals.config,
+        &mut workspace,
+        None,
+        None,
+        false,
+    )
+    .unwrap();
+    assert_eq!(second.assistant.name, None);
+    let lock = workspace.test_lock(handles.remove(0));
+    assert_eq!(turn_config_delta(&second, &lock).unwrap(), None);
+    assert_eq!(lock.events().config_deltas().count(), 1);
 }
 
 #[test]

--- a/crates/jp_cli/src/config_pipeline.rs
+++ b/crates/jp_cli/src/config_pipeline.rs
@@ -24,7 +24,7 @@ use jp_config::{
 use jp_storage::backend::FsStorageBackend;
 use jp_workspace::Workspace;
 use relative_path::RelativePath;
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use super::{CfgKeyword, KeyValueOrPath};
 use crate::error::{Error, Result};
@@ -314,12 +314,20 @@ impl ConfigPipeline {
     /// base only what it does not, which is what the snapshot already meant for
     /// every field that merges by replacement.
     ///
-    /// `--cfg` still merges on top, where combining is what the user asked for.
+    /// `unsets` carries the conversation's explicitly cleared paths.
+    /// These are cleared after filling so the base cannot restore them.
+    /// `--cfg` merges on top and can set them again.
     pub fn partial_with_conversation(
         &self,
         conversation: PartialAppConfig,
+        unsets: &[String],
     ) -> Result<PartialAppConfig> {
-        let partial = conversation.fill_from(self.base.clone());
+        let mut partial = conversation.fill_from(self.base.clone());
+        for path in unsets {
+            if let Err(error) = partial.unset(path) {
+                warn!(%path, %error, "Ignoring a config delta unset for an unknown field.");
+            }
+        }
         apply_cfg_args(partial, &self.cfg_args)
     }
 

--- a/crates/jp_cli/src/config_pipeline_tests.rs
+++ b/crates/jp_cli/src/config_pipeline_tests.rs
@@ -208,7 +208,7 @@ fn with_conversation_preserves_cfg_over_conversation() {
     let mut conv = PartialAppConfig::empty();
     conv.conversation.start_local = Some(false);
 
-    let partial = pipeline.partial_with_conversation(conv).unwrap();
+    let partial = pipeline.partial_with_conversation(conv, &[]).unwrap();
     // `--cfg` should win over conversation layer
     assert_eq!(partial.conversation.start_local, Some(true));
 }
@@ -220,8 +220,76 @@ fn conversation_layer_overrides_base() {
     let mut conv = PartialAppConfig::empty();
     conv.conversation.start_local = Some(true);
 
-    let partial = pipeline.partial_with_conversation(conv).unwrap();
+    let partial = pipeline.partial_with_conversation(conv, &[]).unwrap();
     assert_eq!(partial.conversation.start_local, Some(true));
+}
+
+#[test]
+fn conversation_clears_prevent_base_values_from_returning() {
+    let mut pipeline = empty_pipeline();
+    pipeline.base.assistant.name = Some("Bot".to_owned());
+    pipeline.base.user.name = Some("Alice".to_owned());
+    pipeline
+        .base
+        .providers
+        .mcp
+        .insert("bookworm".to_owned(), mcp_server("serve"));
+    pipeline
+        .base
+        .providers
+        .mcp
+        .insert("kagi".to_owned(), mcp_server("search"));
+    let mut conversation = pipeline.base.clone();
+    conversation.assistant.name = None;
+    conversation.providers.mcp.shift_remove("kagi");
+    conversation
+        .unset("providers.mcp.bookworm.arguments")
+        .unwrap();
+
+    let partial = pipeline
+        .partial_with_conversation(conversation, &[
+            "assistant.name".to_owned(),
+            "providers.mcp.bookworm.arguments".to_owned(),
+            "providers.mcp.kagi".to_owned(),
+        ])
+        .unwrap();
+
+    assert_eq!(partial.assistant.name, None);
+    assert_eq!(partial.user.name.as_deref(), Some("Alice"));
+    assert_eq!(mcp_arguments(&partial, "bookworm"), None);
+    assert!(!partial.providers.mcp.contains_key("kagi"));
+}
+
+#[test]
+fn conversation_clears_allow_explicit_cfg_values() {
+    let mut pipeline = empty_pipeline();
+    pipeline.base.assistant.name = Some("Bot".to_owned());
+    pipeline.cfg_args.push(ResolvedCfgArg::KeyValue(
+        "assistant.name=NewBot".parse().unwrap(),
+    ));
+
+    let partial = pipeline
+        .partial_with_conversation(PartialAppConfig::empty(), &["assistant.name".to_owned()])
+        .unwrap();
+
+    assert_eq!(partial.assistant.name.as_deref(), Some("NewBot"));
+}
+
+#[test]
+fn conversation_clears_allow_cfg_resets() {
+    let mut pipeline = empty_pipeline();
+    pipeline.base.assistant.name = Some("Bot".to_owned());
+    pipeline
+        .cfg_args
+        .push(ResolvedCfgArg::Reset(ConfigReset::Workspace(Box::new(
+            pipeline.base.clone(),
+        ))));
+
+    let partial = pipeline
+        .partial_with_conversation(PartialAppConfig::empty(), &["assistant.name".to_owned()])
+        .unwrap();
+
+    assert_eq!(partial.assistant.name.as_deref(), Some("Bot"));
 }
 
 /// An MCP server entry with a command and one argument.
@@ -258,7 +326,9 @@ fn conversation_layer_does_not_duplicate_an_appended_list() {
         base,
         cfg_args: vec![],
     };
-    let partial = pipeline.partial_with_conversation(conversation).unwrap();
+    let partial = pipeline
+        .partial_with_conversation(conversation, &[])
+        .unwrap();
 
     assert_eq!(
         mcp_arguments(&partial, "bookworm"),
@@ -292,7 +362,9 @@ fn conversation_layer_keeps_a_server_only_the_file_layer_has() {
         base,
         cfg_args: vec![],
     };
-    let partial = pipeline.partial_with_conversation(conversation).unwrap();
+    let partial = pipeline
+        .partial_with_conversation(conversation, &[])
+        .unwrap();
 
     assert_eq!(
         mcp_arguments(&partial, "kagi"),

--- a/crates/jp_cli/src/ctx.rs
+++ b/crates/jp_cli/src/ctx.rs
@@ -293,6 +293,7 @@ pub(crate) trait IntoPartialAppConfig {
         merged_config: Option<&PartialAppConfig>,
     ) -> std::result::Result<PartialAppConfig, Box<dyn std::error::Error + Send + Sync>>;
 
+    /// Apply the conversation layer and return its explicitly cleared paths.
     #[expect(unused_variables)]
     fn apply_conversation_config(
         &self,
@@ -300,8 +301,11 @@ pub(crate) trait IntoPartialAppConfig {
         partial: PartialAppConfig,
         merged_config: Option<&PartialAppConfig>,
         handle: &jp_workspace::ConversationHandle,
-    ) -> std::result::Result<PartialAppConfig, Box<dyn std::error::Error + Send + Sync>> {
-        Ok(partial)
+    ) -> std::result::Result<
+        (PartialAppConfig, Vec<String>),
+        Box<dyn std::error::Error + Send + Sync>,
+    > {
+        Ok((partial, Vec::new()))
     }
 }
 

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -1052,7 +1052,9 @@ pub(crate) fn resolve_config(
     };
 
     let mut partial = match conversation_partial {
-        Some(conversation_config) => pipeline.partial_with_conversation(conversation_config)?,
+        Some((conversation_config, unsets)) => {
+            pipeline.partial_with_conversation(conversation_config, &unsets)?
+        }
         None => pipeline.partial_without_conversation()?,
     };
 

--- a/crates/jp_cli/src/lib_tests.rs
+++ b/crates/jp_cli/src/lib_tests.rs
@@ -862,6 +862,53 @@ fn resolve_config_applies_the_compact_model_flag() {
     );
 }
 
+#[test]
+fn resolve_config_rejects_a_cleared_model_without_changing_the_conversation() {
+    let tmp = tempdir().unwrap();
+    let mut workspace = Workspace::in_memory(tmp.path());
+    workspace.load_conversation_index();
+    let base = Arc::new(config_with_model(ProviderId::Anthropic, "base-model"));
+    let conversation_id = make_id(4002);
+    workspace.create_conversation_with_id(
+        conversation_id,
+        Conversation::default(),
+        Arc::clone(&base),
+    );
+    let id = conversation_id.to_string();
+    let cli = Cli::try_parse_from([
+        "jp",
+        "query",
+        "--id",
+        &id,
+        "--cfg",
+        "assistant.model.id:=null",
+        "hello",
+    ])
+    .unwrap();
+
+    let error = resolve_config(
+        &cli.command,
+        || Ok(base.to_partial()),
+        &cli.globals.config,
+        &mut workspace,
+        None,
+        None,
+        false,
+    )
+    .unwrap_err();
+
+    let handle = workspace.acquire_conversation(&conversation_id).unwrap();
+    let events = workspace.events(&handle).unwrap();
+    assert_eq!(events.config().unwrap(), *base);
+    assert_eq!(events.config_deltas().count(), 0);
+    let (code, rendered) = parse_error(cmd::Error::from(error), OutputFormat::TextPretty);
+    assert_eq!(code, 1);
+    assert_eq!(
+        rendered,
+        "Config error\n\n    Missing required value for field assistant.model.id.provider."
+    );
+}
+
 fn kv(s: &str) -> KeyValueOrPath {
     KeyValueOrPath::KeyValue(s.parse().unwrap())
 }

--- a/crates/jp_conversation/src/stream.rs
+++ b/crates/jp_conversation/src/stream.rs
@@ -1,6 +1,9 @@
 //! See [`ConversationStream`].
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+};
 
 use chrono::{DateTime, Utc};
 use jp_config::{AppConfig, ConfigError, FillDefaults as _, PartialAppConfig, PartialConfig as _};
@@ -549,6 +552,37 @@ impl ConversationStream {
         }
 
         Ok(partial)
+    }
+
+    /// Dotted config paths explicitly cleared and not subsequently set.
+    ///
+    /// Reset deltas discard earlier clears.
+    /// A clear followed by a replacement in the same apply delta is not
+    /// included.
+    /// Unknown paths are ignored.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a delta cannot be folded onto the accumulated state.
+    pub fn config_unsets(&self) -> Result<Vec<String>, StreamError> {
+        let mut unsets = BTreeSet::new();
+        for delta in self.config_deltas() {
+            match delta {
+                ConfigDelta::Apply(apply) => unsets.extend(apply.unsets.iter().cloned()),
+                ConfigDelta::Reset(_) => unsets.clear(),
+            }
+        }
+
+        let partial = self.config_partial()?;
+        Ok(unsets
+            .into_iter()
+            .filter(|path| {
+                // Probe the typed path before resolution injects defaults. Clearing
+                // it changes nothing only when the accumulated field is still absent.
+                let mut cleared = partial.clone();
+                cleared.unset(path).is_ok() && cleared == partial
+            })
+            .collect())
     }
 
     /// Removes all events from the end of the stream, until a [`ChatRequest`]

--- a/crates/jp_conversation/src/stream_tests.rs
+++ b/crates/jp_conversation/src/stream_tests.rs
@@ -136,6 +136,109 @@ fn a_delta_that_only_clears_is_recorded() {
     assert!(resolved_arguments(&stream).is_empty());
 }
 
+#[test]
+fn config_unsets_keeps_clears_across_unrelated_deltas() {
+    let mut stream = stream_with_server(&["serve"]);
+    stream.add_config_delta(ApplyDelta::with_unsets(
+        delta_timestamp(),
+        PartialAppConfig::empty(),
+        vec![
+            "assistant.name".to_owned(),
+            "providers.mcp.bookworm.arguments".to_owned(),
+        ],
+    ));
+    let mut partial = PartialAppConfig::empty();
+    partial.user.name = Some("Alice".to_owned());
+    stream.add_config_delta(ApplyDelta::new(delta_timestamp(), partial));
+
+    assert_eq!(stream.config_unsets().unwrap(), [
+        "assistant.name",
+        "providers.mcp.bookworm.arguments",
+    ]);
+}
+
+#[test]
+fn config_unsets_drops_a_path_when_a_later_delta_sets_it() {
+    let mut stream = stream_with_server(&["serve"]);
+    stream.add_config_delta(ApplyDelta::with_unsets(
+        delta_timestamp(),
+        PartialAppConfig::empty(),
+        vec![
+            "assistant.name".to_owned(),
+            "providers.mcp.bookworm.arguments".to_owned(),
+        ],
+    ));
+    stream.add_config_delta(ApplyDelta::new(
+        delta_timestamp(),
+        server_arguments_partial(&["run"]),
+    ));
+
+    assert_eq!(stream.config_unsets().unwrap(), ["assistant.name"]);
+}
+
+#[test]
+fn config_unsets_excludes_a_same_delta_replacement() {
+    let mut stream = stream_with_server(&["serve", "--verbose"]);
+    stream.add_config_delta(ApplyDelta::with_unsets(
+        delta_timestamp(),
+        server_arguments_partial(&["serve"]),
+        vec![
+            "assistant.name".to_owned(),
+            "providers.mcp.bookworm.arguments".to_owned(),
+        ],
+    ));
+
+    assert_eq!(stream.config_unsets().unwrap(), ["assistant.name"]);
+}
+
+#[test]
+fn config_unsets_discards_clears_before_a_reset() {
+    let mut stream = stream_with_server(&["serve"]);
+    stream.add_config_delta(ApplyDelta::with_unsets(
+        delta_timestamp(),
+        PartialAppConfig::empty(),
+        vec!["assistant.name".to_owned()],
+    ));
+    stream.add_config_delta(ResetDelta {
+        timestamp: delta_timestamp(),
+    });
+    stream.add_config_delta(ApplyDelta::with_unsets(
+        delta_timestamp(),
+        PartialAppConfig::empty(),
+        vec!["user.name".to_owned()],
+    ));
+
+    assert_eq!(stream.config_unsets().unwrap(), ["user.name"]);
+}
+
+#[test]
+fn config_unsets_keeps_a_removed_map_entry() {
+    let mut stream = stream_with_server(&["serve"]);
+    stream.add_config_delta(ApplyDelta::with_unsets(
+        delta_timestamp(),
+        PartialAppConfig::empty(),
+        vec!["providers.mcp.bookworm".to_owned()],
+    ));
+
+    assert_eq!(stream.config_unsets().unwrap(), ["providers.mcp.bookworm"]);
+}
+
+#[test]
+fn config_unsets_deduplicates_paths_and_ignores_unknown_fields() {
+    let mut stream = stream_with_server(&["serve"]);
+    stream.add_config_delta(ApplyDelta::with_unsets(
+        delta_timestamp(),
+        PartialAppConfig::empty(),
+        vec![
+            "assistant.name".to_owned(),
+            "assistant.removed_field".to_owned(),
+            "assistant.name".to_owned(),
+        ],
+    ));
+
+    assert_eq!(stream.config_unsets().unwrap(), ["assistant.name"]);
+}
+
 /// A config granting the local tool `bash` the named access rules.
 ///
 /// Both rule lists carry their own merge strategy, which is what puts them on

--- a/docs/ticket/0gqh7z7-a-cleared-conversation-field-is-refilled-from-the-file-layer.md
+++ b/docs/ticket/0gqh7z7-a-cleared-conversation-field-is-refilled-from-the-file-layer.md
@@ -1,0 +1,102 @@
+# A cleared conversation field is refilled from the file layer on the next invocation
+
+- **Status**: Done
+- **Kind**: Bug
+- **Authors**: jp
+- **Date**: 2026-09-10
+- **Label**: client=cli
+- **Label**: domain=conversation
+- **Label**: package=jp_cli
+- **Label**: package=jp_config
+- **Label**: package=jp_conversation
+- **Label**: type=bug
+
+`jp query --cfg assistant.name=null` clears the field for that turn.
+The next `jp query` on the same conversation runs with the workspace's value
+again, and writes a config delta restoring it, so the clear is undone
+permanently rather than merely forgotten.
+
+Any field a config file also declares behaves this way.
+A field only the conversation ever set stays clear, which is why the delta-level
+tests pass.
+
+## Why
+
+The stream is correct.
+A delta carries the cleared path in `unsets`, `fold_config_delta` applies it
+before merging, and `ConversationStream::config` resolves the field to `None`.
+
+The invocation pipeline then puts the value back.
+`Query::apply_conversation_config` (`crates/jp_cli/src/cmd/query.rs:2392`) turns
+the stream's resolved config into a partial, where the cleared field is `None`.
+`ConfigPipeline::partial_with_conversation`
+(`crates/jp_cli/src/config_pipeline.rs:322`) then calls
+`conversation.fill_from(self.base.clone())`, and filling reads `None` as "this
+layer says nothing".
+`PartialAssistantConfig::fill_from` (`crates/jp_config/src/assistant.rs:166`) is
+`self.name.or(defaults.name)`, so the file layer's value wins.
+
+Nothing in `config_pipeline.rs` mentions `unset`: the cleared paths are consumed
+by the fold and never cross into the pipeline.
+
+The reversal then persists.
+`get_config_delta_from_cli` diffs the stream (`None`) against the runtime config
+(`Some("Bot")`), `delta_opt_at` takes its `(None, next) => next` arm, and a
+delta setting the field back is recorded.
+
+## Scope
+
+Not a regression.
+Before deltas could express a clear, the clear was never recorded and the
+outcome was the same value on the next turn.
+What changed is where it is lost: the stream now holds the clear, and the layer
+above it overrides.
+
+The fill semantics themselves are right, and are what stop an appending list
+from doubling when the conversation snapshot merges over the layer it came from.
+The gap is that a partial cannot distinguish "cleared" from "not stated", which
+is the same distinction `unsets` exists to carry.
+
+## Fix
+
+Carry the conversation's cleared paths across the boundary.
+
+`ConversationStream` grows an accumulator over its deltas' `unsets` — a path
+cleared by one delta and set by a later one is no longer cleared — and
+`partial_with_conversation` applies what it reports after `fill_from`, before
+`--cfg` merges on top.
+A `--cfg` that sets the field in the same invocation still wins, which is what a
+user typing it expects.
+
+## Verifying
+
+A two-invocation regression through the pipeline, which is the boundary the
+`jp_config` sweep in `delta_law_tests.rs` cannot reach: a workspace config
+naming `assistant.name`, one query with `--cfg assistant.name:=null`, then a
+second with no flag.
+Assert the resolved name is still clear, and that the second query wrote no
+delta restoring it.
+
+## Comments
+
+-----
+
+- **From**: jp
+- **Date**: 2026-09-10T18:10:17Z
+
+Implemented `ConversationStream::config_unsets()` to report cleared paths that
+remain absent after folding the stream, excluding clears before a reset and
+paths with replacement values.
+The conversation-config hook carries those paths alongside its partial;
+`ConfigPipeline` reapplies them after base-layer filling and before `--cfg`
+directives.
+
+The regression calls the production `resolve_config` and `turn_config_delta`
+paths for successive invocations.
+It failed before the fix with `Some("Bot")` on the second invocation.
+It passes with the name still `None` and no second config delta.
+Additional tests cover later sets, same-delta replacements, resets, removed map
+entries, duplicate/unknown paths, and CLI override precedence.
+
+Validation: full `jp_cli` and `jp_conversation` test suites pass; scoped Clippy
+checks pass without warnings; formatting and the diff were reviewed.


### PR DESCRIPTION
Fields cleared with `jp query --cfg assistant.name:=null` stay cleared on subsequent invocations, even when workspace config supplies a value. The next query no longer records a delta restoring that value.

Carry active conversation clears through base-layer filling before applying `--cfg` overrides. Explicit values still win, later sets retire clears, and resets discard earlier clears. Existing stored clears work without a data migration.

Fixes: T-0gqh7z7