### PR TITLE
fix(llm, openai): Separate reasoning items

### DIFF
--- a/crates/jp_cli/src/render/chat_tests.rs
+++ b/crates/jp_cli/src/render/chat_tests.rs
@@ -562,6 +562,110 @@ fn test_consecutive_reasoning_events_form_one_region() {
     );
 }
 
+#[test]
+fn reasoning_terminator_does_not_add_spacing_at_end_of_stream() {
+    for (terminator, background) in [
+        ("", None),
+        ("\n\n", None),
+        ("", Some(Color::Ansi256(236))),
+        ("\n\n", Some(Color::Ansi256(236))),
+    ] {
+        let mut config = AppConfig::new_test();
+        config.style.reasoning.display = ReasoningDisplayConfig::Full;
+        config.style.reasoning.background = background;
+        let (mut renderer, out, err) = create_renderer_with_config(config);
+
+        renderer.render_response(&ChatResponse::reasoning("**Heading**\n\nBody."));
+        renderer.render_response(&ChatResponse::reasoning(terminator));
+        renderer.flush();
+        renderer.printer.flush();
+
+        assert_eq!(strip_ansi(&out.lock()), "**Heading**\n\nBody.\n\n");
+        assert_eq!(*err.lock(), "");
+    }
+}
+
+#[test]
+fn reasoning_terminator_does_not_add_spacing_before_message() {
+    for (terminator, background) in [
+        ("", None),
+        ("\n\n", None),
+        ("", Some(Color::Ansi256(236))),
+        ("\n\n", Some(Color::Ansi256(236))),
+    ] {
+        let mut config = AppConfig::new_test();
+        config.style.reasoning.display = ReasoningDisplayConfig::Full;
+        config.style.reasoning.background = background;
+        let (mut renderer, out, err) = create_renderer_with_config(config);
+
+        renderer.render_response(&ChatResponse::reasoning("**Heading**\n\nBody."));
+        renderer.render_response(&ChatResponse::reasoning(terminator));
+        renderer.render_response(&ChatResponse::message("Answer."));
+        renderer.flush();
+        renderer.printer.flush();
+
+        assert_eq!(
+            strip_ansi(&out.lock()),
+            "**Heading**\n\nBody.\n\nAnswer.\n\n"
+        );
+        assert_eq!(*err.lock(), "");
+    }
+}
+
+#[test]
+fn reasoning_terminator_does_not_add_spacing_at_tool_boundary() {
+    for (terminator, background) in [
+        ("", None),
+        ("\n\n", None),
+        ("", Some(Color::Ansi256(236))),
+        ("\n\n", Some(Color::Ansi256(236))),
+    ] {
+        let mut config = AppConfig::new_test();
+        config.style.reasoning.display = ReasoningDisplayConfig::Full;
+        config.style.reasoning.background = background;
+        let (mut renderer, out, err) = create_renderer_with_config(config);
+
+        renderer.render_response(&ChatResponse::reasoning("**Heading**\n\nBody."));
+        renderer.render_response(&ChatResponse::reasoning(terminator));
+        renderer.enter_tool_call();
+        renderer.flush();
+        renderer.printer.flush();
+
+        assert_eq!(strip_ansi(&out.lock()), "**Heading**\n\nBody.\n\n");
+        assert_eq!(*err.lock(), "");
+    }
+}
+
+#[test]
+fn reasoning_terminator_consumes_truncation_budget() {
+    // The renderer counts all input characters, including provider-inserted
+    // newlines. Adding a terminator can exhaust the budget even when the
+    // visible text fits; the renderer cannot distinguish it from model text.
+    for (terminator, expected) in [
+        ("", "Think\n\nAnswer.\n\n"),
+        ("\n\n", "Think ...\n\nAnswer.\n\n"),
+    ] {
+        let mut config = AppConfig::new_test();
+        config.style.reasoning.display =
+            ReasoningDisplayConfig::Truncate(TruncateChars { characters: 6 });
+        config.style.reasoning.background = None;
+        let (mut renderer, out, err) = create_renderer_with_config(config);
+
+        renderer.render_response(&ChatResponse::reasoning("Think"));
+        renderer.render_response(&ChatResponse::reasoning(terminator));
+        renderer.render_response(&ChatResponse::message("Answer."));
+        renderer.flush();
+        renderer.printer.flush();
+
+        assert_eq!(
+            strip_ansi(&out.lock()),
+            expected,
+            "terminator: {terminator:?}"
+        );
+        assert_eq!(*err.lock(), "");
+    }
+}
+
 /// A provider-supplied blank line splits one reasoning region into two blocks.
 ///
 /// This is the channel a provider uses to segment reasoning it delivers as one

--- a/crates/jp_llm/src/provider/openai.rs
+++ b/crates/jp_llm/src/provider/openai.rs
@@ -132,12 +132,20 @@ impl Provider for Openai {
             return Ok(stream::iter(events.into_iter().map(Ok::<_, StreamError>)).boxed());
         }
 
+        let mut reasoning = ReasoningState::default();
         let raw_stream = self
             .client
             .stream(request)
             .filter_map(skip_unknown_events)
             .or_else(map_error)
-            .map_ok(move |v| stream::iter(map_event(v, is_structured, reasoning_enabled)))
+            .map_ok(move |v| {
+                stream::iter(map_event(
+                    v,
+                    is_structured,
+                    reasoning_enabled,
+                    &mut reasoning,
+                ))
+            })
             .try_flatten()
             .boxed();
 
@@ -154,12 +162,13 @@ fn map_non_streaming_response(
     reasoning_enabled: bool,
 ) -> Result<Vec<Event>> {
     let incomplete_reason = response.incomplete_details.map(|details| details.reason);
+    let mut reasoning = ReasoningState::default();
     let mut events = response
         .output
         .into_iter()
         .enumerate()
         .flat_map(|(index, item)| synthesize_non_streaming_output_item_events(index, item))
-        .flat_map(|event| map_event(event, is_structured, reasoning_enabled))
+        .flat_map(|event| map_event(event, is_structured, reasoning_enabled, &mut reasoning))
         .collect::<std::result::Result<Vec<_>, StreamError>>()?;
 
     events.push(map_non_streaming_finish_reason(
@@ -1333,6 +1342,50 @@ async fn map_error(error: OpenaiStreamError) -> std::result::Result<types::Event
     })
 }
 
+/// Tracks the last text-bearing reasoning item within one provider response.
+#[derive(Default)]
+struct ReasoningState {
+    index: Option<usize>,
+    trailing_newlines: usize,
+}
+
+impl ReasoningState {
+    fn delta(&mut self, index: usize, text: String) -> Event {
+        let has_text = !text.trim().is_empty();
+        let missing = if has_text && self.index.is_some_and(|previous| previous != index) {
+            let leading_newlines = text
+                .chars()
+                .take_while(char::is_ascii_whitespace)
+                .filter(|c| *c == '\n')
+                .take(2)
+                .count();
+            2_usize.saturating_sub(self.trailing_newlines + leading_newlines)
+        } else {
+            0
+        };
+        let text = match missing {
+            2 => format!("\n\n{text}"),
+            1 => format!("\n{text}"),
+            _ => text,
+        };
+
+        // Empty items and whitespace-only deltas must not consume the boundary.
+        // Track line endings across chunks so split or existing blank lines count.
+        if has_text {
+            self.index = Some(index);
+        }
+        for character in text.chars() {
+            match character {
+                '\n' => self.trailing_newlines = (self.trailing_newlines + 1).min(2),
+                ' ' | '\t' | '\r' => {}
+                _ => self.trailing_newlines = 0,
+            }
+        }
+
+        Event::reasoning(index, text)
+    }
+}
+
 /// Map an Openai [`types::Event`] into one or more [`Event`]s.
 ///
 /// This is the only place where OpenAI wire events become JP events.
@@ -1344,6 +1397,7 @@ fn map_event(
     event: types::Event,
     is_structured: bool,
     reasoning_enabled: bool,
+    reasoning: &mut ReasoningState,
 ) -> Vec<std::result::Result<Event, StreamError>> {
     use types::Event::*;
 
@@ -1351,6 +1405,12 @@ fn map_event(
         event = serde_json::to_string(&event).unwrap_or_default(),
         "Received event from OpenAI API."
     );
+
+    if let OutputItemAdded { item, .. } = &event
+        && !matches!(item, types::OutputItem::Reasoning(_))
+    {
+        *reasoning = ReasoningState::default();
+    }
 
     #[expect(clippy::cast_possible_truncation)]
     match event {
@@ -1426,13 +1486,13 @@ fn map_event(
             output_index,
             summary_index,
             ..
-        } if summary_index > 0 => vec![Ok(Event::reasoning(output_index as usize, "\n\n"))],
+        } if summary_index > 0 => vec![Ok(reasoning.delta(output_index as usize, "\n\n".into()))],
 
         ReasoningSummaryTextDelta {
             delta,
             output_index,
             ..
-        } => vec![Ok(Event::reasoning(output_index as usize, delta))],
+        } => vec![Ok(reasoning.delta(output_index as usize, delta))],
 
         FunctionCallArgumentsDelta {
             delta,
@@ -1486,6 +1546,7 @@ fn map_event(
         ResponseCompleted { response }
         | ResponseIncomplete { response }
         | ResponseFailed { response } => {
+            *reasoning = ReasoningState::default();
             let incomplete_reason = response.incomplete_details.map(|d| d.reason);
             match map_non_streaming_finish_reason(response.status, incomplete_reason) {
                 Ok(event) => vec![Ok(event)],

--- a/crates/jp_llm/src/provider/openai_tests.rs
+++ b/crates/jp_llm/src/provider/openai_tests.rs
@@ -1531,7 +1531,7 @@ mod synthesize_non_streaming_output_item_events {
     use serde_json::{Map, json};
 
     use super::super::{
-        ENCRYPTED_CONTENT_KEY, ITEM_ID_KEY, PHASE_KEY, map_event,
+        ENCRYPTED_CONTENT_KEY, ITEM_ID_KEY, PHASE_KEY, ReasoningState, map_event,
         synthesize_non_streaming_output_item_events,
     };
     use crate::event::Event;
@@ -1546,9 +1546,10 @@ mod synthesize_non_streaming_output_item_events {
         is_structured: bool,
         reasoning_enabled: bool,
     ) -> Vec<Event> {
+        let mut reasoning = ReasoningState::default();
         synthesize_non_streaming_output_item_events(index, item)
             .into_iter()
-            .flat_map(|event| map_event(event, is_structured, reasoning_enabled))
+            .flat_map(|event| map_event(event, is_structured, reasoning_enabled, &mut reasoning))
             .collect::<std::result::Result<Vec<_>, _>>()
             .unwrap()
     }
@@ -1718,17 +1719,33 @@ mod synthesize_non_streaming_output_item_events {
 }
 
 mod map_event {
+    use jp_conversation::event::ChatResponse;
     use openai_responses::types;
-    use serde_json::json;
+    use serde_json::{Map, json};
 
-    use super::super::map_event;
-    use crate::event::Event;
+    use super::super::{ENCRYPTED_CONTENT_KEY, ITEM_ID_KEY, ReasoningState, map_event};
+    use crate::{event::Event, event_builder::EventBuilder};
 
     fn collect(event: types::Event) -> Vec<Event> {
-        map_event(event, false, true)
+        collect_sequence([event])
+    }
+
+    fn collect_sequence(events: impl IntoIterator<Item = types::Event>) -> Vec<Event> {
+        let mut reasoning = ReasoningState::default();
+        events
             .into_iter()
-            .map(Result::unwrap)
-            .collect()
+            .flat_map(|event| map_event(event, false, true, &mut reasoning))
+            .collect::<Result<_, _>>()
+            .unwrap()
+    }
+
+    fn reasoning_delta(index: u64, text: &str) -> types::Event {
+        types::Event::ReasoningSummaryTextDelta {
+            output_index: index,
+            item_id: format!("rs_{index}"),
+            summary_index: 0,
+            delta: text.to_owned(),
+        }
     }
 
     #[test]
@@ -1782,6 +1799,217 @@ mod map_event {
     }
 
     #[test]
+    fn consecutive_reasoning_items_preserve_separators_in_stored_content() {
+        let wire_events: Vec<types::Event> = serde_json::from_value(json!([
+            {"type": "response.output_item.added", "output_index": 0,
+             "item": {"type": "reasoning", "id": "rs_123", "summary": []}},
+            {"type": "response.reasoning_summary_part.added", "output_index": 0,
+             "item_id": "rs_123", "summary_index": 0,
+             "part": {"type": "summary_text", "text": ""}},
+            {"type": "response.reasoning_summary_text.delta", "output_index": 0,
+             "item_id": "rs_123", "summary_index": 0, "delta": "**First"},
+            {"type": "response.reasoning_summary_text.delta", "output_index": 0,
+             "item_id": "rs_123", "summary_index": 0, "delta": " section**"},
+            {"type": "response.reasoning_summary_part.added", "output_index": 0,
+             "item_id": "rs_123", "summary_index": 1,
+             "part": {"type": "summary_text", "text": ""}},
+            {"type": "response.reasoning_summary_text.delta", "output_index": 0,
+             "item_id": "rs_123", "summary_index": 1, "delta": "**Second section**"},
+            {"type": "response.reasoning_summary_text.done", "output_index": 0,
+             "item_id": "rs_123", "summary_index": 1, "text": "**Second section**"},
+            {"type": "response.reasoning_summary_part.done", "output_index": 0,
+             "item_id": "rs_123", "summary_index": 1,
+             "part": {"type": "summary_text", "text": "**Second section**"}},
+            {"type": "response.output_item.done", "output_index": 0,
+             "item": {"type": "reasoning", "id": "rs_123", "encrypted_content": "enc1",
+                      "summary": [{"type": "summary_text", "text": "**First section**"},
+                                  {"type": "summary_text", "text": "**Second section**"}]}},
+            {"type": "response.output_item.added", "output_index": 1,
+             "item": {"type": "reasoning", "id": "rs_456", "summary": []}},
+            {"type": "response.reasoning_summary_part.added", "output_index": 1,
+             "item_id": "rs_456", "summary_index": 0,
+             "part": {"type": "summary_text", "text": ""}},
+            {"type": "response.reasoning_summary_text.delta", "output_index": 1,
+             "item_id": "rs_456", "summary_index": 0, "delta": "**Third section**"},
+            {"type": "response.output_item.done", "output_index": 1,
+             "item": {"type": "reasoning", "id": "rs_456", "encrypted_content": "enc2",
+                      "summary": [{"type": "summary_text", "text": "**Third section**"}]}}
+        ]))
+        .unwrap();
+        let events = collect_sequence(wire_events);
+
+        assert_eq!(events, vec![
+            Event::reasoning(0, ""),
+            Event::reasoning(0, "**First"),
+            Event::reasoning(0, " section**"),
+            Event::reasoning(0, "\n\n"),
+            Event::reasoning(0, "**Second section**"),
+            Event::flush_with_metadata(
+                0,
+                Map::from_iter([
+                    (ITEM_ID_KEY.to_owned(), "rs_123".into()),
+                    (ENCRYPTED_CONTENT_KEY.to_owned(), "enc1".into()),
+                ])
+            ),
+            Event::reasoning(1, ""),
+            Event::reasoning(1, "\n\n**Third section**"),
+            Event::flush_with_metadata(
+                1,
+                Map::from_iter([
+                    (ITEM_ID_KEY.to_owned(), "rs_456".into()),
+                    (ENCRYPTED_CONTENT_KEY.to_owned(), "enc2".into()),
+                ])
+            ),
+        ]);
+
+        let mut builder = EventBuilder::new();
+        let mut stored = vec![];
+        for event in events {
+            match event {
+                Event::Part {
+                    index,
+                    part,
+                    metadata,
+                } => builder.handle_part(index, part, metadata),
+                Event::Flush { index, metadata } => {
+                    stored.push(
+                        builder
+                            .handle_flush(index, metadata)
+                            .unwrap()
+                            .into_chat_response()
+                            .unwrap(),
+                    );
+                }
+                event => panic!("Unexpected event: {event:?}"),
+            }
+        }
+        assert_eq!(stored, vec![
+            ChatResponse::reasoning("**First section**\n\n**Second section**"),
+            ChatResponse::reasoning("\n\n**Third section**"),
+        ]);
+    }
+
+    #[test]
+    fn cross_item_separator_accounts_for_existing_newlines() {
+        for (first, next, expected) in [
+            ("First", "Next", "\n\nNext"),
+            ("First\n", "Next", "\nNext"),
+            ("First\n\n", "Next", "Next"),
+            ("First", "\nNext", "\n\nNext"),
+            ("First\n", "\nNext", "\nNext"),
+            ("First", "\n\nNext", "\n\nNext"),
+            ("First\r\n\r\n", "Next", "Next"),
+            ("First\n \n", "Next", "Next"),
+        ] {
+            let events = collect_sequence([reasoning_delta(0, first), reasoning_delta(1, next)]);
+            assert_eq!(events, vec![
+                Event::reasoning(0, first),
+                Event::reasoning(1, expected)
+            ]);
+        }
+    }
+
+    #[test]
+    fn cross_item_separator_survives_empty_items_and_split_whitespace() {
+        let events = collect_sequence([
+            reasoning_delta(0, "First"),
+            reasoning_delta(1, ""),
+            reasoning_delta(2, "\n"),
+            reasoning_delta(2, ""),
+            reasoning_delta(2, "Next"),
+            reasoning_delta(2, " chunk"),
+            reasoning_delta(3, "\n"),
+            reasoning_delta(3, "\n"),
+            reasoning_delta(3, "Last"),
+        ]);
+        assert_eq!(events, vec![
+            Event::reasoning(0, "First"),
+            Event::reasoning(1, ""),
+            Event::reasoning(2, "\n"),
+            Event::reasoning(2, ""),
+            Event::reasoning(2, "\nNext"),
+            Event::reasoning(2, " chunk"),
+            Event::reasoning(3, "\n"),
+            Event::reasoning(3, "\n"),
+            Event::reasoning(3, "Last"),
+        ]);
+    }
+
+    #[test]
+    fn message_and_tool_boundaries_discard_pending_reasoning_separation() {
+        for (item, expected) in [
+            (
+                json!({
+                    "type": "message", "id": "msg_123", "status": "in_progress",
+                    "role": "assistant", "content": []
+                }),
+                Event::message(1, ""),
+            ),
+            (
+                json!({
+                    "type": "function_call", "id": "fc_123", "call_id": "call_123",
+                    "name": "run_me", "arguments": "", "status": "in_progress"
+                }),
+                Event::tool_call_start(1, "call_123", "run_me"),
+            ),
+        ] {
+            let events = collect_sequence([
+                reasoning_delta(0, "First"),
+                types::Event::OutputItemAdded {
+                    output_index: 1,
+                    item: serde_json::from_value(item).unwrap(),
+                },
+                reasoning_delta(2, "Next"),
+            ]);
+            assert_eq!(events, vec![
+                Event::reasoning(0, "First"),
+                expected,
+                Event::reasoning(2, "Next")
+            ]);
+        }
+    }
+
+    #[test]
+    fn reasoning_item_done_emits_only_flush() {
+        for text in ["**Heading**", "**Heading**\n", "**Heading**\n\n", "", " \n"] {
+            let events = collect(types::Event::OutputItemDone {
+                output_index: 0,
+                item: serde_json::from_value(json!({
+                    "type": "reasoning", "id": "rs_123", "encrypted_content": "enc",
+                    "summary": [{"type": "summary_text", "text": text}]
+                }))
+                .unwrap(),
+            });
+            let expected = vec![Event::flush_with_metadata(
+                0,
+                Map::from_iter([
+                    (ITEM_ID_KEY.to_owned(), "rs_123".into()),
+                    (ENCRYPTED_CONTENT_KEY.to_owned(), "enc".into()),
+                ]),
+            )];
+            assert_eq!(events, expected, "summary text: {text:?}");
+        }
+    }
+
+    #[test]
+    fn reasoning_item_done_is_skipped_when_reasoning_is_disabled() {
+        let events = map_event(
+            types::Event::OutputItemDone {
+                output_index: 0,
+                item: serde_json::from_value(json!({
+                    "type": "reasoning", "id": "rs_123", "encrypted_content": "enc",
+                    "summary": [{"type": "summary_text", "text": "**Heading**"}]
+                }))
+                .unwrap(),
+            },
+            false,
+            false,
+            &mut ReasoningState::default(),
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
     fn first_reasoning_summary_part_emits_no_break() {
         let events = collect(types::Event::ReasoningSummaryPartAdded {
             item_id: "rs_123".to_owned(),
@@ -1804,6 +2032,7 @@ mod map_event {
             },
             false,
             false,
+            &mut ReasoningState::default(),
         );
 
         assert!(events.is_empty());
@@ -1825,6 +2054,91 @@ mod map_event {
         });
 
         assert_eq!(events, vec![Event::flush(2)]);
+    }
+}
+
+mod map_non_streaming_response {
+    use openai_responses::types::{self, response::Response};
+    use serde_json::{Map, json};
+
+    use super::super::{
+        ENCRYPTED_CONTENT_KEY, ITEM_ID_KEY, ReasoningState, map_event, map_non_streaming_response,
+    };
+    use crate::event::{Event, FinishReason};
+
+    fn response() -> Response {
+        serde_json::from_value(json!({
+            "id": "resp_123", "created_at": 1_577_836_800, "status": "completed",
+            "model": "gpt-6-astra", "metadata": {}, "parallel_tool_calls": true,
+            "reasoning": {}, "temperature": 1.0, "text": {"format": {"type": "text"}},
+            "tool_choice": "auto", "tools": [], "top_p": 1.0, "truncation": "disabled", "store": false,
+            "output": [
+                {"type": "reasoning", "id": "rs_0", "encrypted_content": "enc0",
+                 "summary": [{"type": "summary_text", "text": "First"}]},
+                {"type": "reasoning", "id": "rs_1", "encrypted_content": "enc1", "summary": []},
+                {"type": "reasoning", "id": "rs_2", "encrypted_content": "enc2",
+                 "summary": [{"type": "summary_text", "text": "Next"}]}
+            ]
+        })).unwrap()
+    }
+
+    #[test]
+    fn consecutive_items_share_state_across_non_streaming_output() {
+        let events = map_non_streaming_response(response(), false, true).unwrap();
+        assert_eq!(events, vec![
+            Event::reasoning(0, ""),
+            Event::reasoning(0, "First"),
+            Event::flush_with_metadata(
+                0,
+                Map::from_iter([
+                    (ITEM_ID_KEY.to_owned(), "rs_0".into()),
+                    (ENCRYPTED_CONTENT_KEY.to_owned(), "enc0".into()),
+                ])
+            ),
+            Event::reasoning(1, ""),
+            Event::flush_with_metadata(
+                1,
+                Map::from_iter([
+                    (ITEM_ID_KEY.to_owned(), "rs_1".into()),
+                    (ENCRYPTED_CONTENT_KEY.to_owned(), "enc1".into()),
+                ])
+            ),
+            Event::reasoning(2, ""),
+            Event::reasoning(2, "\n\nNext"),
+            Event::flush_with_metadata(
+                2,
+                Map::from_iter([
+                    (ITEM_ID_KEY.to_owned(), "rs_2".into()),
+                    (ENCRYPTED_CONTENT_KEY.to_owned(), "enc2".into()),
+                ])
+            ),
+            Event::Finished(FinishReason::Completed),
+        ]);
+    }
+
+    #[test]
+    fn terminal_event_discards_pending_reasoning_separation() {
+        let mut reasoning = ReasoningState::default();
+        assert_eq!(
+            reasoning.delta(0, "First".into()),
+            Event::reasoning(0, "First")
+        );
+        let events = map_event(
+            types::Event::ResponseCompleted {
+                response: response(),
+            },
+            false,
+            true,
+            &mut reasoning,
+        );
+        assert_eq!(
+            events.into_iter().collect::<Result<Vec<_>, _>>().unwrap(),
+            vec![Event::Finished(FinishReason::Completed)]
+        );
+        assert_eq!(
+            reasoning.delta(1, "Next".into()),
+            Event::reasoning(1, "Next")
+        );
     }
 }
 


### PR DESCRIPTION
Consecutive OpenAI reasoning items render as separate paragraphs during streaming and when replaying newly recorded conversations. Summary indices restarting at zero no longer glue adjacent headings together.

Insert missing separation before the next reasoning text, preserving existing line breaks and leaving final items untouched. This avoids synthetic trailing text consuming the reasoning display's truncation budget. Keep segmentation provider-local so Anthropic reasoning split mid-word still renders continuously.