### PR TITLE
enhance(cli, rfd): Announce trace logs early

### DIFF
--- a/.config/jp/tools/src/debug_jp/trace.rs
+++ b/.config/jp/tools/src/debug_jp/trace.rs
@@ -2,12 +2,11 @@
 //!
 //! Launches `jp` inside the sandbox with `JP_DEBUG=1` set and `--log-file`
 //! pointing at a path in the real workspace, so the trace log lands at a known
-//! location that survives sandbox cleanup — even when jp is force-killed,
-//! since the file layer writes events as they happen.
+//! location that survives sandbox cleanup, even when jp is force-killed, since
+//! the file layer writes events as they happen.
 //! When the file is missing (jp exited before logging was configured), we fall
-//! back to the path jp announces on stderr at exit: a `Full trace log written
-//! to: <path>` line (text output) or a `{"trace_log": "<path>"}` object (JSON
-//! output).
+//! back to the path jp announces on stderr: a `Streaming trace logs to: <path>`
+//! line (text output) or a `{"trace_log": "<path>"}` object (JSON output).
 //! The events are then filtered by level/target/grep and rendered in a compact
 //! logfmt-like format.
 
@@ -410,9 +409,9 @@ fn run_one(
     let launch_result = launcher.run(&launch_spec, timeouts, &mut |_| {})?;
 
     // Fallback: jp exited before creating `trace_dst` (or ignored the flag).
-    // Locate the trace via the path jp announces on stderr at exit — a text
-    // marker line or a `trace_log` JSON field, depending on `--format` — and
-    // copy it out of the system temp dir into the real workspace.
+    // Locate the trace via the path jp announces on stderr, as a text marker
+    // line or a `trace_log` JSON field depending on `--format`, and copy it out
+    // of the system temp dir into the real workspace.
     if !trace_dst.exists() {
         let Some(trace_path) = trace::extract_trace_path(&launch_result.stderr) else {
             let note = launch_result

--- a/.config/jp/tools/src/debug_jp/util/trace_render_tests.rs
+++ b/.config/jp/tools/src/debug_jp/util/trace_render_tests.rs
@@ -288,22 +288,19 @@ fn render_omits_stdout_section_when_empty() {
 }
 
 #[test]
-fn render_strips_trace_path_marker_from_stderr() {
+fn render_strips_streaming_trace_path_marker_from_stderr() {
     // The marker line jp emits to advertise the trace path should not
-    // appear inside the rendered stderr block — it's already in the footer.
+    // appear inside the rendered stderr block; it is already in the footer.
     let mut launch = fixture_launch();
-    launch.stderr = "some real error\nFull trace log written to: /tmp/x\n".into();
+    launch.stderr = "some real error\nStreaming trace logs to: /tmp/x\n".into();
 
     let report = render(&[], 0, &launch, &["c".into()], fixture_paths());
     assert!(report.contains("## stderr"));
     assert!(report.contains("some real error"));
-    // The marker line appears in the footer reference, not inside the
-    // stderr fenced block. We verify by checking that the stderr block
-    // closes before the marker text could possibly appear.
     let stderr_start = report.find("## stderr").unwrap();
     let footer_start = report.find("**Files:**").unwrap();
     let stderr_section = &report[stderr_start..footer_start];
-    assert!(!stderr_section.contains("Full trace log written to"));
+    assert!(!stderr_section.contains("Streaming trace logs to"));
 }
 
 #[test]

--- a/.config/jp/tools/src/util/trace.rs
+++ b/.config/jp/tools/src/util/trace.rs
@@ -12,9 +12,11 @@
 use serde::Deserialize;
 use serde_json::{Map, Value};
 
-/// Text-format marker jp writes to stderr, right before exit, when `JP_DEBUG=1`
-/// and the output format is human-readable text.
-pub(crate) const TRACE_PATH_PREFIX: &str = "Full trace log written to: ";
+/// Text-format marker jp writes to stderr before execution when `JP_DEBUG=1`.
+pub(crate) const TRACE_PATH_PREFIX: &str = "Streaming trace logs to: ";
+
+/// Text-format marker jp writes after a failed or long-running invocation.
+const COMPLETED_TRACE_PATH_PREFIX: &str = "Full trace log written to: ";
 
 /// Severity, ordered so `level >= Level::Info` is meaningful.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -76,12 +78,12 @@ pub(crate) fn parse_lines(text: &str) -> Vec<TraceEvent> {
     text.lines().filter_map(parse_line).collect()
 }
 
-/// Extract the trace log path jp writes to stderr right before exit.
+/// Extract the trace log path jp writes to stderr.
 ///
-/// jp emits `Full trace log written to: <path>` when the output format is text,
-/// or a `{"trace_log": "<path>"}` JSON object when the format is JSON or
-/// JSON-pretty.
-/// This checks each stderr line for either shape.
+/// Text output announces a streaming log before execution and may repeat the
+/// completed log path afterward.
+/// JSON and JSON-pretty output use a `{"trace_log": "<path>"}` object for
+/// either notice.
 pub(crate) fn extract_trace_path(stderr: &str) -> Option<String> {
     stderr.lines().find_map(parse_trace_path_line)
 }
@@ -93,7 +95,10 @@ pub(crate) fn is_trace_path_marker_line(line: &str) -> bool {
 }
 
 fn parse_trace_path_line(line: &str) -> Option<String> {
-    if let Some(path) = line.strip_prefix(TRACE_PATH_PREFIX) {
+    if let Some(path) = line
+        .strip_prefix(TRACE_PATH_PREFIX)
+        .or_else(|| line.strip_prefix(COMPLETED_TRACE_PATH_PREFIX))
+    {
         return Some(path.trim().to_owned());
     }
     match serde_json::from_str::<Value>(line).ok()? {

--- a/.config/jp/tools/src/util/trace_tests.rs
+++ b/.config/jp/tools/src/util/trace_tests.rs
@@ -82,7 +82,13 @@ fn parse_drops_lines_with_unknown_level() {
 }
 
 #[test]
-fn extract_trace_path_reads_text_marker_line() {
+fn extract_trace_path_reads_streaming_text_marker_line() {
+    let stderr = "some noise\nStreaming trace logs to: /tmp/x.jsonl\n";
+    assert_eq!(extract_trace_path(stderr), Some("/tmp/x.jsonl".to_owned()));
+}
+
+#[test]
+fn extract_trace_path_reads_completed_text_marker_line() {
     let stderr = "some noise\nFull trace log written to: /tmp/x.jsonl\n";
     assert_eq!(extract_trace_path(stderr), Some("/tmp/x.jsonl".to_owned()));
 }
@@ -101,7 +107,10 @@ fn extract_trace_path_returns_none_without_a_marker() {
 }
 
 #[test]
-fn is_trace_path_marker_line_matches_both_formats() {
+fn is_trace_path_marker_line_matches_text_and_json_formats() {
+    assert!(is_trace_path_marker_line(
+        "Streaming trace logs to: /tmp/x.jsonl"
+    ));
     assert!(is_trace_path_marker_line(
         "Full trace log written to: /tmp/x.jsonl"
     ));

--- a/crates/jp_cli/src/lib.rs
+++ b/crates/jp_cli/src/lib.rs
@@ -27,7 +27,7 @@ use std::{
         atomic::{AtomicUsize, Ordering},
     },
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use camino::{Utf8Path, Utf8PathBuf};
@@ -232,9 +232,10 @@ struct Globals {
     /// Write the full tracing log to the given file.
     ///
     /// Use `-` to stream logs to stderr instead.
-    /// When unset, the log is written to a temporary file, which is kept and
-    /// its path printed when a run fails, or when `JP_DEBUG=1` is set and
-    /// stdout is a terminal.
+    /// When unset, the log is written to a temporary file.
+    /// `JP_DEBUG=1` announces its path before execution and keeps it afterward.
+    /// Runs lasting at least five minutes repeat the path at completion.
+    /// A failed run without `JP_DEBUG` reports the retained path at completion.
     #[arg(long, global = true, value_name = "PATH")]
     log_file: Option<String>,
 
@@ -432,6 +433,7 @@ pub fn run() -> ExitCode {
     cli.globals.no_interactive |= env_opt_out("JP_NONINTERACTIVE");
 
     let format = cli.globals.format.resolve(is_tty);
+    let debug_enabled = env_opt_out("JP_DEBUG");
 
     let guard = configure_logging(
         cli.globals.verbose,
@@ -441,6 +443,19 @@ pub fn run() -> ExitCode {
         cli.globals.log_file.as_deref(),
         cli.globals.log.as_deref(),
     );
+
+    let trace_log_started_at =
+        if debug_enabled && let Some(path) = guard.as_ref().and_then(TracingGuard::path) {
+            if format.is_json() {
+                let msg = serde_json::json!({ "trace_log": path.as_str() });
+                eprintln!("{msg}");
+            } else {
+                eprintln!("Streaming trace logs to: {path}");
+            }
+            Some(Instant::now())
+        } else {
+            None
+        };
 
     trace!(command = cli.command.name(), arguments = %cli, "Starting CLI run.");
     let (code, outcome, output) = match run_inner(cli, format) {
@@ -467,12 +482,10 @@ pub fn run() -> ExitCode {
         }
     }
 
-    // Read here rather than inside the policy, which stays a pure function of
-    // its inputs.
-    let debug_enabled = env_opt_out("JP_DEBUG");
-
-    if should_report_trace_log(outcome, debug_enabled)
+    if should_persist_trace_log(outcome, debug_enabled)
         && let Some(path) = guard.and_then(TracingGuard::persist)
+        && trace_log_started_at
+            .is_none_or(|started_at| should_repeat_trace_log_notice(started_at.elapsed()))
     {
         if format.is_json() {
             let msg = serde_json::json!({ "trace_log": path.as_str() });
@@ -500,23 +513,24 @@ enum RunOutcome {
     Failed,
 }
 
-/// Whether to tell the user where the run's trace log was written.
+/// Whether to keep the run's temporary trace log.
 ///
-/// A failed run always reports it: diagnosing the failure matters more than
-/// keeping the output stream clean.
-/// The exit status alone doesn't answer this, since a command can exit non-zero
-/// to report a result rather than a failure.
-///
-/// Every other run makes the report opt-in via `JP_DEBUG`.
-/// The report is developer output that someone asked for by name, so where the
-/// run's own streams are pointed has no say in it.
-/// It goes to stderr either way, and a caller who wants it gone redirects that
-/// stream or unsets the variable.
-const fn should_report_trace_log(outcome: RunOutcome, debug_enabled: bool) -> bool {
+/// A failed run always keeps it because the trace may explain the failure.
+/// The exit status alone does not answer this, since a command can exit
+/// non-zero to report a result rather than a failure.
+/// Every other run makes retention opt-in through `JP_DEBUG`.
+const fn should_persist_trace_log(outcome: RunOutcome, debug_enabled: bool) -> bool {
     match outcome {
         RunOutcome::Failed => true,
         RunOutcome::AsExpected => debug_enabled,
     }
+}
+
+const TRACE_LOG_REMINDER_AFTER: Duration = Duration::from_mins(5);
+
+/// Whether enough time has passed to repeat the trace log path at completion.
+fn should_repeat_trace_log_notice(elapsed: Duration) -> bool {
+    elapsed >= TRACE_LOG_REMINDER_AFTER
 }
 
 /// The width to lay output out against.
@@ -1343,7 +1357,7 @@ pub struct TracingGuard {
 /// Where the full trace log is written.
 enum TraceSink {
     /// A delete-on-drop temp file, kept only when [`TracingGuard::persist`] is
-    /// called (a failed run, or `JP_DEBUG=1` with stdout on a terminal).
+    /// called for a failed run or under `JP_DEBUG=1`.
     Temp(NamedUtf8TempFile),
     /// A caller-chosen path (`--log-file <path>`).
     /// The file always persists.
@@ -1351,6 +1365,13 @@ enum TraceSink {
 }
 
 impl TracingGuard {
+    fn path(&self) -> Option<&Utf8Path> {
+        match self.sink.as_ref()? {
+            TraceSink::Temp(file) => Some(file.path()),
+            TraceSink::Path(path) => Some(path),
+        }
+    }
+
     fn persist(mut self) -> Option<Utf8PathBuf> {
         match self.sink.take()? {
             TraceSink::Temp(file) => file.keep().ok().map(|(_file, path)| path),
@@ -1424,8 +1445,8 @@ fn configure_logging(
 
     // An explicit `--log-file <path>` pins the trace log to that path;
     // otherwise it goes to a delete-on-drop temp file that is only kept when the
-    // run fails, or when `JP_DEBUG=1` is set and stdout is a terminal. (`-`
-    // selects the stderr layer below, not a file path.)
+    // run fails or `JP_DEBUG=1` is set. (`-` selects the stderr layer below, not
+    // a file path.)
     let (file_writer, sink) = match log_file {
         Some(path) if path != "-" => {
             let file = fs::File::create(path).ok()?;

--- a/crates/jp_cli/src/lib_tests.rs
+++ b/crates/jp_cli/src/lib_tests.rs
@@ -24,21 +24,29 @@ use super::*;
 use crate::env_testing::EnvVarGuard;
 
 #[test]
-fn a_successful_run_announces_its_trace_log_only_under_jp_debug() {
-    // `JP_DEBUG` is the whole question for a run that did what was asked. The
-    // report names a file a developer went looking for, so a redirected or
-    // piped stdout does not withdraw it.
-    assert!(should_report_trace_log(RunOutcome::AsExpected, true));
-    assert!(!should_report_trace_log(RunOutcome::AsExpected, false));
+fn a_successful_run_keeps_its_trace_log_only_under_jp_debug() {
+    assert!(should_persist_trace_log(RunOutcome::AsExpected, true));
+    assert!(!should_persist_trace_log(RunOutcome::AsExpected, false));
 }
 
 #[test]
-fn a_failed_run_always_announces_its_trace_log() {
-    // Diagnosing a failure beats keeping the stream clean, so `JP_DEBUG` has no
-    // say. A command that exits non-zero to report a result (`grep` finding
-    // nothing) is `AsExpected`, not `Failed`, and takes the rule above instead.
-    assert!(should_report_trace_log(RunOutcome::Failed, false));
-    assert!(should_report_trace_log(RunOutcome::Failed, true));
+fn a_failed_run_always_keeps_its_trace_log() {
+    // A command that exits non-zero to report a result (`grep` finding nothing)
+    // is `AsExpected`, not `Failed`, and takes the rule above instead.
+    assert!(should_persist_trace_log(RunOutcome::Failed, false));
+    assert!(should_persist_trace_log(RunOutcome::Failed, true));
+}
+
+#[test]
+fn a_run_just_under_five_minutes_does_not_repeat_the_trace_log_notice() {
+    assert!(!should_repeat_trace_log_notice(
+        Duration::from_mins(5) - Duration::from_nanos(1)
+    ));
+}
+
+#[test]
+fn a_five_minute_run_repeats_the_trace_log_notice() {
+    assert!(should_repeat_trace_log_notice(Duration::from_mins(5)));
 }
 
 // The flag has to reach the printer to mean anything: it names a policy the
@@ -239,6 +247,17 @@ fn a_background_task_persist_failure_is_recorded_after_the_command_finished() {
     let error = cmd::fold_persist_failure(Ok(()), Some(recorded))
         .expect_err("an unsaved conversation must not exit zero");
     assert_eq!(error.message.as_deref(), Some("No space left on device"));
+}
+
+#[test]
+fn tracing_guard_exposes_temp_file_path_before_persisting() {
+    let file = NamedUtf8TempFile::new().unwrap();
+    let path = file.path().to_owned();
+    let guard = TracingGuard {
+        sink: Some(TraceSink::Temp(file)),
+    };
+
+    assert_eq!(guard.path(), Some(path.as_path()));
 }
 
 #[test]

--- a/docs/rfd/drafts/D32-jp-tracing-infrastructure.md
+++ b/docs/rfd/drafts/D32-jp-tracing-infrastructure.md
@@ -110,8 +110,8 @@ This keeps `jp --help` clean of developer-only knobs.
 
 | Variable                  | Purpose                                  | Default                              |
 | ------------------------- | ---------------------------------------- | ------------------------------------ |
-| `JP_DEBUG=1`              | Developer mode. Prints log file path at  | off                                  |
-|                           | end of run.                              |                                      |
+| `JP_DEBUG=1`              | Prints the log path before execution.    | off                                  |
+|                           | Repeats it after five minutes.           |                                      |
 | `JP_LOG=<filter>`         | Mirrors tracing to stderr with the given | off                                  |
 |                           | `EnvFilter` expression. Setting it       |                                      |
 |                           | enables the mirror.                      |                                      |
@@ -139,7 +139,8 @@ Examples:
 # Regular user: chrome only, complete log in background
 jp query "fix the bug"
 
-# User with JP_DEBUG always set: same, but prints log path at end
+# User with JP_DEBUG always set: prints the log path before execution
+# and repeats it when the run lasts at least five minutes
 JP_DEBUG=1 jp query "fix the bug"
 
 # Developer wants live tracing for a specific run


### PR DESCRIPTION
With `JP_DEBUG=1`, JP prints the trace log path before command execution. Developers can inspect the file while events arrive. Runs lasting at least five minutes repeat the path at completion so it remains easy to find after lengthy output.

Failed runs without `JP_DEBUG` retain their completion notice. The local trace tooling recognizes both notice forms and preserves the existing JSON marker.