### PR TITLE
fix(config): Preserve partial schema inputs

### DIFF
--- a/crates/contrib/schematic/src/internal.rs
+++ b/crates/contrib/schematic/src/internal.rs
@@ -1,6 +1,6 @@
-use std::str::FromStr;
+use std::{marker::PhantomData, str::FromStr};
 
-use schematic_types::Schema;
+use schematic_types::{Schema, SchemaBuilder, Schematic};
 
 use crate::config::{ConfigError, HandlerError, MergeError, MergeResult, PartialConfig};
 
@@ -122,6 +122,25 @@ pub fn merge_nested_setting<T: PartialConfig>(
         Ok(next)
     } else {
         Ok(prev)
+    }
+}
+
+/// Retain `T`'s schema and mark it for partialization.
+///
+/// The type name and field flags remain those of `T`.
+/// The nested marker is consumed by [`partialize_schema`].
+#[derive(Debug)]
+pub struct NestedSchema<T>(PhantomData<T>);
+
+impl<T: Schematic> Schematic for NestedSchema<T> {
+    fn schema_name() -> Option<String> {
+        T::schema_name()
+    }
+
+    fn build_schema(schema: SchemaBuilder) -> Schema {
+        let mut schema = T::build_schema(schema);
+        schema.partialize();
+        schema
     }
 }
 

--- a/crates/contrib/schematic/tests/field_schema.rs
+++ b/crates/contrib/schematic/tests/field_schema.rs
@@ -1,0 +1,41 @@
+//! Schema attributes on individual config fields.
+
+use schematic::{
+    Config, Schema, SchemaBuilder, SchemaType,
+    schema::{BooleanType, LiteralValue, UnionType},
+};
+
+/// A literal default alongside an additional input shape.
+#[derive(Config)]
+#[expect(dead_code, reason = "only the generated schema is under test")]
+struct DefaultedInput {
+    #[setting(default = true, schema_union_with = inherit_shape)]
+    enabled: bool,
+}
+
+fn inherit_shape(_: &SchemaBuilder) -> Vec<Schema> {
+    vec![Schema::literal_value(LiteralValue::String(
+        "inherit".to_owned(),
+    ))]
+}
+
+#[test]
+fn a_literal_default_preserves_additional_input_shapes() {
+    let schema = SchemaBuilder::build_root::<DefaultedInput>();
+    let SchemaType::Struct(fields) = schema.ty else {
+        panic!("expected a struct");
+    };
+    let field = &fields.fields["enabled"];
+
+    assert!(field.optional);
+    assert_eq!(
+        field.schema,
+        Schema::union(
+            UnionType::new_any([
+                Schema::literal_value(LiteralValue::String("inherit".to_owned())),
+                Schema::boolean(BooleanType::new(true)),
+            ])
+            .with_expanded_index(1)
+        )
+    );
+}

--- a/crates/contrib/schematic_macros/src/common/field.rs
+++ b/crates/contrib/schematic_macros/src/common/field.rs
@@ -381,16 +381,20 @@ impl Field<'_> {
         // the type it resolves to: `attachments` holds a `Vec<AttachmentConfig>`
         // once resolved, but a document writes either a bare list or the merge
         // wrapper carrying one, and the via type is what describes both.
-        let value = self.partial_via_ty.as_ref().unwrap_or(self.value);
+        let value = if self.partial_via_ty.is_some() && self.is_container() {
+            // Nested collections deserialize partial elements in every wire form.
+            self.value_type.to_token_stream()
+        } else {
+            self.partial_via_ty
+                .as_ref()
+                .unwrap_or(self.value)
+                .to_token_stream()
+        };
         let mut inner_schema = if self.is_nested() {
             quote! { schema.infer_as_nested::<#value>() }
         } else {
             quote! { schema.infer::<#value>() }
         };
-
-        if let Some(path) = &self.args.schema_union_with {
-            inner_schema = union_with_declared_shapes(path, &inner_schema);
-        }
 
         if let Some(Expr::Lit(lit)) = self.args.default.expr() {
             let lit_value = match &lit.lit {
@@ -414,6 +418,10 @@ impl Field<'_> {
             };
 
             inner_schema = quote! { schema.infer_with_default::<#value>(#lit_value) };
+        }
+
+        if let Some(path) = &self.args.schema_union_with {
+            inner_schema = union_with_declared_shapes(path, &inner_schema);
         }
 
         // Struct field (named)

--- a/crates/contrib/schematic_macros/src/common/field.rs
+++ b/crates/contrib/schematic_macros/src/common/field.rs
@@ -358,6 +358,44 @@ impl Field<'_> {
         })
     }
 
+    /// The wire type used to infer a field's schema.
+    #[cfg(feature = "schema")]
+    fn schema_value_type(&self) -> TokenStream {
+        // A `partial_via` field is written in the shape of its via type, not of
+        // the type it resolves to: `attachments` holds a `Vec<AttachmentConfig>`
+        // once resolved, but a document writes either a bare list or the merge
+        // wrapper carrying one, and the via type is what describes both.
+        match (&self.partial_via_ty, &self.value_type) {
+            // The adapter carries the element's nested marker through each
+            // wire form without changing its resolved name or field flags.
+            (
+                Some(_),
+                FieldValue::NestedList {
+                    collection, item, ..
+                },
+            ) => {
+                quote! { #collection<schematic::internal::NestedSchema<#item>> }
+            }
+            (
+                Some(_),
+                FieldValue::NestedMap {
+                    collection,
+                    key,
+                    value,
+                    ..
+                },
+            ) => {
+                let key = key.iter();
+                quote! { #collection<#(#key,)* schematic::internal::NestedSchema<#value>> }
+            }
+            _ => self
+                .partial_via_ty
+                .as_ref()
+                .unwrap_or(self.value)
+                .to_token_stream(),
+        }
+    }
+
     #[cfg(feature = "schema")]
     pub fn generate_schema_type(&self, as_field: bool) -> TokenStream {
         use syn::Lit;
@@ -377,19 +415,7 @@ impl Field<'_> {
         let deprecated = map_option_field_quote("deprecated", extract_deprecated(&self.attrs));
         let env_var = map_option_field_quote("env_var", self.get_env_var());
 
-        // A `partial_via` field is written in the shape of its via type, not of
-        // the type it resolves to: `attachments` holds a `Vec<AttachmentConfig>`
-        // once resolved, but a document writes either a bare list or the merge
-        // wrapper carrying one, and the via type is what describes both.
-        let value = if self.partial_via_ty.is_some() && self.is_container() {
-            // Nested collections deserialize partial elements in every wire form.
-            self.value_type.to_token_stream()
-        } else {
-            self.partial_via_ty
-                .as_ref()
-                .unwrap_or(self.value)
-                .to_token_stream()
-        };
+        let value = self.schema_value_type();
         let mut inner_schema = if self.is_nested() {
             quote! { schema.infer_as_nested::<#value>() }
         } else {

--- a/crates/jp_config/src/lib_tests.rs
+++ b/crates/jp_config/src/lib_tests.rs
@@ -39,6 +39,59 @@ fn test_app_config_schema_shape() {
 }
 
 #[test]
+fn the_app_schema_keeps_instruction_elements_resolved_in_both_array_forms() {
+    let schema = AppConfig::schema();
+    let SchemaType::Struct(app) = &schema.ty else {
+        panic!("expected the app struct");
+    };
+    let SchemaType::Struct(assistant) = &app.fields["assistant"].schema.ty else {
+        panic!("expected the assistant struct");
+    };
+    let SchemaType::Union(instructions) = &assistant.fields["instructions"].schema.ty else {
+        panic!("expected the merge wrapper union");
+    };
+    let SchemaType::Array(bare) = &instructions.variants_types[0].ty else {
+        panic!("expected the bare array");
+    };
+    let SchemaType::Struct(wrapper) = &instructions.variants_types[1].ty else {
+        panic!("expected the wrapper struct");
+    };
+    let SchemaType::Array(wrapped) = &wrapper.fields["value"].schema.ty else {
+        panic!("expected the wrapped array");
+    };
+
+    for element in [&bare.items_type, &wrapped.items_type] {
+        let SchemaType::Struct(instruction) = &element.ty else {
+            panic!("expected the instruction struct");
+        };
+        let fields: Vec<_> = instruction
+            .fields
+            .iter()
+            .map(|(name, field)| {
+                (
+                    name.as_str(),
+                    field.optional,
+                    field.nullable,
+                    field.schema.nullable,
+                )
+            })
+            .collect();
+        assert_eq!(fields, [
+            ("description", false, true, false),
+            ("examples", false, false, false),
+            ("items", false, false, false),
+            ("position", true, false, false),
+            ("title", false, true, false),
+        ]);
+        assert_eq!(element.name.as_deref(), Some("InstructionsConfig"));
+        assert!(
+            instruction.partial,
+            "the nested marker must survive for the partial schema"
+        );
+    }
+}
+
+#[test]
 fn the_partial_schema_keeps_instruction_elements_partial_in_both_array_forms() {
     for input in [
         r#"{"assistant":{"instructions":[{"title":"Review"}]}}"#,

--- a/crates/jp_config/src/lib_tests.rs
+++ b/crates/jp_config/src/lib_tests.rs
@@ -3,7 +3,10 @@ use schematic::PartialConfig as _;
 use test_log::test;
 
 use super::*;
-use crate::assignment::{KvAssignmentError, KvAssignmentErrorKind};
+use crate::{
+    assignment::{KvAssignmentError, KvAssignmentErrorKind},
+    assistant::instructions::PartialInstructionsConfig,
+};
 
 #[test]
 fn test_partial_app_config_empty_serialize() {
@@ -33,6 +36,81 @@ fn test_app_config_fields() {
 #[test]
 fn test_app_config_schema_shape() {
     insta::assert_snapshot!(crate::schema_shape::render(&AppConfig::schema()));
+}
+
+#[test]
+fn the_partial_schema_keeps_instruction_elements_partial_in_both_array_forms() {
+    for input in [
+        r#"{"assistant":{"instructions":[{"title":"Review"}]}}"#,
+        r#"{"assistant":{"instructions":{"value":[{"title":"Review"}]}}}"#,
+    ] {
+        let parsed: PartialAppConfig = serde_json::from_str(input).unwrap();
+        assert_eq!(parsed.assistant.instructions.as_slice(), [
+            PartialInstructionsConfig {
+                title: Some("Review".to_owned()),
+                description: None,
+                position: None,
+                items: None,
+                examples: vec![],
+            }
+        ]);
+    }
+
+    let schema = PartialAppConfig::schema();
+    let SchemaType::Struct(app) = &schema.ty else {
+        panic!("expected the app struct");
+    };
+    let SchemaType::Union(assistant) = &app.fields["assistant"].schema.ty else {
+        panic!("expected a nullable assistant");
+    };
+    let SchemaType::Struct(assistant) = &assistant.variants_types[0].ty else {
+        panic!("expected the assistant struct");
+    };
+    let SchemaType::Union(nullable_instructions) = &assistant.fields["instructions"].schema.ty
+    else {
+        panic!("expected nullable instructions");
+    };
+    let SchemaType::Union(instructions) = &nullable_instructions.variants_types[0].ty else {
+        panic!("expected the merge wrapper union");
+    };
+    let SchemaType::Array(bare) = &instructions.variants_types[0].ty else {
+        panic!("expected the bare array");
+    };
+    let SchemaType::Struct(wrapper) = &instructions.variants_types[1].ty else {
+        panic!("expected the wrapper struct");
+    };
+    let SchemaType::Union(value) = &wrapper.fields["value"].schema.ty else {
+        panic!("expected a nullable wrapper value");
+    };
+    let SchemaType::Array(wrapped) = &value.variants_types[0].ty else {
+        panic!("expected the wrapped array");
+    };
+
+    for element in [&bare.items_type, &wrapped.items_type] {
+        let SchemaType::Struct(instruction) = &element.ty else {
+            panic!("expected the instruction struct");
+        };
+        let fields: Vec<_> = instruction
+            .fields
+            .iter()
+            .map(|(name, field)| {
+                (
+                    name.as_str(),
+                    field.optional,
+                    field.nullable,
+                    field.schema.nullable,
+                )
+            })
+            .collect();
+        assert_eq!(fields, [
+            ("description", true, true, true),
+            ("examples", true, true, true),
+            ("items", true, true, true),
+            ("position", true, true, true),
+            ("title", true, true, true),
+        ]);
+        assert_eq!(element.name.as_deref(), Some("PartialInstructionsConfig"));
+    }
 }
 
 /// A reference has to name a type the partial schema still contains.

--- a/crates/jp_config/src/snapshots/jp_config__tests__app_config_schema_shape.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__app_config_schema_shape.snap
@@ -5,39 +5,35 @@ expression: "crate::schema_shape::render(&AppConfig::schema())"
 assistant: AssistantConfig
   instructions?: MergeableVec
     |:
-      []: PartialInstructionsConfig
-        description?: string | null
-        examples?:
-          |:
-            []: PartialExampleConfig
-              |: string
-              |: PartialContrastConfig
-                bad?: string | null
-                good?: string | null
-                reason?: string | null
-          |: null
-        items?: [string] | null
-        position?: int | null
-        title?: string | null
+      []: InstructionsConfig
+        description: string | null
+        examples:
+          []: ExampleConfig
+            |: string
+            |: ContrastConfig
+              bad: string
+              good: string
+              reason: string | null
+        items: [string]
+        position?: int
+        title: string | null
     |: MergedVec
       dedup?: "inherit" | "true" | "false" | bool | null
       discard_when_merged?: bool
       strategy?: "append" | "prepend" | "replace" | null
       value?:
-        []: PartialInstructionsConfig
-          description?: string | null
-          examples?:
-            |:
-              []: PartialExampleConfig
-                |: string
-                |: PartialContrastConfig
-                  bad?: string | null
-                  good?: string | null
-                  reason?: string | null
-            |: null
-          items?: [string] | null
-          position?: int | null
-          title?: string | null
+        []: InstructionsConfig
+          description: string | null
+          examples:
+            []: ExampleConfig
+              |: string
+              |: ContrastConfig
+                bad: string
+                good: string
+                reason: string | null
+          items: [string]
+          position?: int
+          title: string | null
   model: ModelConfig
     id: ModelIdOrAliasConfig
       |: ModelIdConfig
@@ -79,100 +75,90 @@ assistant: AssistantConfig
       value?: string
   system_prompt_sections?: MergeableVec
     |:
-      []: PartialSectionConfig
-        content?: string | null
-        position?: int | null
-        tag?: string | null
-        title?: string | null
+      []: SectionConfig
+        content: string
+        position?: int
+        tag: string | null
+        title: string | null
     |: MergedVec
       dedup?: "inherit" | "true" | "false" | bool | null
       discard_when_merged?: bool
       strategy?: "append" | "prepend" | "replace" | null
       value?:
-        []: PartialSectionConfig
-          content?: string | null
-          position?: int | null
-          tag?: string | null
-          title?: string | null
+        []: SectionConfig
+          content: string
+          position?: int
+          tag: string | null
+          title: string | null
   tool_choice?: "auto" | "none" | "required" | string
 config_load_paths: [string]
 conversation: ConversationConfig
   attachments?: MergeableVec
     |:
-      []: PartialAttachmentConfig
+      []: AttachmentConfig
         |: string
-        |: PartialAttachmentObjectConfig
-          params?:
-            |:
-              *: unknown
-            |: null
-          path?: string | null
-          type?: string | null
+        |: AttachmentObjectConfig
+          params:
+            *: unknown
+          path: string
+          type: string
     |: MergedVec
       dedup?: "inherit" | "true" | "false" | bool | null
       discard_when_merged?: bool
       strategy?: "append" | "prepend" | "replace" | null
       value?:
-        []: PartialAttachmentConfig
+        []: AttachmentConfig
           |: string
-          |: PartialAttachmentObjectConfig
-            params?:
-              |:
-                *: unknown
-              |: null
-            path?: string | null
-            type?: string | null
+          |: AttachmentObjectConfig
+            params:
+              *: unknown
+            path: string
+            type: string
   compaction: CompactionConfig
     rules?: MergeableVec
       |:
-        []: PartialCompactionRuleConfig
-          keep_first?: int | string | null
-          keep_last?: int | string | null
-          reasoning?:
+        []: CompactionRuleConfig
+          keep_first?: int | string
+          keep_last?: int | string
+          reasoning:
             |:
               |: "strip"
               |:
                 over: int | string
                 policy: "strip"
             |: null
-          summary?:
-            |: PartialSummaryConfig
-              context?: string | null
-              instructions?: string | null
-              model?:
-                |: PartialModelConfig
-                  id?:
-                    |: PartialModelIdOrAliasConfig
-                      |: PartialModelIdConfig
-                        name?: string | null
-                        provider?: "anthropic" | "cerebras" | "deepseek" | "google" | "llamacpp" | "ollama" | "openai" | "openrouter" | "xai" | null
-                      |: string
-                    |: null
-                  parameters?:
-                    |: PartialParametersConfig
-                      max_tokens?: int | null
-                      other?:
-                        |:
-                          *: unknown
-                        |: null
-                      reasoning?:
-                        |: PartialReasoningConfig
-                          |: "off"
-                          |: "auto"
-                          |: PartialCustomReasoningConfig
-                            effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string | null
-                            exclude?: bool | null
-                        |: null
-                      service_tier?: "off" | "flex" | "standard" | "priority" | null
-                      stop_words?: [string] | null
-                      temperature?: float | null
-                      top_k?: int | null
-                      top_p?: float | null
-                    |: null
+          summary:
+            |: SummaryConfig
+              context: string | null
+              instructions: string | null
+              model:
+                |: ModelConfig
+                  id: ModelIdOrAliasConfig
+                    |: ModelIdConfig
+                      name: string
+                      provider: "anthropic" | "cerebras" | "deepseek" | "google" | "llamacpp" | "ollama" | "openai" | "openrouter" | "xai"
+                    |: string
+                  parameters: ParametersConfig
+                    max_tokens: int | null
+                    other?:
+                      *: unknown
+                    reasoning:
+                      |: ReasoningConfig
+                        |: "off"
+                        |: "auto"
+                        |: CustomReasoningConfig
+                          effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string
+                          exclude?: bool
+                      |: null
+                    service_tier: "off" | "flex" | "standard" | "priority" | null
+                    stop_words?: [string]
+                    temperature: float | null
+                    top_k: int | null
+                    top_p: float | null
                 |: null
-              text?: string | null
+              text: string | null
             |: null
-          tool_calls?:
+          tool_calls:
             |:
               |: "strip" (aka s) | "strip-responses" (aka strip_responses, sres) | "strip-requests" (aka strip_requests, sreq) | "omit" (aka o)
               |:
@@ -184,54 +170,48 @@ conversation: ConversationConfig
         discard_when_merged?: bool
         strategy?: "append" | "prepend" | "replace" | null
         value?:
-          []: PartialCompactionRuleConfig
-            keep_first?: int | string | null
-            keep_last?: int | string | null
-            reasoning?:
+          []: CompactionRuleConfig
+            keep_first?: int | string
+            keep_last?: int | string
+            reasoning:
               |:
                 |: "strip"
                 |:
                   over: int | string
                   policy: "strip"
               |: null
-            summary?:
-              |: PartialSummaryConfig
-                context?: string | null
-                instructions?: string | null
-                model?:
-                  |: PartialModelConfig
-                    id?:
-                      |: PartialModelIdOrAliasConfig
-                        |: PartialModelIdConfig
-                          name?: string | null
-                          provider?: "anthropic" | "cerebras" | "deepseek" | "google" | "llamacpp" | "ollama" | "openai" | "openrouter" | "xai" | null
-                        |: string
-                      |: null
-                    parameters?:
-                      |: PartialParametersConfig
-                        max_tokens?: int | null
-                        other?:
-                          |:
-                            *: unknown
-                          |: null
-                        reasoning?:
-                          |: PartialReasoningConfig
-                            |: "off"
-                            |: "auto"
-                            |: PartialCustomReasoningConfig
-                              effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string | null
-                              exclude?: bool | null
-                          |: null
-                        service_tier?: "off" | "flex" | "standard" | "priority" | null
-                        stop_words?: [string] | null
-                        temperature?: float | null
-                        top_k?: int | null
-                        top_p?: float | null
-                      |: null
+            summary:
+              |: SummaryConfig
+                context: string | null
+                instructions: string | null
+                model:
+                  |: ModelConfig
+                    id: ModelIdOrAliasConfig
+                      |: ModelIdConfig
+                        name: string
+                        provider: "anthropic" | "cerebras" | "deepseek" | "google" | "llamacpp" | "ollama" | "openai" | "openrouter" | "xai"
+                      |: string
+                    parameters: ParametersConfig
+                      max_tokens: int | null
+                      other?:
+                        *: unknown
+                      reasoning:
+                        |: ReasoningConfig
+                          |: "off"
+                          |: "auto"
+                          |: CustomReasoningConfig
+                            effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string
+                            exclude?: bool
+                        |: null
+                      service_tier: "off" | "flex" | "standard" | "priority" | null
+                      stop_words?: [string]
+                      temperature: float | null
+                      top_k: int | null
+                      top_p: float | null
                   |: null
-                text?: string | null
+                text: string | null
               |: null
-            tool_calls?:
+            tool_calls:
               |:
                 |: "strip" (aka s) | "strip-responses" (aka strip_responses, sres) | "strip-requests" (aka strip_requests, sreq) | "omit" (aka o)
                 |:
@@ -243,39 +223,35 @@ conversation: ConversationConfig
     assistant: AssistantConfig
       instructions?: MergeableVec
         |:
-          []: PartialInstructionsConfig
-            description?: string | null
-            examples?:
-              |:
-                []: PartialExampleConfig
-                  |: string
-                  |: PartialContrastConfig
-                    bad?: string | null
-                    good?: string | null
-                    reason?: string | null
-              |: null
-            items?: [string] | null
-            position?: int | null
-            title?: string | null
+          []: InstructionsConfig
+            description: string | null
+            examples:
+              []: ExampleConfig
+                |: string
+                |: ContrastConfig
+                  bad: string
+                  good: string
+                  reason: string | null
+            items: [string]
+            position?: int
+            title: string | null
         |: MergedVec
           dedup?: "inherit" | "true" | "false" | bool | null
           discard_when_merged?: bool
           strategy?: "append" | "prepend" | "replace" | null
           value?:
-            []: PartialInstructionsConfig
-              description?: string | null
-              examples?:
-                |:
-                  []: PartialExampleConfig
-                    |: string
-                    |: PartialContrastConfig
-                      bad?: string | null
-                      good?: string | null
-                      reason?: string | null
-                |: null
-              items?: [string] | null
-              position?: int | null
-              title?: string | null
+            []: InstructionsConfig
+              description: string | null
+              examples:
+                []: ExampleConfig
+                  |: string
+                  |: ContrastConfig
+                    bad: string
+                    good: string
+                    reason: string | null
+              items: [string]
+              position?: int
+              title: string | null
       model: ModelConfig
         id: ModelIdOrAliasConfig
           |: ModelIdConfig
@@ -317,21 +293,21 @@ conversation: ConversationConfig
           value?: string
       system_prompt_sections?: MergeableVec
         |:
-          []: PartialSectionConfig
-            content?: string | null
-            position?: int | null
-            tag?: string | null
-            title?: string | null
+          []: SectionConfig
+            content: string
+            position?: int
+            tag: string | null
+            title: string | null
         |: MergedVec
           dedup?: "inherit" | "true" | "false" | bool | null
           discard_when_merged?: bool
           strategy?: "append" | "prepend" | "replace" | null
           value?:
-            []: PartialSectionConfig
-              content?: string | null
-              position?: int | null
-              tag?: string | null
-              title?: string | null
+            []: SectionConfig
+              content: string
+              position?: int
+              tag: string | null
+              title: string | null
       tool_choice?: "auto" | "none" | "required" | string
   labels: MergeableMap
     |:
@@ -413,42 +389,42 @@ conversation: ConversationConfig
         |: AccessConfig
           env: MergeableVec
             |:
-              []: PartialEnvRuleConfig
-                name?: string | null
-                read?: bool | null
+              []: EnvRuleConfig
+                name: string
+                read: bool | null
             |: MergedVec
               dedup?: "inherit" | "true" | "false" | bool | null
               discard_when_merged?: bool
               strategy?: "append" | "prepend" | "replace" | null
               value?:
-                []: PartialEnvRuleConfig
-                  name?: string | null
-                  read?: bool | null
+                []: EnvRuleConfig
+                  name: string
+                  read: bool | null
           fs: MergeableVec
             |:
-              []: PartialFsRuleConfig
-                create?: bool | null
-                delete?: bool | null
-                execute?: bool | null
-                external?: bool | null
-                path?: string | null
-                read?: bool | null
-                update?: bool | null
-                write?: bool | null
+              []: FsRuleConfig
+                create: bool | null
+                delete: bool | null
+                execute: bool | null
+                external: bool | null
+                path: string
+                read: bool | null
+                update: bool | null
+                write: bool | null
             |: MergedVec
               dedup?: "inherit" | "true" | "false" | bool | null
               discard_when_merged?: bool
               strategy?: "append" | "prepend" | "replace" | null
               value?:
-                []: PartialFsRuleConfig
-                  create?: bool | null
-                  delete?: bool | null
-                  execute?: bool | null
-                  external?: bool | null
-                  path?: string | null
-                  read?: bool | null
-                  update?: bool | null
-                  write?: bool | null
+                []: FsRuleConfig
+                  create: bool | null
+                  delete: bool | null
+                  execute: bool | null
+                  external: bool | null
+                  path: string
+                  read: bool | null
+                  update: bool | null
+                  write: bool | null
         |: null
       cancellation_response?: string
       enable:
@@ -486,42 +462,42 @@ conversation: ConversationConfig
           |: AccessConfig
             env: MergeableVec
               |:
-                []: PartialEnvRuleConfig
-                  name?: string | null
-                  read?: bool | null
+                []: EnvRuleConfig
+                  name: string
+                  read: bool | null
               |: MergedVec
                 dedup?: "inherit" | "true" | "false" | bool | null
                 discard_when_merged?: bool
                 strategy?: "append" | "prepend" | "replace" | null
                 value?:
-                  []: PartialEnvRuleConfig
-                    name?: string | null
-                    read?: bool | null
+                  []: EnvRuleConfig
+                    name: string
+                    read: bool | null
             fs: MergeableVec
               |:
-                []: PartialFsRuleConfig
-                  create?: bool | null
-                  delete?: bool | null
-                  execute?: bool | null
-                  external?: bool | null
-                  path?: string | null
-                  read?: bool | null
-                  update?: bool | null
-                  write?: bool | null
+                []: FsRuleConfig
+                  create: bool | null
+                  delete: bool | null
+                  execute: bool | null
+                  external: bool | null
+                  path: string
+                  read: bool | null
+                  update: bool | null
+                  write: bool | null
               |: MergedVec
                 dedup?: "inherit" | "true" | "false" | bool | null
                 discard_when_merged?: bool
                 strategy?: "append" | "prepend" | "replace" | null
                 value?:
-                  []: PartialFsRuleConfig
-                    create?: bool | null
-                    delete?: bool | null
-                    execute?: bool | null
-                    external?: bool | null
-                    path?: string | null
-                    read?: bool | null
-                    update?: bool | null
-                    write?: bool | null
+                  []: FsRuleConfig
+                    create: bool | null
+                    delete: bool | null
+                    execute: bool | null
+                    external: bool | null
+                    path: string
+                    read: bool | null
+                    update: bool | null
+                    write: bool | null
           |: null
         cancellation_response: string | null
         command:

--- a/crates/jp_config/src/snapshots/jp_config__tests__app_config_schema_shape.snap
+++ b/crates/jp_config/src/snapshots/jp_config__tests__app_config_schema_shape.snap
@@ -5,35 +5,39 @@ expression: "crate::schema_shape::render(&AppConfig::schema())"
 assistant: AssistantConfig
   instructions?: MergeableVec
     |:
-      []: InstructionsConfig
-        description: string | null
-        examples:
-          []: ExampleConfig
-            |: string
-            |: ContrastConfig
-              bad: string
-              good: string
-              reason: string | null
-        items: [string]
-        position?: int
-        title: string | null
+      []: PartialInstructionsConfig
+        description?: string | null
+        examples?:
+          |:
+            []: PartialExampleConfig
+              |: string
+              |: PartialContrastConfig
+                bad?: string | null
+                good?: string | null
+                reason?: string | null
+          |: null
+        items?: [string] | null
+        position?: int | null
+        title?: string | null
     |: MergedVec
       dedup?: "inherit" | "true" | "false" | bool | null
       discard_when_merged?: bool
       strategy?: "append" | "prepend" | "replace" | null
       value?:
-        []: InstructionsConfig
-          description: string | null
-          examples:
-            []: ExampleConfig
-              |: string
-              |: ContrastConfig
-                bad: string
-                good: string
-                reason: string | null
-          items: [string]
-          position?: int
-          title: string | null
+        []: PartialInstructionsConfig
+          description?: string | null
+          examples?:
+            |:
+              []: PartialExampleConfig
+                |: string
+                |: PartialContrastConfig
+                  bad?: string | null
+                  good?: string | null
+                  reason?: string | null
+            |: null
+          items?: [string] | null
+          position?: int | null
+          title?: string | null
   model: ModelConfig
     id: ModelIdOrAliasConfig
       |: ModelIdConfig
@@ -75,90 +79,100 @@ assistant: AssistantConfig
       value?: string
   system_prompt_sections?: MergeableVec
     |:
-      []: SectionConfig
-        content: string
-        position?: int
-        tag: string | null
-        title: string | null
+      []: PartialSectionConfig
+        content?: string | null
+        position?: int | null
+        tag?: string | null
+        title?: string | null
     |: MergedVec
       dedup?: "inherit" | "true" | "false" | bool | null
       discard_when_merged?: bool
       strategy?: "append" | "prepend" | "replace" | null
       value?:
-        []: SectionConfig
-          content: string
-          position?: int
-          tag: string | null
-          title: string | null
+        []: PartialSectionConfig
+          content?: string | null
+          position?: int | null
+          tag?: string | null
+          title?: string | null
   tool_choice?: "auto" | "none" | "required" | string
 config_load_paths: [string]
 conversation: ConversationConfig
   attachments?: MergeableVec
     |:
-      []: AttachmentConfig
+      []: PartialAttachmentConfig
         |: string
-        |: AttachmentObjectConfig
-          params:
-            *: unknown
-          path: string
-          type: string
+        |: PartialAttachmentObjectConfig
+          params?:
+            |:
+              *: unknown
+            |: null
+          path?: string | null
+          type?: string | null
     |: MergedVec
       dedup?: "inherit" | "true" | "false" | bool | null
       discard_when_merged?: bool
       strategy?: "append" | "prepend" | "replace" | null
       value?:
-        []: AttachmentConfig
+        []: PartialAttachmentConfig
           |: string
-          |: AttachmentObjectConfig
-            params:
-              *: unknown
-            path: string
-            type: string
+          |: PartialAttachmentObjectConfig
+            params?:
+              |:
+                *: unknown
+              |: null
+            path?: string | null
+            type?: string | null
   compaction: CompactionConfig
     rules?: MergeableVec
       |:
-        []: CompactionRuleConfig
-          keep_first?: int | string
-          keep_last?: int | string
-          reasoning:
+        []: PartialCompactionRuleConfig
+          keep_first?: int | string | null
+          keep_last?: int | string | null
+          reasoning?:
             |:
               |: "strip"
               |:
                 over: int | string
                 policy: "strip"
             |: null
-          summary:
-            |: SummaryConfig
-              context: string | null
-              instructions: string | null
-              model:
-                |: ModelConfig
-                  id: ModelIdOrAliasConfig
-                    |: ModelIdConfig
-                      name: string
-                      provider: "anthropic" | "cerebras" | "deepseek" | "google" | "llamacpp" | "ollama" | "openai" | "openrouter" | "xai"
-                    |: string
-                  parameters: ParametersConfig
-                    max_tokens: int | null
-                    other?:
-                      *: unknown
-                    reasoning:
-                      |: ReasoningConfig
-                        |: "off"
-                        |: "auto"
-                        |: CustomReasoningConfig
-                          effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string
-                          exclude?: bool
-                      |: null
-                    service_tier: "off" | "flex" | "standard" | "priority" | null
-                    stop_words?: [string]
-                    temperature: float | null
-                    top_k: int | null
-                    top_p: float | null
+          summary?:
+            |: PartialSummaryConfig
+              context?: string | null
+              instructions?: string | null
+              model?:
+                |: PartialModelConfig
+                  id?:
+                    |: PartialModelIdOrAliasConfig
+                      |: PartialModelIdConfig
+                        name?: string | null
+                        provider?: "anthropic" | "cerebras" | "deepseek" | "google" | "llamacpp" | "ollama" | "openai" | "openrouter" | "xai" | null
+                      |: string
+                    |: null
+                  parameters?:
+                    |: PartialParametersConfig
+                      max_tokens?: int | null
+                      other?:
+                        |:
+                          *: unknown
+                        |: null
+                      reasoning?:
+                        |: PartialReasoningConfig
+                          |: "off"
+                          |: "auto"
+                          |: PartialCustomReasoningConfig
+                            effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string | null
+                            exclude?: bool | null
+                        |: null
+                      service_tier?: "off" | "flex" | "standard" | "priority" | null
+                      stop_words?: [string] | null
+                      temperature?: float | null
+                      top_k?: int | null
+                      top_p?: float | null
+                    |: null
                 |: null
-              text: string | null
+              text?: string | null
             |: null
-          tool_calls:
+          tool_calls?:
             |:
               |: "strip" (aka s) | "strip-responses" (aka strip_responses, sres) | "strip-requests" (aka strip_requests, sreq) | "omit" (aka o)
               |:
@@ -170,48 +184,54 @@ conversation: ConversationConfig
         discard_when_merged?: bool
         strategy?: "append" | "prepend" | "replace" | null
         value?:
-          []: CompactionRuleConfig
-            keep_first?: int | string
-            keep_last?: int | string
-            reasoning:
+          []: PartialCompactionRuleConfig
+            keep_first?: int | string | null
+            keep_last?: int | string | null
+            reasoning?:
               |:
                 |: "strip"
                 |:
                   over: int | string
                   policy: "strip"
               |: null
-            summary:
-              |: SummaryConfig
-                context: string | null
-                instructions: string | null
-                model:
-                  |: ModelConfig
-                    id: ModelIdOrAliasConfig
-                      |: ModelIdConfig
-                        name: string
-                        provider: "anthropic" | "cerebras" | "deepseek" | "google" | "llamacpp" | "ollama" | "openai" | "openrouter" | "xai"
-                      |: string
-                    parameters: ParametersConfig
-                      max_tokens: int | null
-                      other?:
-                        *: unknown
-                      reasoning:
-                        |: ReasoningConfig
-                          |: "off"
-                          |: "auto"
-                          |: CustomReasoningConfig
-                            effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string
-                            exclude?: bool
-                        |: null
-                      service_tier: "off" | "flex" | "standard" | "priority" | null
-                      stop_words?: [string]
-                      temperature: float | null
-                      top_k: int | null
-                      top_p: float | null
+            summary?:
+              |: PartialSummaryConfig
+                context?: string | null
+                instructions?: string | null
+                model?:
+                  |: PartialModelConfig
+                    id?:
+                      |: PartialModelIdOrAliasConfig
+                        |: PartialModelIdConfig
+                          name?: string | null
+                          provider?: "anthropic" | "cerebras" | "deepseek" | "google" | "llamacpp" | "ollama" | "openai" | "openrouter" | "xai" | null
+                        |: string
+                      |: null
+                    parameters?:
+                      |: PartialParametersConfig
+                        max_tokens?: int | null
+                        other?:
+                          |:
+                            *: unknown
+                          |: null
+                        reasoning?:
+                          |: PartialReasoningConfig
+                            |: "off"
+                            |: "auto"
+                            |: PartialCustomReasoningConfig
+                              effort?: "none" | "auto" | "max" | "xhigh" | "high" | "medium" | "low" | "xlow" | string | null
+                              exclude?: bool | null
+                          |: null
+                        service_tier?: "off" | "flex" | "standard" | "priority" | null
+                        stop_words?: [string] | null
+                        temperature?: float | null
+                        top_k?: int | null
+                        top_p?: float | null
+                      |: null
                   |: null
-                text: string | null
+                text?: string | null
               |: null
-            tool_calls:
+            tool_calls?:
               |:
                 |: "strip" (aka s) | "strip-responses" (aka strip_responses, sres) | "strip-requests" (aka strip_requests, sreq) | "omit" (aka o)
                 |:
@@ -223,35 +243,39 @@ conversation: ConversationConfig
     assistant: AssistantConfig
       instructions?: MergeableVec
         |:
-          []: InstructionsConfig
-            description: string | null
-            examples:
-              []: ExampleConfig
-                |: string
-                |: ContrastConfig
-                  bad: string
-                  good: string
-                  reason: string | null
-            items: [string]
-            position?: int
-            title: string | null
+          []: PartialInstructionsConfig
+            description?: string | null
+            examples?:
+              |:
+                []: PartialExampleConfig
+                  |: string
+                  |: PartialContrastConfig
+                    bad?: string | null
+                    good?: string | null
+                    reason?: string | null
+              |: null
+            items?: [string] | null
+            position?: int | null
+            title?: string | null
         |: MergedVec
           dedup?: "inherit" | "true" | "false" | bool | null
           discard_when_merged?: bool
           strategy?: "append" | "prepend" | "replace" | null
           value?:
-            []: InstructionsConfig
-              description: string | null
-              examples:
-                []: ExampleConfig
-                  |: string
-                  |: ContrastConfig
-                    bad: string
-                    good: string
-                    reason: string | null
-              items: [string]
-              position?: int
-              title: string | null
+            []: PartialInstructionsConfig
+              description?: string | null
+              examples?:
+                |:
+                  []: PartialExampleConfig
+                    |: string
+                    |: PartialContrastConfig
+                      bad?: string | null
+                      good?: string | null
+                      reason?: string | null
+                |: null
+              items?: [string] | null
+              position?: int | null
+              title?: string | null
       model: ModelConfig
         id: ModelIdOrAliasConfig
           |: ModelIdConfig
@@ -293,21 +317,21 @@ conversation: ConversationConfig
           value?: string
       system_prompt_sections?: MergeableVec
         |:
-          []: SectionConfig
-            content: string
-            position?: int
-            tag: string | null
-            title: string | null
+          []: PartialSectionConfig
+            content?: string | null
+            position?: int | null
+            tag?: string | null
+            title?: string | null
         |: MergedVec
           dedup?: "inherit" | "true" | "false" | bool | null
           discard_when_merged?: bool
           strategy?: "append" | "prepend" | "replace" | null
           value?:
-            []: SectionConfig
-              content: string
-              position?: int
-              tag: string | null
-              title: string | null
+            []: PartialSectionConfig
+              content?: string | null
+              position?: int | null
+              tag?: string | null
+              title?: string | null
       tool_choice?: "auto" | "none" | "required" | string
   labels: MergeableMap
     |:
@@ -389,42 +413,42 @@ conversation: ConversationConfig
         |: AccessConfig
           env: MergeableVec
             |:
-              []: EnvRuleConfig
-                name: string
-                read: bool | null
+              []: PartialEnvRuleConfig
+                name?: string | null
+                read?: bool | null
             |: MergedVec
               dedup?: "inherit" | "true" | "false" | bool | null
               discard_when_merged?: bool
               strategy?: "append" | "prepend" | "replace" | null
               value?:
-                []: EnvRuleConfig
-                  name: string
-                  read: bool | null
+                []: PartialEnvRuleConfig
+                  name?: string | null
+                  read?: bool | null
           fs: MergeableVec
             |:
-              []: FsRuleConfig
-                create: bool | null
-                delete: bool | null
-                execute: bool | null
-                external: bool | null
-                path: string
-                read: bool | null
-                update: bool | null
-                write: bool | null
+              []: PartialFsRuleConfig
+                create?: bool | null
+                delete?: bool | null
+                execute?: bool | null
+                external?: bool | null
+                path?: string | null
+                read?: bool | null
+                update?: bool | null
+                write?: bool | null
             |: MergedVec
               dedup?: "inherit" | "true" | "false" | bool | null
               discard_when_merged?: bool
               strategy?: "append" | "prepend" | "replace" | null
               value?:
-                []: FsRuleConfig
-                  create: bool | null
-                  delete: bool | null
-                  execute: bool | null
-                  external: bool | null
-                  path: string
-                  read: bool | null
-                  update: bool | null
-                  write: bool | null
+                []: PartialFsRuleConfig
+                  create?: bool | null
+                  delete?: bool | null
+                  execute?: bool | null
+                  external?: bool | null
+                  path?: string | null
+                  read?: bool | null
+                  update?: bool | null
+                  write?: bool | null
         |: null
       cancellation_response?: string
       enable:
@@ -462,42 +486,42 @@ conversation: ConversationConfig
           |: AccessConfig
             env: MergeableVec
               |:
-                []: EnvRuleConfig
-                  name: string
-                  read: bool | null
+                []: PartialEnvRuleConfig
+                  name?: string | null
+                  read?: bool | null
               |: MergedVec
                 dedup?: "inherit" | "true" | "false" | bool | null
                 discard_when_merged?: bool
                 strategy?: "append" | "prepend" | "replace" | null
                 value?:
-                  []: EnvRuleConfig
-                    name: string
-                    read: bool | null
+                  []: PartialEnvRuleConfig
+                    name?: string | null
+                    read?: bool | null
             fs: MergeableVec
               |:
-                []: FsRuleConfig
-                  create: bool | null
-                  delete: bool | null
-                  execute: bool | null
-                  external: bool | null
-                  path: string
-                  read: bool | null
-                  update: bool | null
-                  write: bool | null
+                []: PartialFsRuleConfig
+                  create?: bool | null
+                  delete?: bool | null
+                  execute?: bool | null
+                  external?: bool | null
+                  path?: string | null
+                  read?: bool | null
+                  update?: bool | null
+                  write?: bool | null
               |: MergedVec
                 dedup?: "inherit" | "true" | "false" | bool | null
                 discard_when_merged?: bool
                 strategy?: "append" | "prepend" | "replace" | null
                 value?:
-                  []: FsRuleConfig
-                    create: bool | null
-                    delete: bool | null
-                    execute: bool | null
-                    external: bool | null
-                    path: string
-                    read: bool | null
-                    update: bool | null
-                    write: bool | null
+                  []: PartialFsRuleConfig
+                    create?: bool | null
+                    delete?: bool | null
+                    execute?: bool | null
+                    external?: bool | null
+                    path?: string | null
+                    read?: bool | null
+                    update?: bool | null
+                    write?: bool | null
           |: null
         cancellation_response: string | null
         command:
@@ -542,36 +566,40 @@ conversation: ConversationConfig
                 instructions?:
                   |: PartialMergeableVec
                     |:
-                      []: InstructionsConfig
-                        description: string | null
-                        examples:
-                          []: PartialExampleConfig
-                            |: string
-                            |: PartialContrastConfig
-                              bad?: string | null
-                              good?: string | null
-                              reason?: string | null
-                        items: [string]
-                        position?: int
-                        title: string | null
+                      []: PartialInstructionsConfig
+                        description?: string | null
+                        examples?:
+                          |:
+                            []: PartialExampleConfig
+                              |: string
+                              |: PartialContrastConfig
+                                bad?: string | null
+                                good?: string | null
+                                reason?: string | null
+                          |: null
+                        items?: [string] | null
+                        position?: int | null
+                        title?: string | null
                     |: PartialMergedVec
                       dedup?: "inherit" | "true" | "false" | bool | null | null
                       discard_when_merged?: bool | null
                       strategy?: "append" | "prepend" | "replace" | null
                       value?:
                         |:
-                          []: InstructionsConfig
-                            description: string | null
-                            examples:
-                              []: PartialExampleConfig
-                                |: string
-                                |: PartialContrastConfig
-                                  bad?: string | null
-                                  good?: string | null
-                                  reason?: string | null
-                            items: [string]
-                            position?: int
-                            title: string | null
+                          []: PartialInstructionsConfig
+                            description?: string | null
+                            examples?:
+                              |:
+                                []: PartialExampleConfig
+                                  |: string
+                                  |: PartialContrastConfig
+                                    bad?: string | null
+                                    good?: string | null
+                                    reason?: string | null
+                              |: null
+                            items?: [string] | null
+                            position?: int | null
+                            title?: string | null
                         |: null
                   |: null
                 model?:
@@ -628,22 +656,22 @@ conversation: ConversationConfig
                 system_prompt_sections?:
                   |: PartialMergeableVec
                     |:
-                      []: SectionConfig
-                        content: string
-                        position?: int
-                        tag: string | null
-                        title: string | null
+                      []: PartialSectionConfig
+                        content?: string | null
+                        position?: int | null
+                        tag?: string | null
+                        title?: string | null
                     |: PartialMergedVec
                       dedup?: "inherit" | "true" | "false" | bool | null | null
                       discard_when_merged?: bool | null
                       strategy?: "append" | "prepend" | "replace" | null
                       value?:
                         |:
-                          []: SectionConfig
-                            content: string
-                            position?: int
-                            tag: string | null
-                            title: string | null
+                          []: PartialSectionConfig
+                            content?: string | null
+                            position?: int | null
+                            tag?: string | null
+                            title?: string | null
                         |: null
                   |: null
                 tool_choice?: "auto" | "none" | "required" | string | null
@@ -723,6 +751,7 @@ providers: ProviderConfig
         |: string
     anthropic: AnthropicConfig
       api_key_env?: string
+      auth?: [string]
       base_url?: string
       beta_headers?: [string]
       chain_on_max_tokens?: bool


### PR DESCRIPTION
The config schema describes nested collection elements as partial in both bare lists and merge wrappers, so schema consumers do not require fields that a config layer may omit. Configuration loading and merge behavior are unchanged.

Fields with literal defaults retain their additional input shapes. The default belongs to the inferred variant and must not replace the union built by `schema_union_with`.

Refs: #1159