### PR TITLE
fix(md): Preserve reference-link definitions

### DIFF
--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -19,6 +19,81 @@ fn create_renderer() -> (ChatRenderer, SharedBuffer, SharedBuffer) {
     create_renderer_with_config(AppConfig::new_test())
 }
 
+#[test]
+fn reference_definition_remains_visible_after_its_paragraph_streams() {
+    let (printer, out, err) = Printer::memory(OutputFormat::TextPretty);
+    let mut renderer = ChatRenderer::new(
+        Arc::new(printer.clone()),
+        AppConfig::new_test().style,
+        RenderFlow::Live,
+    );
+
+    renderer.render_response(&ChatResponse::Message {
+        message: "Read [the documentation][docs].\n\n".into(),
+    });
+    printer.flush();
+    assert_eq!(*out.lock(), "Read [the documentation][docs].\n\n");
+
+    renderer.render_response(&ChatResponse::Message {
+        message: "[docs]: https://example.com/documentation\n".into(),
+    });
+    renderer.flush();
+    printer.flush();
+
+    assert_eq!(
+        *out.lock(),
+        "Read [the documentation][docs].\n\n[docs]: https://example.com/documentation\n\n"
+    );
+    assert_eq!(*err.lock(), "");
+}
+
+#[test]
+fn reference_definitions_render_identically_whole_or_fragmented() {
+    let source = "Read [the documentation][docs].\n\n[docs]:\n  <https://example.com/a_b>\n  \"A \
+                  *literal* title\"\n[other]: /other";
+    let expected = "Read [the documentation][docs].\n\n[docs]:\n  <https://example.com/a_b>\n  \
+                    \"A *literal* title\"\n[other]: /other\n\n";
+
+    let (mut renderer, out, _) = create_renderer();
+    renderer.render_response(&ChatResponse::Message {
+        message: source.into(),
+    });
+    renderer.flush();
+    renderer.printer.flush();
+    assert_eq!(*out.lock(), expected);
+
+    let (mut renderer, out, _) = create_renderer();
+    for ch in source.chars() {
+        renderer.render_response(&ChatResponse::Message {
+            message: ch.to_string(),
+        });
+    }
+    renderer.flush();
+    renderer.printer.flush();
+    assert_eq!(*out.lock(), expected);
+}
+
+#[test]
+fn reference_definition_waits_for_its_multiline_title() {
+    let (mut renderer, out, _) = create_renderer();
+    renderer.render_response(&ChatResponse::Message {
+        message: "[docs]: https://example.com\n  \"A title that continues\n".into(),
+    });
+    renderer.printer.flush();
+    assert_eq!(*out.lock(), "");
+
+    renderer.render_response(&ChatResponse::Message {
+        message: "  on another line\"\n\nAfter.\n\n".into(),
+    });
+    renderer.flush();
+    renderer.printer.flush();
+    assert_eq!(
+        *out.lock(),
+        "[docs]: https://example.com\n  \"A title that continues\n  on another \
+         line\"\n\nAfter.\n\n"
+    );
+}
+
 // The gap that spaces a tool call's chrome from the content after it is chrome
 // itself: the chrome is on the error stream, so a stdout captured on its own
 // must not carry a blank line standing in for something that never landed

--- a/crates/jp_md/src/buffer.rs
+++ b/crates/jp_md/src/buffer.rs
@@ -18,6 +18,10 @@
 //! non-streaming buffering emits, so a consumer that re-renders the accumulated
 //! source produces byte-identical output.
 //!
+//! Reference-definition candidates wait for a block boundary so multiline
+//! labels and titles stay together.
+//! This also applies inside blockquotes.
+//!
 //! GFM tables do not stream: their column widths depend on later rows, so a
 //! table is kept whole, detected by the leading pipe on its header row.
 //!
@@ -266,6 +270,9 @@ impl Buffer {
     /// With it disabled the buffer emits each paragraph as a single
     /// [`Event::Block`] once a terminator is seen, never an
     /// [`Event::ParagraphChunk`].
+    ///
+    /// Potential reference definitions wait for a block boundary even when
+    /// streaming is enabled, since their labels and titles may span lines.
     ///
     /// Streamed output is byte-identical to whole-paragraph buffering except
     /// for two edge cases, neither produced by assistant output: an
@@ -549,11 +556,6 @@ impl Buffer {
             return (Some(Event::block(block)), State::AtBoundary); // Stay at boundary
         }
 
-        if indent_len <= 3 && is_link_ref_def(line_content) {
-            let block: String = self.data.drain(..=first_line_end).collect();
-            return (Some(Event::block(block)), State::AtBoundary); // Stay at boundary
-        }
-
         // Check for "Container Blocks" that change our state. Per spec, these
         // blocks may also be preceded by up to 3 spaces of indentation
         if indent_len <= 3
@@ -669,11 +671,12 @@ impl Buffer {
             return self.flush_paragraph(flush_len, setext_split);
         }
 
-        // No terminator yet. Once the paragraph is too long to be a short
-        // setext heading, stream the largest inline-safe prefix of its
-        // not-yet-emitted source — unless the block is a GFM table (a pipe-led
-        // header), whose column widths make its rendering prefix-unstable.
-        if self.streaming && self.data.len() >= SETEXT_STREAM_THRESHOLD && !self.is_table() {
+        // Later table rows or definition titles can change the rendered prefix.
+        if self.streaming
+            && self.data.len() >= SETEXT_STREAM_THRESHOLD
+            && !self.is_table()
+            && !self.may_start_reference_definition()
+        {
             // Commit only confirmed paragraph lines: never past the last
             // newline, since the in-progress line could still become a block
             // starter. The sole exception is the first line, which is the
@@ -692,6 +695,30 @@ impl Buffer {
         }
 
         (None, State::BufferingParagraph)
+    }
+
+    /// Whether the buffered prefix can still begin a reference definition.
+    ///
+    /// Incomplete labels and a closing bracket at the buffer edge remain
+    /// candidates.
+    /// Leading quote markers are ignored; destinations and titles are not
+    /// validated.
+    fn may_start_reference_definition(&self) -> bool {
+        let source = self.data.trim_start_matches([' ', '\t', '>']);
+        let Some(label) = source.strip_prefix('[') else {
+            return false;
+        };
+        let mut chars = label.chars().peekable();
+        while let Some(ch) = chars.next() {
+            match ch {
+                '\\' => {
+                    chars.next();
+                }
+                ']' => return chars.peek().is_none_or(|ch| *ch == ':'),
+                _ => {}
+            }
+        }
+        true
     }
 
     /// Whether this block is a GFM table, which must never stream.
@@ -1674,17 +1701,6 @@ fn is_fenced_code_start(line: &str) -> Option<(FenceType, usize, String)> {
     }
 
     Some((fence_type, fence_len, info_string.to_string()))
-}
-
-/// Checks if a line (without indent) is a Link Reference Definition
-fn is_link_ref_def(line: &str) -> bool {
-    // This is a simplified check. A full one can be added later. We just check
-    // for the `[label]: url` structure.
-    if !line.starts_with('[') {
-        return false;
-    }
-    line.find("]:")
-        .is_some_and(|label_end| !line[label_end + 2..].trim_start().is_empty())
 }
 
 /// Checks if a line (without indent) is a Setext Underline

--- a/crates/jp_md/src/buffer_tests.rs
+++ b/crates/jp_md/src/buffer_tests.rs
@@ -1363,17 +1363,40 @@ fn test_buffer_thematic_break() {
 }
 
 #[test]
-fn test_buffer_link_ref_def() {
-    let cases = vec![("simple", TestCase {
-        in_out: vec![("[my-link]: https://example.com\n", vec![Event::block(
-            "[my-link]: https://example.com\n",
-        )])],
-        flushed: None,
-    })];
+fn reference_definition_waits_for_a_block_boundary() {
+    let mut buffer = Buffer::new();
+    buffer.push("[my-link]: https://example.com\n");
+    assert_eq!(buffer.next(), None);
 
-    for (name, case) in cases {
-        case.run(name);
-    }
+    buffer.push("  \"A title\"\n\n");
+    assert_eq!(
+        buffer.next(),
+        Some(Event::block(
+            "[my-link]: https://example.com\n  \"A title\"\n\n"
+        ))
+    );
+    assert_eq!(buffer.flush_events(), vec![]);
+}
+
+#[test]
+fn long_reference_definition_does_not_stream_before_its_title_is_complete() {
+    let source = "[docs]: /docs \"This title is long enough to cross the paragraph streaming \
+                  threshold, but its next line still belongs to the definition\n";
+    assert!(source.len() > SETEXT_STREAM_THRESHOLD);
+    let mut buffer = Buffer::new();
+    buffer.push(source);
+    assert_eq!(buffer.next(), None);
+
+    buffer.push("and must be kept as literal source.\"\n\n");
+    assert_eq!(
+        buffer.next(),
+        Some(Event::block(
+            "[docs]: /docs \"This title is long enough to cross the paragraph streaming \
+             threshold, but its next line still belongs to the definition\nand must be kept as \
+             literal source.\"\n\n"
+        ))
+    );
+    assert_eq!(buffer.flush_events(), vec![]);
 }
 
 #[test]

--- a/crates/jp_md/src/format.rs
+++ b/crates/jp_md/src/format.rs
@@ -12,6 +12,7 @@ use two_face::syntax;
 
 use crate::{
     ansi::{self, AnsiState, Segment},
+    references,
     render::{self, HrOptions, RenderOptions},
     table::TableOptions,
     theme,
@@ -262,6 +263,10 @@ impl Formatter {
     /// This injects ANSI escape codes into the text, to make certain markdown
     /// elements reflect their style (strong, italics, code, color, etc.).
     ///
+    /// Link reference definitions remain visible as literal Markdown, including
+    /// unused definitions.
+    /// Only references defined within `text` are resolved.
+    ///
     /// # Errors
     ///
     /// Returns an error if `fmt::Error` is returned when formatting the
@@ -299,6 +304,7 @@ impl Formatter {
         let comrak_options = self.parse_options();
         let arena = Arena::new();
         let ast = comrak::parse_document(&arena, text, &comrak_options);
+        references::restore(&arena, ast, text, &comrak_options);
         let table_options = TableOptions::new(self.table_max_column_width)
             .continuation_edge(self.table_continuation_edge);
         let hr_options = HrOptions {

--- a/crates/jp_md/src/lib.rs
+++ b/crates/jp_md/src/lib.rs
@@ -31,6 +31,7 @@ mod ansi;
 pub mod buffer;
 pub mod format;
 pub mod heading;
+mod references;
 mod render;
 pub mod shade;
 mod table;

--- a/crates/jp_md/src/references.rs
+++ b/crates/jp_md/src/references.rs
@@ -1,0 +1,211 @@
+//! Reference-definition preservation for terminal rendering.
+//!
+//! [`restore`] adds literal paragraphs for definitions consumed by comrak.
+
+use std::ops::Range;
+
+use comrak::{
+    Arena, Node, Options,
+    nodes::{Ast, NodeValue},
+    parse_document,
+};
+
+/// Add literal paragraphs for reference definitions consumed during parsing.
+///
+/// `root` must be an unmodified comrak AST parsed from `source` with `options`.
+/// Existing links keep their resolved destinations; definitions retain their
+/// source order and container nesting.
+pub fn restore<'a>(arena: &'a Arena<'a>, root: Node<'a>, source: &str, options: &Options<'_>) {
+    if !source.contains("]:") {
+        return;
+    }
+
+    // Source positions count CRLF and bare CR as single line endings.
+    let source = source.replace("\r\n", "\n").replace('\r', "\n");
+    let lines: Vec<_> = source.split_inclusive('\n').collect();
+    // Only inspect the parser's nodes, not the literal paragraphs we insert.
+    let nodes: Vec<_> = root.descendants().collect();
+    for node in nodes {
+        let data = node.data();
+        let span = data.sourcepos;
+        match data.value {
+            NodeValue::Document
+            | NodeValue::BlockQuote
+            | NodeValue::Item(_)
+            | NodeValue::TaskItem(_) => {
+                drop(data);
+                // Definition-only paragraphs leave gaps between child spans.
+                let mut start = span.start.line.saturating_sub(1);
+                let children: Vec<_> = node.children().collect();
+                for child in children {
+                    let child_span = child.data().sourcepos;
+                    let end = child_span.start.line.saturating_sub(1);
+                    let gap = container_source(node, &lines, start..end);
+                    if definition_size(&gap, options) > 0 {
+                        child.insert_before(literal_paragraph(arena, &gap));
+                    }
+                    start = child_span.end.line;
+                }
+                let gap = container_source(node, &lines, start..span.end.line);
+                if definition_size(&gap, options) > 0 {
+                    node.append(literal_paragraph(arena, &gap));
+                }
+            }
+            NodeValue::Paragraph | NodeValue::Heading(_) => {
+                drop(data);
+                // The source span includes definitions removed before inline parsing.
+                let text = container_source(
+                    node,
+                    &lines,
+                    span.start.line.saturating_sub(1)..span.end.line,
+                );
+                let size = definition_size(&text, options);
+                if size > 0 {
+                    node.insert_before(literal_paragraph(arena, &text[..size]));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Return the byte count of complete leading definitions, including whitespace.
+fn definition_size(source: &str, options: &Options<'_>) -> usize {
+    if !source.trim_start().starts_with('[') || !source.contains("]:") {
+        return 0;
+    }
+
+    let leading = source.len() - source.trim_start().len();
+    let mut size = 0;
+    let mut end = 0;
+    for line in source.split_inclusive('\n') {
+        end += line.len();
+        if end <= leading {
+            continue;
+        }
+        let arena = Arena::new();
+        let root = parse_document(&arena, &source[..end], options);
+        if root.first_child().is_none() {
+            size = end;
+        }
+        if line.trim().is_empty() && size > 0 {
+            break;
+        }
+    }
+    size
+}
+
+/// Build a paragraph from source text without parsing inline Markdown.
+fn literal_paragraph<'a>(arena: &'a Arena<'a>, source: &str) -> Node<'a> {
+    let paragraph = arena.alloc(Ast::new(NodeValue::Paragraph, (1, 1).into()).into());
+    for line in source
+        .trim_matches(['\n', '\r'])
+        .trim_end()
+        .split_inclusive('\n')
+    {
+        let content = line.trim_start_matches([' ', '\t']);
+        let indent = &line[..line.len() - content.len()];
+        // The terminal writer drops leading spaces in Text nodes when wrapping.
+        // Raw nodes preserve indentation; the remaining text stays wrappable.
+        if !indent.is_empty() {
+            paragraph.append(
+                arena.alloc(Ast::new(NodeValue::Raw(indent.to_owned()), (1, 1).into()).into()),
+            );
+        }
+        paragraph.append(
+            arena.alloc(Ast::new(NodeValue::Text(content.to_owned().into()), (1, 1).into()).into()),
+        );
+    }
+    paragraph
+}
+
+/// Extract source lines without the list and blockquote prefixes of `node`.
+fn container_source(node: Node<'_>, lines: &[&str], range: Range<usize>) -> String {
+    let ancestors: Vec<_> = node.ancestors().collect();
+    let mut source = String::new();
+    for index in range {
+        let Some(line) = lines.get(index) else {
+            break;
+        };
+        let mut line = (*line).to_owned();
+        let mut column = 0;
+        for ancestor in ancestors.iter().rev() {
+            let data = ancestor.data();
+            match data.value {
+                NodeValue::BlockQuote => {
+                    let trimmed = line.trim_start_matches([' ', '\t']);
+                    if trimmed.starts_with('>') {
+                        let offset = line.len() - trimmed.len() + 1;
+                        column = line[..offset].chars().fold(column, advance_column);
+                        line.drain(..offset);
+                        column += strip_columns(&mut line, 1, false, column);
+                    }
+                }
+                NodeValue::Item(list) => {
+                    column += strip_columns(
+                        &mut line,
+                        list.marker_offset + list.padding,
+                        index + 1 == data.sourcepos.start.line,
+                        column,
+                    );
+                }
+                NodeValue::TaskItem(ref task) => {
+                    if let Some(parent) = ancestor.parent()
+                        && let NodeValue::List(list) = parent.data().value
+                    {
+                        // TaskItem has no padding field. Its checkbox position
+                        // identifies the content column even when numbering
+                        // crosses from 9 to 10.
+                        let opening = lines[data.sourcepos.start.line - 1];
+                        let marker = data.sourcepos.start.column - 1;
+                        let checkbox = task.symbol_sourcepos.start.column - 1;
+                        let start_column = opening[..marker].chars().fold(0, advance_column);
+                        let end_column = opening[marker..checkbox]
+                            .chars()
+                            .fold(start_column, advance_column);
+                        let count = list.marker_offset + end_column - start_column;
+                        column += strip_columns(
+                            &mut line,
+                            count,
+                            index + 1 == data.sourcepos.start.line,
+                            column,
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+        source.push_str(&line);
+    }
+    source
+}
+
+/// Remove up to `count` source columns and return how many were consumed.
+///
+/// Tabs are measured from `start_column`; a partially consumed tab leaves
+/// spaces.
+/// `marker` permits stripping non-whitespace characters on an item's opening
+/// line.
+fn strip_columns(line: &mut String, count: usize, marker: bool, start_column: usize) -> usize {
+    let mut column = start_column;
+    let target = start_column + count;
+    let mut offset = 0;
+    for ch in line.chars() {
+        if column >= target || ch == '\n' || (!marker && !matches!(ch, ' ' | '\t')) {
+            break;
+        }
+        column = advance_column(column, ch);
+        offset += ch.len_utf8();
+    }
+    line.replace_range(..offset, &" ".repeat(column.saturating_sub(target)));
+    (column - start_column).min(count)
+}
+
+/// Advance a CommonMark source column, where tabs use four-column stops.
+const fn advance_column(column: usize, ch: char) -> usize {
+    column + if ch == '\t' { 4 - column % 4 } else { 1 }
+}
+
+#[cfg(test)]
+#[path = "references_tests.rs"]
+mod tests;

--- a/crates/jp_md/src/references_tests.rs
+++ b/crates/jp_md/src/references_tests.rs
@@ -1,0 +1,245 @@
+use crate::format::{BackgroundFill, DefaultBackground, Formatter, TerminalOptions};
+
+#[test]
+fn reference_definitions_survive_beside_other_blocks() {
+    let output = Formatter::with_width(0)
+        .format_terminal("Before.\n\n[docs]: /docs\n\nAfter.\n")
+        .unwrap();
+    assert_eq!(output, "Before.\n\n[docs]: /docs\n\nAfter.\n");
+}
+
+#[test]
+fn reference_definitions_survive_at_the_start_of_a_paragraph() {
+    let output = Formatter::with_width(0)
+        .format_terminal("[docs]: /docs\nRead **this**.\n")
+        .unwrap();
+    assert_eq!(output, "[docs]: /docs\n\nRead \x1b[1m**this**\x1b[22m.\n");
+}
+
+#[test]
+fn reference_definitions_survive_inside_containers() {
+    let output = Formatter::with_width(0)
+        .format_terminal("- First.\n\n  [docs]: /docs\n\n  Last.\n")
+        .unwrap();
+    // The terminal writer retains the list prefix on blank lines.
+    assert_eq!(output, "- First.\n  \n  [docs]: /docs\n  \n  Last.\n");
+
+    let output = Formatter::with_width(0)
+        .format_terminal("> [docs]: /docs\n")
+        .unwrap();
+    assert_eq!(output, "\x1b[38;2;131;148;150m> [docs]: /docs\x1b[39m\n");
+}
+
+#[test]
+fn multiline_reference_definitions_preserve_their_source() {
+    let output = Formatter::with_width(0)
+        .format_terminal("[my\nlabel]:\n  <https://example.com/a_b>\n  \"A *literal* title\"\n")
+        .unwrap();
+    assert_eq!(
+        output,
+        "[my\nlabel]:\n  <https://example.com/a_b>\n  \"A *literal* title\"\n"
+    );
+}
+
+#[test]
+fn definitions_keep_duplicates_escaped_labels_and_relative_destinations() {
+    let output = Formatter::with_width(0)
+        .format_terminal("[a\\]b]: <../a_b> \"A *literal* title\"\n[a\\]b]: /second\n")
+        .unwrap();
+    assert_eq!(
+        output,
+        "[a\\]b]: <../a_b> \"A *literal* title\"\n[a\\]b]: /second\n"
+    );
+}
+
+#[test]
+fn resolved_links_and_unused_definitions_remain_visible() {
+    let output = Formatter::with_width(0)
+        .format_terminal("See [docs][id].\n\n[id]: /docs\n[unused]: /unused\n")
+        .unwrap();
+    assert_eq!(
+        output,
+        "See [docs](/docs).\n\n[id]: /docs\n[unused]: /unused\n"
+    );
+}
+
+#[test]
+fn definitions_in_nested_containers_keep_their_prefixes() {
+    let output = Formatter::with_width(0)
+        .format_terminal("- > [docs]: /docs\n  >\n  > Read **this**.\n")
+        .unwrap();
+    // Comrak classifies this as a tight list, so TerminalWriter suppresses
+    // blank lines.
+    assert_eq!(
+        output,
+        "- \x1b[38;2;131;148;150m> [docs]: /docs\n\x1b[38;2;131;148;150m  > Read \
+         \x1b[1m**this**\x1b[22m.\x1b[39m\n"
+    );
+}
+
+#[test]
+fn definitions_inside_an_ordered_list_keep_continuation_indentation() {
+    let output = Formatter::with_width(0)
+        .format_terminal("10. [docs]: /docs\n    [other]: /other\n11. Read.\n")
+        .unwrap();
+    assert_eq!(
+        output,
+        "10. [docs]: /docs\n    [other]: /other\n11. Read.\n"
+    );
+}
+
+#[test]
+fn definitions_inside_a_task_item_remain_visible() {
+    let output = Formatter::with_width(0)
+        .format_terminal("- [x] Done.\n\n  [docs]: /docs\n")
+        .unwrap();
+    // Definitions do not make the parsed task list loose.
+    assert_eq!(output, "- [x] Done.\n  [docs]: /docs\n");
+}
+
+#[test]
+fn task_items_use_their_own_marker_width() {
+    let output = Formatter::with_width(0)
+        .format_terminal("9. [x] First.\n10. [x] Second.\n\n    [docs]: /docs\n")
+        .unwrap();
+    assert_eq!(
+        output,
+        "9. [x] First.\n10. [x] Second.\n    [docs]: /docs\n"
+    );
+}
+
+#[test]
+fn definitions_before_a_setext_heading_remain_visible() {
+    let output = Formatter::with_width(0)
+        .format_terminal("[docs]: /docs\nTitle\n=====\n")
+        .unwrap();
+    assert_eq!(output, "[docs]: /docs\n\n# \x1b[1mTitle\x1b[22m\n");
+}
+
+#[test]
+fn definition_lookalikes_inside_code_and_html_are_not_duplicated() {
+    let formatter = Formatter::with_width(0);
+    assert_eq!(
+        formatter
+            .format_terminal("```\n[docs]: /docs\n```\n")
+            .unwrap(),
+        "```\n[docs]: /docs\n```\n"
+    );
+    assert_eq!(
+        formatter.format_terminal("    [docs]: /docs\n").unwrap(),
+        "```\n[docs]: /docs\n```\n"
+    );
+    assert_eq!(
+        formatter
+            .format_terminal("<pre>\n[docs]: /docs\n</pre>\n")
+            .unwrap(),
+        "<pre>\n[docs]: /docs\n</pre>\n"
+    );
+}
+
+#[test]
+fn invalid_definitions_and_definitions_after_prose_remain_ordinary_markdown() {
+    let formatter = Formatter::with_width(0);
+    assert_eq!(
+        formatter
+            .format_terminal("[docs]: /docs trailing **text**\n")
+            .unwrap(),
+        "[docs]: /docs trailing \x1b[1m**text**\x1b[22m\n"
+    );
+    assert_eq!(
+        formatter.format_terminal("Read.\n[docs]: /docs\n").unwrap(),
+        "Read.\n[docs]: /docs\n"
+    );
+    assert_eq!(
+        formatter.format_terminal("\\[docs]: /docs\n").unwrap(),
+        "[docs]: /docs\n"
+    );
+}
+
+#[test]
+fn definition_line_endings_are_normalized() {
+    let formatter = Formatter::with_width(0);
+    assert_eq!(
+        formatter
+            .format_terminal("[docs]:\r\n  /docs\r\n  \"Title\"\r\n")
+            .unwrap(),
+        "[docs]:\n  /docs\n  \"Title\"\n"
+    );
+    assert_eq!(
+        formatter
+            .format_terminal("[docs]: /docs\r\rAfter.\r")
+            .unwrap(),
+        "[docs]: /docs\n\nAfter.\n"
+    );
+}
+
+#[test]
+fn definitions_use_the_terminal_indent_wrap_width_and_background() {
+    let output = Formatter::with_width(22)
+        .format_terminal_with("[docs]: /docs \"A title with words\"\n", &TerminalOptions {
+            indent: 2,
+            default_background: Some(DefaultBackground {
+                param: "48;5;236".into(),
+                fill: BackgroundFill::Content,
+            }),
+            suppress_trailing_separator: true,
+            ..TerminalOptions::default()
+        })
+        .unwrap();
+    assert_eq!(
+        output,
+        "\x1b[48;5;236m  [docs]: /docs \"A\x1b[0m\n\x1b[48;5;236m  title with words\"\x1b[0m\n"
+    );
+}
+
+#[test]
+fn definitions_in_nested_lists_and_tab_indented_items_keep_their_destinations() {
+    let formatter = Formatter::with_width(0);
+    assert_eq!(
+        formatter
+            .format_terminal(" - [outer]: /outer\n   - [inner]: /inner\n")
+            .unwrap(),
+        "- [outer]: /outer\n  - [inner]: /inner\n"
+    );
+    assert_eq!(
+        formatter
+            .format_terminal("-\t[docs]: /docs\n\t[other]: /other\n")
+            .unwrap(),
+        "- [docs]: /docs\n  [other]: /other\n"
+    );
+}
+
+#[test]
+fn nested_list_tabs_are_measured_from_their_source_column() {
+    let output = Formatter::with_width(0)
+        .format_terminal("- - [docs]: /docs\n  \t   [other]: /other\n    Read.\n")
+        .unwrap();
+    assert_eq!(
+        output,
+        "- - [docs]: /docs\n       [other]: /other\n    Read.\n"
+    );
+}
+
+#[test]
+fn definitions_separated_by_blank_lines_are_preserved_once() {
+    let output = Formatter::with_width(0)
+        .format_terminal("\n[one]: /one\n\n[two]: /two\n\nAfter.\n")
+        .unwrap();
+    assert_eq!(output, "[one]: /one\n\n[two]: /two\n\nAfter.\n");
+}
+
+#[test]
+fn definitions_with_unicode_labels_keep_their_source() {
+    let output = Formatter::with_width(0)
+        .format_terminal("[日本語]: /docs \"Français\"\n")
+        .unwrap();
+    assert_eq!(output, "[日本語]: /docs \"Français\"\n");
+}
+
+#[test]
+fn commonmark_serialization_still_resolves_definitions() {
+    let output = Formatter::with_width(0)
+        .format("See [docs][id].\n\n[id]: /docs\n[unused]: /unused\n")
+        .unwrap();
+    assert_eq!(output, "See [docs](/docs).\n");
+}

--- a/crates/jp_md/tests/snapshots/buffer__doc-inline.snap
+++ b/crates/jp_md/tests/snapshots/buffer__doc-inline.snap
@@ -19,7 +19,7 @@ description: "Source: doc-inline"
         content: "Subscripts such as H~2~O and superscripts such as x^2^ round out the inline set\nthat this renderer has enabled, and they should survive word-wrapping intact.\n\n",
         indent: 0,
     },
-    Block {
+    Flush {
         content: "[gfm]: https://github.github.com/gfm/\n",
         indent: 0,
     },


### PR DESCRIPTION
Terminal output retains `[label]: URL` definitions, so streamed reference-style links no longer lose their destinations. Multiline definitions and definitions inside lists or blockquotes remain visible with the surrounding terminal styling. Markdown serialization is unchanged.

Block-by-block parsing cannot resolve definitions that arrive later, and comrak consumes definitions without rendering them. Preserve their source as literal text and buffer potential multiline definitions until a block boundary, while ordinary bracket-led prose continues to stream.