### PR TITLE
fix(llm, llamacpp): Release reasoning extractor tail before tool calls

### DIFF
--- a/crates/jp_llm/src/provider/llamacpp.rs
+++ b/crates/jp_llm/src/provider/llamacpp.rs
@@ -284,6 +284,21 @@ fn handle_sse_event_sync(
                 }
 
                 // Tool calls
+                if delta.tool_calls.is_some() {
+                    // A tool call terminates this message's content. Release
+                    // any extractor-held tail now, before the tool-call parts
+                    // are emitted: downstream drains the in-progress markdown
+                    // paragraph at the tool-call boundary, so a tail released
+                    // afterwards would land in a fresh paragraph and render as
+                    // a mid-word blank-line split.
+                    state.extractor.finalize();
+                    events.extend(
+                        drain_extractor(&mut state.extractor, state.is_structured)
+                            .into_iter()
+                            .map(Ok),
+                    );
+                }
+
                 if let Some(tool_calls) = &delta.tool_calls {
                     flush_reasoning_if_needed(&mut events, &mut state.reasoning_flushed);
 

--- a/crates/jp_llm/src/provider/llamacpp_tests.rs
+++ b/crates/jp_llm/src/provider/llamacpp_tests.rs
@@ -459,12 +459,12 @@ fn length_finish_reason_drops_pending_tool_calls() {
 /// A tool-call frame must release the extractor's held-back tail before
 /// emitting any tool-call parts.
 ///
-/// The `ReasoningExtractor` withholds the last bytes of content (one less
-/// than the `<think>\n` opener) in case a tag is split across frames.
+/// The `ReasoningExtractor` withholds the last bytes of content (one less than
+/// the `<think>\n` opener) in case a tag is split across frames.
 /// Downstream drains the in-progress markdown paragraph at the tool-call
-/// boundary, so if the tail were released after `ToolCallPart::Start`, it
-/// would land in a fresh paragraph and render as a mid-word blank-line split
-/// (e.g. `…directo` then a blank line then `ries.`).
+/// boundary, so if the tail were released after `ToolCallPart::Start`, it would
+/// land in a fresh paragraph and render as a mid-word blank-line split (e.g.
+/// `…directo` then a blank line then `ries.`).
 #[test]
 fn tool_call_frame_releases_extractor_tail_before_tool_call_parts() {
     let mut state = StreamState {

--- a/crates/jp_llm/src/provider/llamacpp_tests.rs
+++ b/crates/jp_llm/src/provider/llamacpp_tests.rs
@@ -4,7 +4,7 @@ use jp_conversation::ConversationEvent;
 use reqwest_eventsource::Error as SseError;
 
 use super::*;
-use crate::provider::openai_compat::StreamChunk;
+use crate::{event::EventPart, provider::openai_compat::StreamChunk};
 
 fn qwen_model() -> LlamacppModel {
     serde_json::from_value(serde_json::json!({
@@ -453,5 +453,122 @@ fn length_finish_reason_drops_pending_tool_calls() {
     assert!(
         matches!(last, Event::Finished(FinishReason::MaxTokens)),
         "expected Finished(MaxTokens), got {last:?}"
+    );
+}
+
+/// A tool-call frame must release the extractor's held-back tail before
+/// emitting any tool-call parts.
+///
+/// The `ReasoningExtractor` withholds the last bytes of content (one less
+/// than the `<think>\n` opener) in case a tag is split across frames.
+/// Downstream drains the in-progress markdown paragraph at the tool-call
+/// boundary, so if the tail were released after `ToolCallPart::Start`, it
+/// would land in a fresh paragraph and render as a mid-word blank-line split
+/// (e.g. `…directo` then a blank line then `ries.`).
+#[test]
+fn tool_call_frame_releases_extractor_tail_before_tool_call_parts() {
+    let mut state = StreamState {
+        extractor: ReasoningExtractor::default(),
+        tool_call_indices: Vec::new(),
+        reasoning_flushed: false,
+        message_flushed: false,
+        finished: false,
+        finish_reason: None,
+        is_structured: false,
+    };
+
+    // A full paragraph in one frame, ending in a word long enough that the
+    // hold-back window splits it.
+    let content =
+        "Let me first check what tools are available to me for reading files and directories.\n\n";
+    let content_chunk = serde_json::json!({
+        "choices": [{
+            "delta": { "content": content },
+            "index": 0,
+            "finish_reason": null
+        }]
+    });
+    let content_events =
+        handle_sse_event_sync(Ok(sse_message(&content_chunk.to_string())), &mut state).unwrap();
+
+    // The content frame withholds the tail while tag detection stays armed.
+    let content_emitted: String = content_events
+        .iter()
+        .filter_map(|e| match e.as_ref().ok() {
+            Some(Event::Part {
+                part: EventPart::Message(text),
+                ..
+            }) => Some(text.clone()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        !content_emitted.ends_with("directories.\n\n"),
+        "the tail should still be held back after the content frame: {content_emitted:?}"
+    );
+
+    // The tool-call frame releases the tail...
+    let tool_chunk = serde_json::json!({
+        "choices": [{
+            "delta": {
+                "tool_calls": [{
+                    "index": 0,
+                    "id": "call_1",
+                    "function": { "name": "describe_tools", "arguments": "{}" }
+                }]
+            },
+            "index": 0,
+            "finish_reason": "tool_calls"
+        }]
+    });
+    let tool_events =
+        handle_sse_event_sync(Ok(sse_message(&tool_chunk.to_string())), &mut state).unwrap();
+
+    let tail: String = tool_events
+        .iter()
+        .filter_map(|e| match e.as_ref().ok() {
+            Some(Event::Part {
+                part: EventPart::Message(text),
+                ..
+            }) => Some(text.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        format!("{content_emitted}{tail}"),
+        content,
+        "content must be preserved across the tool-call boundary"
+    );
+
+    // ...and it must precede every tool-call part in the emitted order, so the
+    // downstream paragraph drain at the tool-call boundary sees the complete
+    // paragraph.
+    let first_tool_call = tool_events
+        .iter()
+        .position(|e| {
+            matches!(
+                e.as_ref().ok(),
+                Some(Event::Part {
+                    part: EventPart::ToolCall(_),
+                    ..
+                })
+            )
+        })
+        .unwrap();
+    let last_message = tool_events
+        .iter()
+        .rposition(|e| {
+            matches!(
+                e.as_ref().ok(),
+                Some(Event::Part {
+                    part: EventPart::Message(_),
+                    ..
+                })
+            )
+        })
+        .unwrap();
+    assert!(
+        last_message < first_tool_call,
+        "the extractor tail must be emitted before the tool-call parts, got {tool_events:?}"
     );
 }

--- a/crates/jp_llm/src/stream/aggregator/reasoning.rs
+++ b/crates/jp_llm/src/stream/aggregator/reasoning.rs
@@ -126,3 +126,7 @@ impl ReasoningExtractor {
         self.buffer.clear();
     }
 }
+
+#[cfg(test)]
+#[path = "reasoning_tests.rs"]
+mod tests;

--- a/crates/jp_llm/src/stream/aggregator/reasoning_tests.rs
+++ b/crates/jp_llm/src/stream/aggregator/reasoning_tests.rs
@@ -1,0 +1,58 @@
+use super::*;
+
+/// The holdback invariant the llamacpp provider relies on: with no tag
+/// present, `handle` releases everything except a tail of `tag_len - 1`
+/// bytes (in case a tag opener straddles the next chunk), and `finalize`
+/// releases the remainder. Consumers must treat the unreleased tail as
+/// still-pending: releasing it only after a tool-call boundary would split
+/// the final word across paragraphs.
+#[test]
+fn idle_holds_back_seven_byte_tail() {
+    let mut x = ReasoningExtractor::default();
+    x.handle("hello world"); // 11 bytes, no tag
+    // 11 - 7 = 4 bytes released; the last 7 are held back.
+    assert_eq!(x.other, "hell");
+    assert_eq!(x.reasoning, "");
+    x.finalize();
+    assert_eq!(x.other, "hello world");
+    assert_eq!(x.reasoning, "");
+}
+
+/// A complete open/close tag pair segments the stream into the
+/// `other` / `reasoning` / `other` buckets.
+#[test]
+fn complete_tags_split_buckets() {
+    let mut x = ReasoningExtractor::default();
+    x.handle("pre");
+    x.handle("<think>\nx");
+    x.handle("</think>\ny");
+    assert_eq!(x.other, "prey");
+    assert_eq!(x.reasoning, "x");
+}
+
+/// The case the holdback exists for: an opener tag straddling a chunk
+/// boundary. Nothing may be emitted until the tag is resolved.
+#[test]
+fn opener_split_across_chunks() {
+    let mut x = ReasoningExtractor::default();
+    x.handle("ab<thi"); // 6 bytes: all held (buf < holdback)
+    assert_eq!(x.other, "");
+    x.handle("nk>\nx"); // completes the opener
+    assert_eq!(x.other, "ab");
+    assert_eq!(x.reasoning, "");
+    x.handle("</think>\ny"); // closes the block
+    assert_eq!(x.other, "aby");
+    assert_eq!(x.reasoning, "x");
+}
+
+/// A stream that ends inside an open block: `finalize` treats the
+/// remainder as reasoning (no closer present).
+#[test]
+fn finalize_with_unclosed_block() {
+    let mut x = ReasoningExtractor::default();
+    x.handle("ab <think>\nreason");
+    assert_eq!(x.other, "ab ");
+    x.finalize();
+    assert_eq!(x.other, "ab ");
+    assert_eq!(x.reasoning, "reason");
+}

--- a/crates/jp_llm/src/stream/aggregator/reasoning_tests.rs
+++ b/crates/jp_llm/src/stream/aggregator/reasoning_tests.rs
@@ -1,11 +1,10 @@
 use super::*;
 
-/// The holdback invariant the llamacpp provider relies on: with no tag
-/// present, `handle` releases everything except a tail of `tag_len - 1`
-/// bytes (in case a tag opener straddles the next chunk), and `finalize`
-/// releases the remainder. Consumers must treat the unreleased tail as
-/// still-pending: releasing it only after a tool-call boundary would split
-/// the final word across paragraphs.
+/// The holdback invariant the llamacpp provider relies on: with no tag present,
+/// `handle` releases everything except a tail of `tag_len - 1` bytes (in case a
+/// tag opener straddles the next chunk), and `finalize` releases the remainder.
+/// Consumers must treat the unreleased tail as still-pending: releasing it only
+/// after a tool-call boundary would split the final word across paragraphs.
 #[test]
 fn idle_holds_back_seven_byte_tail() {
     let mut x = ReasoningExtractor::default();
@@ -18,8 +17,8 @@ fn idle_holds_back_seven_byte_tail() {
     assert_eq!(x.reasoning, "");
 }
 
-/// A complete open/close tag pair segments the stream into the
-/// `other` / `reasoning` / `other` buckets.
+/// A complete open/close tag pair segments the stream into the `other` /
+/// `reasoning` / `other` buckets.
 #[test]
 fn complete_tags_split_buckets() {
     let mut x = ReasoningExtractor::default();
@@ -30,8 +29,8 @@ fn complete_tags_split_buckets() {
     assert_eq!(x.reasoning, "x");
 }
 
-/// The case the holdback exists for: an opener tag straddling a chunk
-/// boundary. Nothing may be emitted until the tag is resolved.
+/// The case the holdback exists for: an opener tag straddling a chunk boundary.
+/// Nothing may be emitted until the tag is resolved.
 #[test]
 fn opener_split_across_chunks() {
     let mut x = ReasoningExtractor::default();
@@ -45,8 +44,8 @@ fn opener_split_across_chunks() {
     assert_eq!(x.reasoning, "x");
 }
 
-/// A stream that ends inside an open block: `finalize` treats the
-/// remainder as reasoning (no closer present).
+/// A stream that ends inside an open block: `finalize` treats the remainder as
+/// reasoning (no closer present).
 #[test]
 fn finalize_with_unclosed_block() {
     let mut x = ReasoningExtractor::default();


### PR DESCRIPTION
The extractor deliberately withholds the last 7 bytes of the stream in case a `<think>` tag opener straddles the next frame. When a message is followed by a tool call, the provider emitted `ToolCallPart::Start` before releasing that withheld tail; the turn loop drains the in-progress markdown paragraph at the tool-call boundary. The tail arrived afterwards as a new paragraph, splitting the final word mid-string with a blank line (e.g. `…directo⏎⏎ries.`).

The fix will `finalize()` the extractor and drain its held tail *before* emitting any tool-call parts. (A tool call terminates the message content, so no tag can straddle that boundary.)

Adds a regression test for the bug and four `ReasoningExtractor` unit tests.

Fixes #1167 